### PR TITLE
feat: add headless Chrome as default for CCI robot tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ The main branch targets Salesforce Release 260 (Spring '26, GA). Other branches 
      pipx inject cumulusci robotframework robotframework-seleniumlibrary webdriver-manager "urllib3>=2.6.3"
      ```
      webdriver-manager provides ChromeDriver automatically (no need to install ChromeDriver in PATH). If you previously installed these with `pip install` globally, uninstall first: `python3 -m pip uninstall -y robotframework-seleniumlibrary robotframework webdriver-manager`. If you use a project virtual environment instead of pipx for CCI, install there: `pip install -r robot/requirements.txt` (or the packages above) inside the venv.
-   - Chrome (or set `BROWSER=firefox`). With webdriver-manager installed, ChromeDriver is downloaded automatically when the test runs. If webdriver-manager is **not** installed, the test falls back to the system ChromeDriver on `PATH`.
+   - Chrome (or set `BROWSER=firefox`). Robot tasks run headless by default. With webdriver-manager installed, ChromeDriver is downloaded automatically when the test runs. If webdriver-manager is **not** installed, the test falls back to the system ChromeDriver on `PATH`.
    - The task uses `sf org open --url-only` to authenticate the browser; ensure the Salesforce CLI (`sf`) is installed and the org is logged in.
 
 3. **Install SFDMU (v5+):**

--- a/robot/rlm-base/resources/ChromeOptionsHelper.py
+++ b/robot/rlm-base/resources/ChromeOptionsHelper.py
@@ -1,0 +1,29 @@
+"""Helper library for creating Chrome options for headless execution.
+
+Used by default for CCI robot tasks (e.g. enable_document_builder, enable_constraints_settings,
+configure_revenue_settings). Set BROWSER to use a different browser (e.g. firefox).
+"""
+
+from selenium import webdriver
+
+
+def get_headless_chrome_options():
+    """Create and return Chrome options configured for headless execution.
+
+    Returns:
+        selenium.webdriver.ChromeOptions: Configured options object
+    """
+    options = webdriver.ChromeOptions()
+
+    # Required for headless
+    options.add_argument('--headless=new')
+    options.add_argument('--no-sandbox')
+    options.add_argument('--disable-dev-shm-usage')
+    options.add_argument('--disable-gpu')
+
+    # Additional stability options
+    options.add_argument('--window-size=1920,1080')
+    options.add_argument('--disable-extensions')
+    options.add_argument('--disable-software-rasterizer')
+
+    return options

--- a/robot/rlm-base/resources/SetupToggles.robot
+++ b/robot/rlm-base/resources/SetupToggles.robot
@@ -5,6 +5,7 @@ Library           Collections
 Library           String
 Library           Process
 Library           ${EXECDIR}/robot/rlm-base/resources/WebDriverManager.py    WITH NAME    WebDriverManager
+Library           ${EXECDIR}/robot/rlm-base/resources/ChromeOptionsHelper.py
 
 *** Variables ***
 # Default timeout for waiting for setup page and toggle elements
@@ -354,14 +355,21 @@ Open Browser For Setup
     Maximize Browser Window
 
 _Open Chrome With Managed Driver
-    [Documentation]    Create Chrome driver. Uses webdriver-manager when available; falls back to system ChromeDriver on PATH.
+    [Documentation]    Create Chrome driver with headless options (default for CCI robot tasks). Uses webdriver-manager when available; falls back to system ChromeDriver on PATH.
     ${path}=    WebDriverManager.Get Chrome Driver Path
     Run Keyword If    """${path}""" != "None" and """${path}""" != ""    _Open Chrome With Explicit Path    ${path}
-    ...    ELSE    Open Browser    about:blank    chrome
+    ...    ELSE    _Open Chrome With Options Fallback
 
 _Open Chrome With Explicit Path
     [Arguments]    ${path}
-    Create Webdriver    Chrome    executable_path=${path}
+    ${options}=    Get Headless Chrome Options
+    Create Webdriver    Chrome    executable_path=${path}    options=${options}
+    Go To    about:blank
+
+_Open Chrome With Options Fallback
+    [Documentation]    Opens Chrome with headless options when no explicit ChromeDriver path is provided.
+    ${options}=    Get Headless Chrome Options
+    Create Webdriver    Chrome    options=${options}
     Go To    about:blank
 
 Close Browser After Setup

--- a/robot/rlm-base/resources/WebDriverManager.py
+++ b/robot/rlm-base/resources/WebDriverManager.py
@@ -49,9 +49,27 @@ _patch_selenium_timeout()
 def get_chrome_driver_path():
     """Return the path to the ChromeDriver executable.
 
-    Uses webdriver-manager if available; otherwise returns None so the
-    caller can fall back to the default (system PATH) ChromeDriver.
+    Prefers system ChromeDriver (/usr/bin/chromedriver) when available
+    (e.g., in CI or when chromium-driver is installed). Falls back to
+    webdriver-manager for automatic driver management, or returns None
+    to use system PATH as a last resort.
     """
+    import os
+    import shutil
+
+    # Check for system ChromeDriver first
+    system_chromedriver = "/usr/bin/chromedriver"
+    if os.path.isfile(system_chromedriver) and os.access(system_chromedriver, os.X_OK):
+        _logger.debug(f"Using system ChromeDriver: {system_chromedriver}")
+        return system_chromedriver
+
+    # Try PATH-based chromedriver
+    path_chromedriver = shutil.which("chromedriver")
+    if path_chromedriver:
+        _logger.debug(f"Using ChromeDriver from PATH: {path_chromedriver}")
+        return path_chromedriver
+
+    # Fall back to webdriver-manager
     if not _HAS_WDM:
         return None
 

--- a/robot/rlm-base/tests/setup/README.md
+++ b/robot/rlm-base/tests/setup/README.md
@@ -12,7 +12,7 @@ Robot Framework tests that configure Salesforce Revenue Settings page options th
 
 ## Prerequisites
 
-Install and verify prerequisites in the **main README** only: [Installation — Document Builder automation dependencies](../../../README.md#installation) (Robot Framework, SeleniumLibrary, Chrome/ChromeDriver, Salesforce CLI, urllib3 >= 2.6.3). Do not install or verify from this folder; the main README is the single source of truth. If you see **"Timeout value connect was &lt;object object at ...&gt;"** during suite setup, ensure urllib3 >= 2.6.3 is installed and the main README [Troubleshooting](../../../README.md#troubleshooting) explains the fix.
+Install and verify prerequisites in the **main README** only: [Installation — Document Builder automation dependencies](../../../README.md#installation) (Robot Framework, SeleniumLibrary, Chrome/ChromeDriver, Salesforce CLI, urllib3 >= 2.6.3). Do not install or verify from this folder; the main README is the single source of truth. Tests run headless by default. If you see **"Timeout value connect was &lt;object object at ...&gt;"** during suite setup, ensure urllib3 >= 2.6.3 is installed and the main README [Troubleshooting](../../../README.md#troubleshooting) explains the fix.
 
 ## Running Tests
 


### PR DESCRIPTION
- Add ChromeOptionsHelper.py for headless Chrome options
- Update SetupToggles.robot to use headless browser by default
- Update WebDriverManager to prefer system chromedriver, fallback to webdriver-manager
- Document headless default in README

Made-with: Cursor