### PR TITLE
260-dev: CDO release, Procedure Plans, constraints infrastructure, and robot fixes

### DIFF
--- a/tasks/rlm_validate_setup.py
+++ b/tasks/rlm_validate_setup.py
@@ -323,12 +323,13 @@ class ValidateSetup(BaseTask):
                     f"auto-fix failed: {err}\n"
                     f'  Fix: pipx inject cumulusci "urllib3>={MIN_URLLIB3_STR}" --force',
                 )
-            # Re-import to read the newly installed version.
-            # Pop the cached module first so import_module reads from disk, not from
-            # the already-loaded (old) entry in sys.modules.
+            # Clear cached urllib3 modules so import_module reads from disk, not from
+            # the already-loaded (old) entries in sys.modules.
             try:
                 import importlib  # noqa: PLC0415
-                sys.modules.pop("urllib3", None)
+                for name in list(sys.modules):
+                    if name == "urllib3" or name.startswith("urllib3."):
+                        sys.modules.pop(name, None)
                 urllib3 = importlib.import_module("urllib3")
                 new_ver = getattr(urllib3, "__version__", "unknown")
             except Exception:


### PR DESCRIPTION
## Summary

This PR merges all work from the `260-dev` branch into `main`, encompassing five logical areas of change:

### 1. CDO Release (`1b5e34d`)
- Baseline CDO release changes included in this branch.

### 2. Procedure Plans integration (`5471d25`)
- New `feat: integrate Procedure Plans` with an idempotent SFDMU data plan and Connect API task.
- Added `RLM_ProcedurePlans` permission set, `RevenueManagement.settings-meta.xml` update, and supporting metadata.
- Removed stale expression set definition files and unused custom fields.

### 3. Constraints infrastructure and context service utility
- **Deployment order fix**: Moved `RLM_QuoteItemTrigger`, `RC_Asset_Action_Source_Record_Page` flexipage, order product and quote line item layouts, and `RLM_QuantumBit` field permissions for `RLM_ConstraintEngineNodeStatus__c` into `unpackaged/post_constraints` to ensure they deploy *after* the custom fields exist.
- **Context service utility** (`tasks/rlm_context_service.py`): New CCI task `manage_context_definition` to extend `RLM_SalesTransactionContext` with `ConstraintEngineNodeStatus__c` attributes, SOBJECT/CONTEXT node mappings across `QuoteEntitiesMapping`, `OrderEntitiesMapping`, `AssetEntitiesMapping`, and `AssetToSalesTransactionMapping`, and context tags.
- **Context plans** (`datasets/context_plans/ConstraintEngineNodeStatus/`): Manifest + plan file for the constraint engine node status context modifications.
- **SFDMU TransactionProcessingType plan**: Pre-constraint data plan to seed `TransactionProcessingType` records via the `manage_transaction_processing_types` Tooling API task.
- **`cumulusci.yml`**: Integrated `prepare_constraints` flow with ordered steps: TransactionProcessingType data load → `deploy_post_constraints` → `apply_context_constraint_engine_node_status`. Temporarily disabled product/component data insertion tasks pending further validation.
- **Documentation**: New `docs/constraints_setup.md`, `docs/context_service_utility.md`, updated `README.md`, `docs/TASK_EXAMPLES.md`.

### 4. Robot / urllib3 alignment
- **`robot/requirements.txt`** (new): Pinned Robot Framework dependencies including **`urllib3>=2.6.3`** for security (CVE-2026-21441) and compatibility with the CCI environment; matches the minimum enforced by `validate_setup`.
- **`robot/rlm-base/resources/WebDriverManager.py`**: `_normalize_timeout()` helper + temporary monkey-patch of `requests.Session.request` scoped to `ChromeDriverManager().install()` to avoid invalid timeout values.
- **`tasks/rlm_enable_document_builder_toggle.py`**, **`tasks/rlm_enable_constraints_settings.py`**, **`tasks/rlm_configure_revenue_settings.py`**: Added `_check_urllib3_for_robot()` pre-run version check.
- **`README.md`** and **`robot/rlm-base/tests/setup/README.md`**: Updated Installation and Troubleshooting sections.

### 5. ValidateSetup urllib3 check + Copilot review fixes
- **`tasks/rlm_validate_setup.py`**:
  - Module-level constants `MIN_URLLIB3` / `MIN_URLLIB3_STR` (2.6.3); urllib3 check uses `_warn` (optional dep, consistent with other Robot deps).
  - New **`auto_fix_urllib3`** task option (default **false**) so urllib3 install/upgrade is opt-in; **`auto_fix`** remains SFDMU-only.
  - `_fix_urllib3()`: 180s timeout, `sys.modules.pop` + `importlib.import_module` to read new version; on pipx failure returns `_warn()` with manual fix guidance (no task raise); on success logs a warning that a process restart may be required for the upgrade to take full effect.
  - Docstrings and task_options updated to document both options.
- **Copilot review**: Promoted urllib3 constants to module level; removed redundant `sys` import; consistent `--force` in fix messages.

## Test plan
- [ ] `cci flow run prepare_rlm_org --org beta` — no constraint field reference errors during deployment
- [ ] `cci flow run prepare_constraints --org beta` — TransactionProcessingType records created, `post_constraints` deploys cleanly, context node mappings applied to `RLM_SalesTransactionContext`
- [ ] `cci task run manage_context_definition --org beta -o verify true` — hydration details logged for SOBJECT mappings
- [ ] `cci task run validate_setup` — urllib3 shows as warn when missing/outdated; `cci task run validate_setup -o auto_fix_urllib3 true` upgrades and reports version; auto-fix failure does not raise when `fail_on_error=true`
- [ ] Document Builder / Robot setup tests run with `urllib3>=2.6.3` from `robot/requirements.txt`
- [ ] `extend_context_definitions` flow steps 1–11 numbered correctly with no gaps
