### PR TITLE
fix: resolve FIELD_INTEGRITY_EXCEPTION in RLM renewal opportunities flow

### DIFF
--- a/force-app/main/default/flows/RLM_Create_and_Update_Renewal_Opportunities.flow-meta.xml
+++ b/force-app/main/default/flows/RLM_Create_and_Update_Renewal_Opportunities.flow-meta.xml
@@ -338,13 +338,6 @@
             </value>
         </assignmentItems>
         <assignmentItems>
-            <assignToReference>opportunityProductToCreate.TotalPrice</assignToReference>
-            <operator>Assign</operator>
-            <value>
-                <elementReference>IterateOverAssets.totalLineAmount</elementReference>
-            </value>
-        </assignmentItems>
-        <assignmentItems>
             <assignToReference>OpportunityProductsToCreate</assignToReference>
             <operator>Add</operator>
             <value>
@@ -408,13 +401,6 @@
             <operator>Assign</operator>
             <value>
                 <elementReference>IterateOverAssets.endDate</elementReference>
-            </value>
-        </assignmentItems>
-        <assignmentItems>
-            <assignToReference>opportunityProductToUpdate.TotalPrice</assignToReference>
-            <operator>Assign</operator>
-            <value>
-                <elementReference>IterateOverAssets.totalLineAmount</elementReference>
             </value>
         </assignmentItems>
         <assignmentItems>
@@ -501,13 +487,6 @@
             </value>
         </assignmentItems>
         <assignmentItems>
-            <assignToReference>opportunityProductToCreate.TotalPrice</assignToReference>
-            <operator>Assign</operator>
-            <value>
-                <elementReference>IterateOverOpportunityProducts.TotalPrice</elementReference>
-            </value>
-        </assignmentItems>
-        <assignmentItems>
             <assignToReference>OpportunityProductsWithOpportunityIdForAllProducts</assignToReference>
             <operator>Add</operator>
             <value>
@@ -578,13 +557,6 @@
             <operator>Assign</operator>
             <value>
                 <elementReference>IterateOverOpportunityProductsToCreate.AssetId</elementReference>
-            </value>
-        </assignmentItems>
-        <assignmentItems>
-            <assignToReference>opportunityProductToCreate.TotalPrice</assignToReference>
-            <operator>Assign</operator>
-            <value>
-                <elementReference>IterateOverOpportunityProductsToCreate.TotalPrice</elementReference>
             </value>
         </assignmentItems>
         <assignmentItems>


### PR DESCRIPTION
## Summary

This change fixes the `FIELD_INTEGRITY_EXCEPTION` error in the RLM Create and Update Renewal Opportunities flow.

## Problem

The flow was setting **both** `TotalPrice` and `UnitPrice` when creating or updating OpportunityLineItem records. Salesforce does not allow setting both fields—you must set either one or the other. Setting both caused the field integrity error.

## Solution

Remove all `TotalPrice` assignments from the flow. The flow now sets only `UnitPrice` and `Quantity`, allowing Salesforce to automatically calculate `TotalPrice = UnitPrice × Quantity`.

## Changes

- Remove TotalPrice from `AddCurrentOpportunityProductAndPriceBookEntryToCollection`
- Remove TotalPrice from `AddCurrentOpportunityProductToCollection`
- Remove TotalPrice from `AddCurrentOpportunityToCollection`
- Remove TotalPrice from `AddCurrentRootOpportunityToCollection`

Made with [Cursor](https://cursor.com)