### PR TITLE
fix: remove invalid Security.settings-meta.xml blocking prepare_payments

### DIFF
--- a/unpackaged/post_payments_settings/settings/Security.settings-meta.xml
+++ b/unpackaged/post_payments_settings/settings/Security.settings-meta.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<SecuritySettings xmlns="http://soap.sforce.com/2006/04/metadata">
-    <sessionSettings>
-        <enableSeparateSalesforceAndSiteLogin>false</enableSeparateSalesforceAndSiteLogin>
-    </sessionSettings>
-</SecuritySettings>


### PR DESCRIPTION
## Summary
- Removes `unpackaged/post_payments_settings/settings/Security.settings-meta.xml` which was merged in #79 but causes a hard deployment failure
- `enableSeparateSalesforceAndSiteLogin` is not a valid field in `SecuritySettings.sessionSettings` at API v66 — deploying it throws `Element {}enableSeparateSalesforceAndSiteLogin invalid at this location in type SessionSettings`
- The correct mechanism for controlling this setting is still under investigation (tracked in #76)

## Why emergency
`prepare_payments` (and by extension `prepare_rlm_org`) fails on `deploy_post_payments_settings` in any org that pulls from main.

## Test plan
- [ ] Run `cci task run deploy_post_payments_settings --org <scratch>` — should succeed with only `Payments.settings-meta.xml` deployed
- [ ] Verify `prepare_payments` completes without settings deployment error

🤖 Generated with [Claude Code](https://claude.com/claude-code)