### PR TITLE
chore: add .gitattributes to enforce consistent line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,5 @@
-# Default: normalize all text files to LF on commit
-* text=auto
+# Default: normalize all text files to LF on commit and checkout
+* text=auto eol=lf
 
 # Explicitly LF for files that must stay Unix-style
 *.py text eol=lf
@@ -11,9 +11,11 @@
 *.xml text eol=lf
 *.md text eol=lf
 *.apex text eol=lf
+*.cls text eol=lf
 
 # Binaries — no line-ending conversion
 *.png binary
 *.jpg binary
 *.pdf binary
 *.zip binary
+*.asset binary


### PR DESCRIPTION
## Summary
- Add repo-level `.gitattributes` normalizing all text files to LF on commit and checkout
- Wildcard `* text=auto eol=lf` enforces LF storage in the object store and LF checkout on all platforms, overriding `core.autocrlf`
- Explicitly pins `.py`, `.robot`, `.yml`, `.yaml`, `.json`, `.csv`, `.xml`, `.md`, `.apex`, `.cls` to `eol=lf` (self-documenting intent; provides fallback if wildcard is changed)
- Marks binary files (`.png`, `.jpg`, `.pdf`, `.zip`, `.asset`) to skip line-ending conversion

Prevents noisy CRLF→LF wholesale rewrites in CSV and metadata file diffs when different editors are used.

## Line ending behavior by platform
- **macOS (primary):** No change — git already checks out LF by default and macOS tools handle LF natively. Files on disk are almost certainly already LF.
- **Windows (rare):** `eol=lf` overrides `core.autocrlf`, so files are checked out as LF even on Windows. `sf CLI`, `cci`, Python, and Robot Framework all handle LF fine on Windows — no toolchain impact.

## Post-merge renormalization
After pulling this change, run once to make the git index consistent with the new rules:

```bash
git pull
git add --renormalize .
git status  # expected: clean on a macOS-only repo (files were already LF)
git commit -m "chore: renormalize line endings per .gitattributes"  # only if status shows changes
```

On a macOS-only team `git status` will almost certainly be empty — confirming everything was already LF. If a few files do appear, it means CRLF crept in at some point and this cleans it up. No commit needed if status is clean.

## Test plan
- [ ] Verify `.gitattributes` is picked up: `git check-attr eol -- datasets/sfdmu/qb/en-US/qb-pricing/PricebookEntry.csv`
- [ ] Run `git add --renormalize .` after merge — confirm `git status` is clean
- [ ] Confirm no unintended re-normalization of binary `.asset` files

Closes #98

🤖 Generated with [Claude Code](https://claude.com/claude-code)