### PR TITLE
fix: remove scratch-only conditions and hardcoded org IDs

### DIFF
--- a/cumulusci.yml
+++ b/cumulusci.yml
@@ -2307,10 +2307,8 @@ flows:
         task: deactivate_expression_sets
       2:
         task: ensure_pricing_schedules
-        when: org_config.scratch
       3:
         task: deploy_expression_sets
-        when: org_config.scratch
   
   prepare_product_data:
     group: Revenue Lifecycle Management
@@ -2639,14 +2637,12 @@ flows:
     steps:
       1:
         task: activate_decision_tables
-        when: org_config.scratch
 
   prepare_price_adjustment_schedules:
     group: Revenue Lifecycle Management
     steps:
       1:
         task: activate_price_adjustment_schedules
-        when: org_config.scratch
 
   prepare_procedureplans:
     group: Revenue Lifecycle Management
@@ -2782,7 +2778,6 @@ flows:
     steps:
       1:
         task: reconfigure_pricing_discovery
-        when: org_config.scratch
 
   prepare_ramp_builder:
     group: Revenue Lifecycle Management

--- a/force-app/main/default/expressionSetDefinition/RLM_ProductDiscoveryQualificationProcedure.expressionSetDefinition-meta.xml
+++ b/force-app/main/default/expressionSetDefinition/RLM_ProductDiscoveryQualificationProcedure.expressionSetDefinition-meta.xml
@@ -35,13 +35,6 @@
                     <value>RLM_ProductCategoryQualification</value>
                 </parameters>
                 <parameters>
-                    <input>true</input>
-                    <name>DTId</name>
-                    <output>false</output>
-                    <type>Literal</type>
-                    <value>0lDWL0000000n5Z2AQ</value>
-                </parameters>
-                <parameters>
                     <input>false</input>
                     <name>IsQualified</name>
                     <output>true</output>
@@ -97,13 +90,6 @@
                     <output>false</output>
                     <type>Literal</type>
                     <value>RLM_ProductQualification</value>
-                </parameters>
-                <parameters>
-                    <input>true</input>
-                    <name>DTId</name>
-                    <output>false</output>
-                    <type>Literal</type>
-                    <value>0lDWL0000000n5a2AA</value>
                 </parameters>
                 <parameters>
                     <input>false</input>


### PR DESCRIPTION
## Summary

- Remove `when: org_config.scratch` guards from activation flow steps (`ensure_pricing_schedules`, `deploy_expression_sets`, `activate_decision_tables`, `activate_price_adjustment_schedules`, `reconfigure_pricing_discovery`) so they run on all org types, not just scratch orgs
- Remove hardcoded `DTId` record ID literals from `RLM_ProductDiscoveryQualificationProcedure` expression set definition to eliminate org-specific values from source control

## Test plan

- [x] Run affected flows (`prepare_expression_sets`, `prepare_price_adjustment_schedules`, `prepare_pricing_discovery`) against a sandbox org and confirm activation steps execute
- [x] Confirm expression set deploys without the removed `DTId` parameters and activates correctly
- [x] Run against a scratch org to confirm no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)