### PR TITLE
fix: resolve deploy failures in post_utils and post_prm

### DIFF
--- a/unpackaged/post_prm/force-app/main/default/networks/rlm.network-meta.xml
+++ b/unpackaged/post_prm/force-app/main/default/networks/rlm.network-meta.xml
@@ -36,7 +36,7 @@
     <headlessRegistrationTemplate>unfiled$public/CommunityHeadlessRegistrationTemplate</headlessRegistrationTemplate>
     <networkAuthApiSettings>
         <doesForgotPasswordRequireAuth>false</doesForgotPasswordRequireAuth>
-        <doesPasswordLoginRequireAuth>true</doesPasswordLoginRequireAuth>
+        <doesPasswordLoginRequireAuth>false</doesPasswordLoginRequireAuth>
         <doesPwdlessLoginRequireAuth>false</doesPwdlessLoginRequireAuth>
         <doesRegistrationRequireAuth>false</doesRegistrationRequireAuth>
         <isFirstPartyAppsAllowed>false</isFirstPartyAppsAllowed>

--- a/unpackaged/post_utils/permissionsets/RLM_UsageDatatables.permissionset-meta.xml
+++ b/unpackaged/post_utils/permissionsets/RLM_UsageDatatables.permissionset-meta.xml
@@ -4,7 +4,7 @@
      need to view usage data on Account record pages.
 
      Objects included:
-     - Account (dependency for child usage objects)
+     - Account (dependency for child usage objects), Contact (required by Account)
      - TransactionJournal, UsageSummary, UsageBillingPeriodItem (queried by the component)
      - Asset, UnitOfMeasure, UsageEntitlementAccount, UsageEntitlementBucket, UsageResource
        (related objects accessed via lookup field traversals)
@@ -102,6 +102,15 @@
         <allowRead>true</allowRead>
         <modifyAllRecords>false</modifyAllRecords>
         <object>Asset</object>
+        <viewAllRecords>false</viewAllRecords>
+    </objectPermissions>
+    <objectPermissions>
+        <allowCreate>false</allowCreate>
+        <allowDelete>false</allowDelete>
+        <allowEdit>false</allowEdit>
+        <allowRead>true</allowRead>
+        <modifyAllRecords>false</modifyAllRecords>
+        <object>Contact</object>
         <viewAllRecords>false</viewAllRecords>
     </objectPermissions>
     <objectPermissions>


### PR DESCRIPTION
## Summary

- **RLM_UsageDatatables permset** (`post_utils`): Added Read on Contact — Salesforce enforces it as a required dependency for Read on Account; deploys fail without it
- **rlm.network-meta.xml** (`post_prm`): Set `doesPasswordLoginRequireAuth` to `false` — `true` requires the `HeadlessIdentity` scratch org feature, which is absent from the org definition, causing _"operation is not allowed"_ on Network update
- Restored `emailSenderAddress` placeholder (was left patched on disk after the failed deploy; `patch_network_email_for_deploy` / `revert_network_email_after_deploy` handle substitution at deploy time)

## Test plan

- [x] Re-run `cci task run deploy_post_utils --org beta` — should complete without PermissionSet error
- [x] Re-run `cci flow run prepare_prm --org beta` (or from `patch_network_email_for_deploy` step) — Network deploy should succeed
- [x] Confirm email placeholder `rlm-network-sender@example.com` is in repo file after flow completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)