### PR TITLE
refactor: consolidate prepare_core permission assignments and fix UX/CCI issues

### DIFF
--- a/cumulusci.yml
+++ b/cumulusci.yml
@@ -2520,7 +2520,8 @@ flows:
         task: assign_permission_set_licenses
         when: project_config.project__custom__analytics
         options:
-          api_names: EinsteinAnalyticsPlusPsl
+          api_names:
+            - EinsteinAnalyticsPlusPsl
       4:
         task: assign_permission_set_licenses
         when: project_config.project__custom__tso

--- a/tasks/rlm_assign_permission_set_groups.py
+++ b/tasks/rlm_assign_permission_set_groups.py
@@ -16,9 +16,10 @@ class AssignPermissionSetGroupsTolerant(AssignPermissionSetGroups):
     """Assign Permission Set Groups, but continue on warnings about unavailable permissions."""
 
     task_options = {
-        **AssignPermissionSetGroups.task_options,
+        **getattr(AssignPermissionSetGroups, "task_options", {}),
         # Override the inherited `user_alias` option to add explicit type and required keys,
         # suppressing the CCI "Unknown option type <class 'dict'>" deprecation warning.
+        # getattr guards against the ImportError fallback where AssignPermissionSetGroups = object.
         "user_alias": {
             "description": "Alias of target user (if not the current running user, the default).",
             "required": False,

--- a/tasks/rlm_ux_assembly.py
+++ b/tasks/rlm_ux_assembly.py
@@ -1102,8 +1102,9 @@ class AssembleAndDeployUX(SFDXBaseTask):
 
         # --- Conditional standalone apps ---
         conditional_apps = []
-        if features.get("billing"):
-            # billing_ui=true wins over billing=true — provides the Billing Account Record Page override
+        if features.get("billing") or features.get("billing_ui"):
+            # billing_ui=true wins over billing=true — provides the Billing Account Record Page override.
+            # Guard covers either flag so billing_ui can be enabled independently of billing.
             billing_subdir = "billing_ui" if features.get("billing_ui") else "billing"
             conditional_apps.append(
                 (app_base / "conditional" / billing_subdir / "standard__BillingConsole.app-meta.xml", billing_subdir)


### PR DESCRIPTION
## Summary

- **`prepare_core` flow refactor** — extracted feature-gated PSL grants into `assign_feature_psls` subflow and PS grants into `assign_feature_permission_sets` subflow, reducing `prepare_core` from 17 to 15 top-level steps and making the permission assignment strategy explicit
- **TSO consolidation** — `RLM_TSO` PSG recalc + assignment moved from `prepare_tso` into `prepare_core` (steps 10–11, `when: tso`); TSO PSLs moved from `prepare_tso` step 1 into `assign_feature_psls` step 4; `prepare_tso` trimmed from 6 to 4 steps
- **3× `util_sleep` removed** — 90s wall-clock savings per run: pre-PSG-recalc sleep was redundant with `recalculate_permission_set_groups.initial_delay_seconds`; inter-rule-library sleep had no dependency; post-`extend_context_definitions` sleep was unnecessary
- **`EinsteinAnalyticsPlusPsl` guarded** — was assigned unconditionally, now gated on `analytics` feature flag
- **UX assembly fix** — `billing_ui=true` now correctly selects `templates/applications/conditional/billing_ui/standard__BillingConsole.app-meta.xml`, providing the Billing Account Record Page app default override; previously the `billing_ui` conditional directory was wired for flexipages but dead for application assembly
- **CCI deprecation warning fix** — `AssignPermissionSetGroupsTolerant` now overrides the inherited `user_alias` task option with explicit `type` and `required` keys, silencing the "Unknown option type `<class 'dict'>`" warning

## Test plan

- [x] TSO scratch build (`cci flow run prepare_rlm_org --org <tso-scratch>`) — verify `RLM_TSO` PSG assigned in `prepare_core`, PSLs assigned via `assign_feature_psls`, `prepare_tso` steps 1–4 run cleanly
- [x] Non-TSO scratch build — verify `RLM_TSO` steps skip cleanly, no regression on core PSG recalc
- [x] Billing + billing_ui org — run `assemble_and_deploy_ux` and confirm Billing Account Record Page is set as app default in BillingConsole
- [x] Confirm no "Unknown option type" warning for `assign_permission_set_groups_tolerant`
- [x] Confirm no `util_sleep` steps appear in flow logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)