### PR TITLE
feat: configure Billing Email Delivery Settings via UI toggle cycle (closes #136)

### DIFF
--- a/.cursor/skills/robot-testing/SKILL.md
+++ b/.cursor/skills/robot-testing/SKILL.md
@@ -37,6 +37,7 @@ Use this skill when writing, modifying, or debugging Robot Framework tests.
 | `configure_revenue_settings` | Pricing Procedure, Usage Rating, Instant Pricing, flows | Shadow DOM controls, no API |
 | `configure_core_pricing_setup` | Default Pricing Procedure on CorePricingSetup page | Shadow DOM combobox, no API |
 | `configure_product_discovery_settings` | Default Catalog on Product Discovery Settings page | Shadow DOM combobox, no API |
+| `configure_billing_email_settings` | Cycle Email Delivery Settings toggle to create default invoice email template | Metadata API cycling does not trigger template auto-creation; UI cycle required |
 | `enable_analytics` | CRM Analytics + Data Sync toggle | VF iframe, no API |
 | `enable_document_builder` | Document Builder toggle | Shadow DOM, no API |
 | `enable_constraints_settings` | Transaction Type, Asset Context, Constraints Engine | Shadow DOM, no API |

--- a/.cursor/skills/robot-testing/patterns.md
+++ b/.cursor/skills/robot-testing/patterns.md
@@ -18,6 +18,7 @@ robot/rlm-base/
 │       ├── configure_revenue_settings.robot
 │       ├── configure_core_pricing_setup.robot
 │       ├── configure_product_discovery_settings.robot
+│       ├── configure_billing_email_settings.robot
 │       ├── enable_analytics.robot
 │       ├── enable_document_builder.robot
 │       ├── enable_constraints_settings.robot
@@ -47,6 +48,7 @@ robot/rlm-base/
 | `configure_revenue_settings` | `ConfigureRevenueSettings` | `tests/setup/configure_revenue_settings.robot` |
 | `configure_core_pricing_setup` | `ConfigureCorePricingSetup` | `tests/setup/configure_core_pricing_setup.robot` |
 | `configure_product_discovery_settings` | `ConfigureProductDiscoverySettings` | `tests/setup/configure_product_discovery_settings.robot` |
+| `configure_billing_email_settings` | `ConfigureBillingEmailSettings` | `tests/setup/configure_billing_email_settings.robot` |
 | `enable_analytics_replication` | `EnableAnalyticsReplication` | `tests/setup/enable_analytics.robot` |
 | `enable_document_builder_toggle` | `EnableDocumentBuilderToggle` | `tests/setup/enable_document_builder.robot` |
 | `enable_constraints_settings` | `EnableConstraintsSettings` | `tests/setup/enable_constraints_settings.robot` |

--- a/cumulusci.yml
+++ b/cumulusci.yml
@@ -1189,6 +1189,16 @@ tasks:
     options:
       path: unpackaged/post_billing_template_settings
 
+  configure_billing_email_settings:
+    description: >
+      Cycle the "Configure Email Delivery Settings" toggle via the Billing Settings UI
+      to trigger auto-creation of the default invoice email template. The Metadata API
+      cycling in deploy_billing_template_settings sets the boolean but does not trigger
+      the backend that creates BillingSettings.defaultEmailTemplate. Must run after
+      deploy_billing_template_settings. Idempotent: skips if template already exists.
+    class_path: tasks.rlm_configure_billing_email_settings.ConfigureBillingEmailSettings
+    group: Revenue Lifecycle Management
+
   deploy_post_guidedselling:
     description: Deploy Guided Selling Metadata
     class_path: cumulusci.tasks.salesforce.Deploy
@@ -2851,6 +2861,9 @@ flows:
       13:
         task: apply_context_billing_order
         when: project_config.project__custom__billing and project_config.project__custom__billing_ui
+      14:
+        task: configure_billing_email_settings
+        when: project_config.project__custom__billing
 
   prepare_prm:
     group: Revenue Lifecycle Management

--- a/cumulusci.yml
+++ b/cumulusci.yml
@@ -1198,6 +1198,9 @@ tasks:
       deploy_billing_template_settings. Idempotent: skips if template already exists.
     class_path: tasks.rlm_configure_billing_email_settings.ConfigureBillingEmailSettings
     group: Revenue Lifecycle Management
+    options:
+      suite: robot/rlm-base/tests/setup/configure_billing_email_settings.robot
+      outputdir: robot/rlm-base/results
 
   deploy_post_guidedselling:
     description: Deploy Guided Selling Metadata

--- a/cumulusci.yml
+++ b/cumulusci.yml
@@ -1195,7 +1195,8 @@ tasks:
       to trigger auto-creation of the default invoice email template. The Metadata API
       cycling in deploy_billing_template_settings sets the boolean but does not trigger
       the backend that creates BillingSettings.defaultEmailTemplate. Must run after
-      deploy_billing_template_settings. Idempotent: skips if template already exists.
+      deploy_billing_template_settings. Idempotent: toggle clicks are skipped when
+      already in target state; post-cycle polling verifies the template is populated.
     class_path: tasks.rlm_configure_billing_email_settings.ConfigureBillingEmailSettings
     group: Revenue Lifecycle Management
     options:

--- a/robot/rlm-base/resources/ChromeOptionsHelper.py
+++ b/robot/rlm-base/resources/ChromeOptionsHelper.py
@@ -28,3 +28,23 @@ def get_headless_chrome_options():
 
     return options
 
+
+def get_headed_chrome_options():
+    """Create and return Chrome options configured for headed (visible) execution.
+
+    Use when headless mode does not trigger required browser events — e.g. Billing
+    Settings toggle cycling, where the LWC dispatches an Apex call that only
+    completes when Chrome is running in headed mode.
+
+    Returns:
+        selenium.webdriver.ChromeOptions: Configured options object
+    """
+    options = webdriver.ChromeOptions()
+
+    options.add_argument('--no-sandbox')
+    options.add_argument('--disable-dev-shm-usage')
+    options.add_argument('--window-size=1920,1080')
+    options.add_argument('--disable-extensions')
+
+    return options
+

--- a/robot/rlm-base/resources/SetupToggles.robot
+++ b/robot/rlm-base/resources/SetupToggles.robot
@@ -367,28 +367,37 @@ _ClickToggleElement
 
 *** Keywords ***
 Open Browser For Setup
-    [Documentation]    Opens a browser (Chrome by default). If webdriver-manager is installed it manages ChromeDriver automatically; otherwise falls back to the system ChromeDriver on PATH. Set BROWSER or \${BROWSER} to override (e.g. firefox).
+    [Documentation]    Opens Chrome in headless mode (default for CCI robot tasks). If webdriver-manager is installed it manages ChromeDriver automatically; otherwise falls back to the system ChromeDriver on PATH. Set BROWSER or \${BROWSER} to override (e.g. firefox).
     [Arguments]    ${browser}=chrome
-    Run Keyword If    """${browser}""" == "chrome"    _Open Chrome With Managed Driver
+    ${options}=    Get Headless Chrome Options
+    Run Keyword If    """${browser}""" == "chrome"    _Open Chrome With Managed Driver    ${options}
     ...    ELSE    Open Browser    about:blank    ${browser}
     Maximize Browser Window
 
+Open Headed Browser For Setup
+    [Documentation]    Opens Chrome in headed (visible) mode. Required for tasks where the LWC
+    ...    dispatches Apex calls that only complete when Chrome is running headed (e.g. Billing
+    ...    Settings toggle cycling). Uses webdriver-manager when available; falls back to PATH.
+    ${options}=    Get Headed Chrome Options
+    _Open Chrome With Managed Driver    ${options}
+    Maximize Browser Window
+
 _Open Chrome With Managed Driver
-    [Documentation]    Create Chrome driver with headless options (default for CCI robot tasks). Uses webdriver-manager when available; falls back to system ChromeDriver on PATH.
+    [Documentation]    Creates a Chrome driver with the supplied options. Uses webdriver-manager when available; falls back to system ChromeDriver on PATH.
+    [Arguments]    ${options}
     ${path}=    WebDriverManager.Get Chrome Driver Path
-    Run Keyword If    """${path}""" != "None" and """${path}""" != ""    _Open Chrome With Explicit Path    ${path}
-    ...    ELSE    _Open Chrome With Options Fallback
+    Run Keyword If    """${path}""" != "None" and """${path}""" != ""    _Open Chrome With Explicit Path    ${path}    ${options}
+    ...    ELSE    _Open Chrome With Options Fallback    ${options}
 
 _Open Chrome With Explicit Path
-    [Arguments]    ${path}
-    ${options}=    Get Headless Chrome Options
+    [Arguments]    ${path}    ${options}
     ${service}=    Evaluate    selenium.webdriver.chrome.service.Service(executable_path=$path)    selenium.webdriver.chrome.service
     Create Webdriver    Chrome    service=${service}    options=${options}
     Go To    about:blank
 
 _Open Chrome With Options Fallback
-    [Documentation]    Opens Chrome with headless options when no explicit ChromeDriver path is provided.
-    ${options}=    Get Headless Chrome Options
+    [Documentation]    Opens Chrome with the supplied options when no explicit ChromeDriver path is provided.
+    [Arguments]    ${options}
     Create Webdriver    Chrome    options=${options}
     Go To    about:blank
 

--- a/robot/rlm-base/tests/setup/README.md
+++ b/robot/rlm-base/tests/setup/README.md
@@ -128,7 +128,8 @@ The Default Transaction Type field is a `<lightning-combobox>` component (distin
 ### Idempotency
 
 All tests detect current state before making changes:
-- **Toggles:** Read `checked` property via JavaScript; skip click if already enabled
+- **Toggles (general):** Read `checked` property via JavaScript; skip click if already in target state
+- **Billing email delivery toggle:** Always performs the off→on cycle (the click keywords check `inp.checked` and skip the click if already in the target state), then polls up to 30s for the Default Invoice Email Template field to be populated — safe to re-run because the backend template creation is idempotent
 - **Combobox-recipe fields (Pricing, Usage Rating, Asset Context):** Check if correct value is shown in pill within the scoped `<li>`; skip if matched. If wrong value, clear pill, wait for dropdown, select correct value.
 - **Lightning combobox (Transaction Type):** Check `Get Selected List Label`; skip if already correct
 - **Text inputs (Create Orders Flow):** Compare current value; skip if already correct

--- a/robot/rlm-base/tests/setup/README.md
+++ b/robot/rlm-base/tests/setup/README.md
@@ -10,6 +10,7 @@ Robot Framework tests that configure Salesforce Setup page options that cannot b
 | `enable_constraints_settings.robot` | `enable_constraints_settings` | Set Default Transaction Type, Asset Context picklist, and enable Constraints Engine toggle |
 | `configure_revenue_settings.robot` | `configure_revenue_settings` | Set Pricing Procedure, Usage Rating Procedure, enable Instant Pricing toggle, set Create Orders Flow |
 | `configure_core_pricing_setup.robot` | `configure_core_pricing_setup` | Set default Pricing Procedure on Salesforce Pricing Setup page (CorePricingSetup) |
+| `configure_billing_email_settings.robot` | `configure_billing_email_settings` | Cycle the Configure Email Delivery Settings toggle via the UI to trigger auto-creation of the default invoice email template (Metadata API cycling alone does not trigger this) |
 
 ## Prerequisites
 
@@ -140,6 +141,7 @@ All tests detect current state before making changes:
 | `enable_constraints_settings` | `prepare_constraints` | Step 5 (when `constraints_data` is true) |
 | `configure_revenue_settings` | `prepare_rlm_org` | Step 24 (via `prepare_revenue_settings`) |
 | `configure_core_pricing_setup` | `prepare_rlm_org` | Step 24 (via `prepare_revenue_settings`, step 3) |
+| `configure_billing_email_settings` | `prepare_billing` | Step 14 (when `billing` is true) |
 
 ## Generated Output
 

--- a/robot/rlm-base/tests/setup/configure_billing_email_settings.robot
+++ b/robot/rlm-base/tests/setup/configure_billing_email_settings.robot
@@ -20,17 +20,13 @@ Configure Billing Email Delivery Settings
     [Documentation]    Navigates to Billing Settings and cycles the "Configure Email
     ...    Delivery Settings" toggle off then on via the UI to trigger the Salesforce
     ...    backend that auto-creates and sets the default invoice email template.
-    ...    Skips if the template is already present (idempotent).
-    ${template_exists}=    _Check Default Email Template Exists
-    IF    "${template_exists}" == "true"
-        Log    Default Invoice Email Template already exists. Cycling not needed.
-    ELSE
-        Open Billing Settings Page
-        Capture Page Screenshot
-        _Cycle Email Delivery Toggle
-        Capture Page Screenshot
-        Log    Configure Email Delivery Settings cycled. Default invoice email template should now be created.
-    END
+    ...    The Disable/Enable keywords check current toggle state before clicking,
+    ...    so re-running is safe (the backend template creation is idempotent).
+    Open Billing Settings Page
+    Capture Page Screenshot
+    _Cycle Email Delivery Toggle
+    Capture Page Screenshot
+    Log    Configure Email Delivery Settings cycled. Default invoice email template should now be created.
 
 *** Keywords ***
 Open Billing Settings Page
@@ -44,19 +40,6 @@ Open Billing Settings Page
     ELSE
         Fail    msg=Set ORG_ALIAS (e.g. -v ORG_ALIAS:my-scratch) or BILLING_SETTINGS_URL
     END
-
-_Check Default Email Template Exists
-    [Documentation]    Returns 'true' if the Default Invoice Email Template record
-    ...    already exists in the org (idempotency guard). Returns 'false' when
-    ...    ORG_ALIAS is not set (browser-only mode — cannot query without sf CLI).
-    Run Keyword If    """${ORG_ALIAS}""" == ""    RETURN    false
-    ${result}=    Run Process    sf    data    query
-    ...    -q    SELECT Id FROM EmailTemplate WHERE Name = 'Default Invoice Email Template' ORDER BY CreatedDate DESC LIMIT 1
-    ...    --json    -o    ${ORG_ALIAS}    shell=False
-    ${has_record}=    Run Keyword And Return Status    Should Contain    ${result.stdout}    "totalSize": 1
-    ${exists}=    Set Variable If    ${has_record}    true    false
-    Log    Default Invoice Email Template exists check: ${exists}
-    RETURN    ${exists}
 
 _Cycle Email Delivery Toggle
     [Documentation]    Turns "Configure Email Delivery Settings" toggle OFF then ON to

--- a/robot/rlm-base/tests/setup/configure_billing_email_settings.robot
+++ b/robot/rlm-base/tests/setup/configure_billing_email_settings.robot
@@ -7,7 +7,7 @@ Documentation     Configure Billing Email Delivery Settings: cycle the "Configur
 ...               template. A UI toggle cycle (off then on) is required. Must run after
 ...               deploy_billing_template_settings.
 Resource          ../../resources/SetupToggles.robot
-Suite Setup       Open Browser For Setup
+Suite Setup       _Open Headed Browser For Billing
 Suite Teardown    Close Browser After Setup
 
 *** Variables ***
@@ -29,6 +29,21 @@ Configure Billing Email Delivery Settings
     Log    Configure Email Delivery Settings cycled. Default invoice email template should now be created.
 
 *** Keywords ***
+_Open Headed Browser For Billing
+    [Documentation]    Opens Chrome in headed (visible) mode. Required for Billing Settings
+    ...    toggle cycling: the LWC dispatches an Apex call on toggle that only completes
+    ...    when Chrome is running headed. Headless mode suppresses this backend event.
+    ${path}=    WebDriverManager.Get Chrome Driver Path
+    ${options}=    Get Headed Chrome Options
+    IF    """${path}""" != "None" and """${path}""" != ""
+        ${service}=    Evaluate    selenium.webdriver.chrome.service.Service(executable_path=$path)    selenium.webdriver.chrome.service
+        Create Webdriver    Chrome    service=${service}    options=${options}
+    ELSE
+        Create Webdriver    Chrome    options=${options}
+    END
+    Go To    about:blank
+    Maximize Browser Window
+
 Open Billing Settings Page
     [Documentation]    Opens the Billing Settings setup page using sf org open when
     ...    ORG_ALIAS is set, or falls back to BILLING_SETTINGS_URL.

--- a/robot/rlm-base/tests/setup/configure_billing_email_settings.robot
+++ b/robot/rlm-base/tests/setup/configure_billing_email_settings.robot
@@ -1,0 +1,69 @@
+*** Settings ***
+Documentation     Configure Billing Email Delivery Settings: cycle the "Configure Email
+...               Delivery Settings" toggle via the UI to trigger auto-creation of the
+...               default invoice email template. The Metadata API toggle cycling in
+...               prepare_billing (steps 9→10) sets the boolean but does not trigger the
+...               Salesforce backend logic that auto-creates and sets the default email
+...               template. A UI toggle cycle (off then on) is required. Must run after
+...               deploy_billing_template_settings.
+Resource          ../../resources/SetupToggles.robot
+Suite Setup       Open Browser For Setup
+Suite Teardown    Close Browser After Setup
+
+*** Variables ***
+${ORG_ALIAS}                  ${EMPTY}
+${BILLING_SETTINGS_URL}       ${EMPTY}
+${MANUAL_LOGIN_WAIT}          90s
+
+*** Test Cases ***
+Configure Billing Email Delivery Settings
+    [Documentation]    Navigates to Billing Settings and cycles the "Configure Email
+    ...    Delivery Settings" toggle off then on via the UI to trigger the Salesforce
+    ...    backend that auto-creates and sets the default invoice email template.
+    ...    Skips if the template is already present (idempotent).
+    ${template_exists}=    _Check Default Email Template Exists
+    IF    "${template_exists}" == "true"
+        Log    Default Invoice Email Template already exists. Cycling not needed.
+    ELSE
+        Open Billing Settings Page
+        Capture Page Screenshot
+        _Cycle Email Delivery Toggle
+        Capture Page Screenshot
+        Log    Configure Email Delivery Settings cycled. Default invoice email template should now be created.
+    END
+
+*** Keywords ***
+Open Billing Settings Page
+    [Documentation]    Opens the Billing Settings setup page using sf org open when
+    ...    ORG_ALIAS is set, or falls back to BILLING_SETTINGS_URL.
+    ${path}=    Set Variable    /lightning/setup/BillingSettings/home
+    IF    """${ORG_ALIAS}""" != ""
+        Open Setup Page    ${path}
+    ELSE IF    """${BILLING_SETTINGS_URL}""" != ""
+        Open Setup Page    url=${BILLING_SETTINGS_URL}
+    ELSE
+        Fail    msg=Set ORG_ALIAS (e.g. -v ORG_ALIAS:my-scratch) or BILLING_SETTINGS_URL
+    END
+
+_Check Default Email Template Exists
+    [Documentation]    Returns 'true' if the Default Invoice Email Template record
+    ...    already exists in the org (idempotency guard). Returns 'false' when
+    ...    ORG_ALIAS is not set (browser-only mode — cannot query without sf CLI).
+    Run Keyword If    """${ORG_ALIAS}""" == ""    RETURN    false
+    ${result}=    Run Process    sf    data    query
+    ...    -q    SELECT Id FROM EmailTemplate WHERE Name = 'Default Invoice Email Template' ORDER BY CreatedDate DESC LIMIT 1
+    ...    --json    -o    ${ORG_ALIAS}    shell=False
+    ${has_record}=    Run Keyword And Return Status    Should Contain    ${result.stdout}    "totalSize": 1
+    ${exists}=    Set Variable If    ${has_record}    true    false
+    Log    Default Invoice Email Template exists check: ${exists}
+    RETURN    ${exists}
+
+_Cycle Email Delivery Toggle
+    [Documentation]    Turns "Configure Email Delivery Settings" toggle OFF then ON to
+    ...    trigger the Salesforce backend that auto-creates the default invoice email
+    ...    template and sets it as the BillingSettings.defaultEmailTemplate. A sleep
+    ...    after re-enabling allows async template creation to complete.
+    Disable Toggle By Label    Configure Email Delivery Settings
+    Sleep    2s    reason=Allow toggle-off state to register before cycling back on
+    Enable Toggle By Label    Configure Email Delivery Settings
+    Sleep    5s    reason=Allow Salesforce to auto-create the default invoice email template

--- a/robot/rlm-base/tests/setup/configure_billing_email_settings.robot
+++ b/robot/rlm-base/tests/setup/configure_billing_email_settings.robot
@@ -7,7 +7,7 @@ Documentation     Configure Billing Email Delivery Settings: cycle the "Configur
 ...               template. A UI toggle cycle (off then on) is required. Must run after
 ...               deploy_billing_template_settings.
 Resource          ../../resources/SetupToggles.robot
-Suite Setup       _Open Headed Browser For Billing
+Suite Setup       Open Headed Browser For Setup
 Suite Teardown    Close Browser After Setup
 
 *** Variables ***
@@ -34,21 +34,6 @@ Configure Billing Email Delivery Settings
     Log    Configure Email Delivery Settings cycled. Default Email Template confirmed: "${template}".
 
 *** Keywords ***
-_Open Headed Browser For Billing
-    [Documentation]    Opens Chrome in headed (visible) mode. Required for Billing Settings
-    ...    toggle cycling: the LWC dispatches an Apex call on toggle that only completes
-    ...    when Chrome is running headed. Headless mode suppresses this backend event.
-    ${path}=    WebDriverManager.Get Chrome Driver Path
-    ${options}=    Get Headed Chrome Options
-    IF    """${path}""" != "None" and """${path}""" != ""
-        ${service}=    Evaluate    selenium.webdriver.chrome.service.Service(executable_path=$path)    selenium.webdriver.chrome.service
-        Create Webdriver    Chrome    service=${service}    options=${options}
-    ELSE
-        Create Webdriver    Chrome    options=${options}
-    END
-    Go To    about:blank
-    Maximize Browser Window
-
 Open Billing Settings Page
     [Documentation]    Opens the Billing Settings setup page using sf org open when
     ...    ORG_ALIAS is set, or falls back to BILLING_SETTINGS_URL.

--- a/robot/rlm-base/tests/setup/configure_billing_email_settings.robot
+++ b/robot/rlm-base/tests/setup/configure_billing_email_settings.robot
@@ -14,6 +14,8 @@ Suite Teardown    Close Browser After Setup
 ${ORG_ALIAS}                  ${EMPTY}
 ${BILLING_SETTINGS_URL}       ${EMPTY}
 ${MANUAL_LOGIN_WAIT}          90s
+# Shared shadow-DOM traversal helper prepended to Execute JavaScript blocks that need findEl.
+${_JS_FIND_EL}    function findEl(root, sel, d) { if (d > 6) return null; var el = root.querySelector(sel); if (el) return el; var all = root.querySelectorAll('*'); for (var i=0;i<all.length;i++){if(all[i].shadowRoot){var f=findEl(all[i].shadowRoot,sel,d+1);if(f)return f;}} return null; }
 
 *** Test Cases ***
 Configure Billing Email Delivery Settings
@@ -24,9 +26,14 @@ Configure Billing Email Delivery Settings
     ...    so re-running is safe (the backend template creation is idempotent).
     Open Billing Settings Page
     Capture Page Screenshot
-    _Cycle Email Delivery Toggle
+    Wait Until Keyword Succeeds    30s    5s    _Toggle Off Email Delivery
+    Sleep    2s    reason=Allow toggle-off state to register
+    Wait Until Keyword Succeeds    30s    5s    _Toggle On Email Delivery
+    ${template}=    Wait Until Keyword Succeeds    30s    5s    _Get Email Template Selection
+    Should Not Be Equal    ${template}    not_set
+    ...    msg=Default invoice email template was not populated after toggle cycle (got: ${template})
     Capture Page Screenshot
-    Log    Configure Email Delivery Settings cycled. Default invoice email template should now be created.
+    Log    Configure Email Delivery Settings cycled. Default Email Template confirmed: "${template}".
 
 *** Keywords ***
 _Open Headed Browser For Billing
@@ -56,12 +63,97 @@ Open Billing Settings Page
         Fail    msg=Set ORG_ALIAS (e.g. -v ORG_ALIAS:my-scratch) or BILLING_SETTINGS_URL
     END
 
-_Cycle Email Delivery Toggle
-    [Documentation]    Turns "Configure Email Delivery Settings" toggle OFF then ON to
-    ...    trigger the Salesforce backend that auto-creates the default invoice email
-    ...    template and sets it as the BillingSettings.defaultEmailTemplate. A sleep
-    ...    after re-enabling allows async template creation to complete.
-    Disable Toggle By Label    Configure Email Delivery Settings
-    Sleep    2s    reason=Allow toggle-off state to register before cycling back on
-    Enable Toggle By Label    Configure Email Delivery Settings
-    Sleep    5s    reason=Allow Salesforce to auto-create the default invoice email template
+_Toggle Off Email Delivery
+    [Documentation]    Turns Configure Email Delivery Settings OFF via targeted JS.
+    ...    Uses compareDocumentPosition to find only the toggle following the section
+    ...    heading — avoids the top-level Billing service toggle which precedes it.
+    ...    Returns page_not_ready when LWC hasn't rendered; retried by caller.
+    ${result}=    Execute JavaScript
+    ...    ${_JS_GET_INPUT_FROM_TOGGLE}
+    ...    return (function() {
+    ...        var walker = document.createTreeWalker(document.body, NodeFilter.SHOW_TEXT);
+    ...        while (walker.nextNode()) {
+    ...            if (walker.currentNode.textContent.trim() !== 'Configure Email Delivery Settings') continue;
+    ...            var textEl = walker.currentNode.parentElement;
+    ...            var section = textEl;
+    ...            for (var d = 0; d < 8; d++) {
+    ...                section = section.parentElement;
+    ...                if (!section || section === document.body) break;
+    ...                var lis = Array.from(section.querySelectorAll('lightning-input'));
+    ...                var after = lis.filter(function(li) { return textEl.compareDocumentPosition(li) & 4; });
+    ...                if (after.length === 0) continue;
+    ...                var inp = getInputFromToggle(after[0]);
+    ...                if (!inp) continue;
+    ...                if (!inp.checked) return 'already_off';
+    ...                (inp.closest('label') || inp).click();
+    ...                return 'turned_off';
+    ...            }
+    ...            return 'page_not_ready';
+    ...        }
+    ...        return 'page_not_ready';
+    ...    })()
+    Log    Toggle OFF result: ${result}
+    Should Contain    ${result}    off    msg=${result}
+
+_Toggle On Email Delivery
+    [Documentation]    Turns Configure Email Delivery Settings ON via targeted JS.
+    ...    Uses compareDocumentPosition to find only the toggle following the section
+    ...    heading — avoids the top-level Billing service toggle which precedes it.
+    ...    Returns page_not_ready when LWC hasn't rendered; retried by caller.
+    ${result}=    Execute JavaScript
+    ...    ${_JS_GET_INPUT_FROM_TOGGLE}
+    ...    return (function() {
+    ...        var walker = document.createTreeWalker(document.body, NodeFilter.SHOW_TEXT);
+    ...        while (walker.nextNode()) {
+    ...            if (walker.currentNode.textContent.trim() !== 'Configure Email Delivery Settings') continue;
+    ...            var textEl = walker.currentNode.parentElement;
+    ...            var section = textEl;
+    ...            for (var d = 0; d < 8; d++) {
+    ...                section = section.parentElement;
+    ...                if (!section || section === document.body) break;
+    ...                var lis = Array.from(section.querySelectorAll('lightning-input'));
+    ...                var after = lis.filter(function(li) { return textEl.compareDocumentPosition(li) & 4; });
+    ...                if (after.length === 0) continue;
+    ...                var inp = getInputFromToggle(after[0]);
+    ...                if (!inp) continue;
+    ...                if (inp.checked) return 'already_on';
+    ...                (inp.closest('label') || inp).click();
+    ...                return 'turned_on';
+    ...            }
+    ...            return 'page_not_ready';
+    ...        }
+    ...        return 'page_not_ready';
+    ...    })()
+    Log    Toggle ON result: ${result}
+    Should Contain    ${result}    on    msg=${result}
+
+_Get Email Template Selection
+    [Documentation]    Returns the current value of the "Select Default Email Template"
+    ...    combobox via JavaScript, or 'not_set' if empty. Used by Wait Until Keyword
+    ...    Succeeds to poll until Salesforce's async template creation completes.
+    ${value}=    Execute JavaScript
+    ...    ${_JS_FIND_EL}
+    ...    return (function() {
+    ...        var walker = document.createTreeWalker(document.body, NodeFilter.SHOW_TEXT);
+    ...        while (walker.nextNode()) {
+    ...            if (walker.currentNode.textContent.trim() === 'Select Default Email Template') {
+    ...                var el = walker.currentNode.parentElement;
+    ...                for (var d = 0; d < 10; d++) {
+    ...                    el = el.parentElement;
+    ...                    if (!el) break;
+    ...                    var pill = findEl(el, '.slds-pill__label', 0);
+    ...                    if (pill && pill.textContent.trim()) return pill.textContent.trim();
+    ...                    var btn = findEl(el, 'button[role="combobox"]', 0);
+    ...                    if (btn) {
+    ...                        var t = btn.textContent.trim();
+    ...                        if (t && t !== 'Select...' && t !== '') return t;
+    ...                    }
+    ...                    var sel = el.querySelector('lightning-combobox,select');
+    ...                    if (sel && sel.value && sel.value !== '') return sel.value;
+    ...                }
+    ...                break;
+    ...            }
+    ...        }
+    ...        return 'not_set';
+    ...    })()
+    RETURN    ${value}

--- a/robot/rlm-base/tests/setup/configure_billing_email_settings.robot
+++ b/robot/rlm-base/tests/setup/configure_billing_email_settings.robot
@@ -29,9 +29,7 @@ Configure Billing Email Delivery Settings
     Wait Until Keyword Succeeds    30s    5s    _Toggle Off Email Delivery
     Sleep    2s    reason=Allow toggle-off state to register
     Wait Until Keyword Succeeds    30s    5s    _Toggle On Email Delivery
-    ${template}=    Wait Until Keyword Succeeds    30s    5s    _Get Email Template Selection
-    Should Not Be Equal    ${template}    not_set
-    ...    msg=Default invoice email template was not populated after toggle cycle (got: ${template})
+    ${template}=    Wait Until Keyword Succeeds    30s    5s    _Assert Email Template Populated
     Capture Page Screenshot
     Log    Configure Email Delivery Settings cycled. Default Email Template confirmed: "${template}".
 
@@ -127,10 +125,19 @@ _Toggle On Email Delivery
     Log    Toggle ON result: ${result}
     Should Contain    ${result}    on    msg=${result}
 
+_Assert Email Template Populated
+    [Documentation]    Calls _Get Email Template Selection and FAILS if the value is
+    ...    'not_set'. Designed for use with Wait Until Keyword Succeeds so the retry
+    ...    loop actually polls — _Get Email Template Selection always returns a string
+    ...    and never raises, so it cannot be used directly with Wait Until Keyword Succeeds.
+    ${value}=    _Get Email Template Selection
+    Should Not Be Equal    ${value}    not_set
+    ...    msg=Default invoice email template not yet populated (got: ${value})
+    RETURN    ${value}
+
 _Get Email Template Selection
     [Documentation]    Returns the current value of the "Select Default Email Template"
-    ...    combobox via JavaScript, or 'not_set' if empty. Used by Wait Until Keyword
-    ...    Succeeds to poll until Salesforce's async template creation completes.
+    ...    combobox via JavaScript, or 'not_set' if empty.
     ${value}=    Execute JavaScript
     ...    ${_JS_FIND_EL}
     ...    return (function() {

--- a/tasks/rlm_configure_billing_email_settings.py
+++ b/tasks/rlm_configure_billing_email_settings.py
@@ -8,8 +8,9 @@ enableInvoiceEmailDelivery) sets the BillingSettings boolean but does not trigge
 Salesforce backend logic that auto-creates the default invoice email template and
 sets BillingSettings.defaultEmailTemplate. A UI toggle cycle (off then on) is required.
 
-This task is idempotent: it queries for the default email template first and skips
-the browser cycle if the template already exists.
+This task is idempotent: the Robot toggle keywords check current toggle state before
+clicking (skipping the click if already in the target state), and the post-cycle
+verification polls until the Default Invoice Email Template field is populated.
 """
 
 import subprocess

--- a/tasks/rlm_configure_billing_email_settings.py
+++ b/tasks/rlm_configure_billing_email_settings.py
@@ -35,7 +35,9 @@ class ConfigureBillingEmailSettings(BaseSalesforceTask):
 
     Navigates to /lightning/setup/BillingSettings/home and cycles the
     "Configure Email Delivery Settings" toggle off→on to trigger auto-creation
-    of the default invoice email template. Skips if the template already exists.
+    of the default invoice email template. Idempotent: the Robot toggle keywords
+    check current toggle state before clicking, and post-cycle polling verifies
+    the Default Invoice Email Template field is populated.
     """
 
     task_options = {

--- a/tasks/rlm_configure_billing_email_settings.py
+++ b/tasks/rlm_configure_billing_email_settings.py
@@ -1,0 +1,105 @@
+"""Configure Billing Email Delivery Settings via Robot Framework.
+
+Cycles the "Configure Email Delivery Settings" toggle on the Billing Settings
+Lightning Setup page (/lightning/setup/BillingSettings/home) via browser automation.
+
+The Metadata API toggle cycling in prepare_billing (steps 9→10: disable then re-enable
+enableInvoiceEmailDelivery) sets the BillingSettings boolean but does not trigger the
+Salesforce backend logic that auto-creates the default invoice email template and
+sets BillingSettings.defaultEmailTemplate. A UI toggle cycle (off then on) is required.
+
+This task is idempotent: it queries for the default email template first and skips
+the browser cycle if the template already exists.
+"""
+
+import subprocess
+import sys
+from pathlib import Path
+
+try:
+    from cumulusci.tasks.salesforce import BaseSalesforceTask
+    from cumulusci.core.exceptions import TaskOptionsError
+except ImportError:
+    BaseSalesforceTask = object  # type: ignore
+    TaskOptionsError = Exception  # type: ignore
+
+from tasks.robot_utils import check_urllib3_for_robot
+
+DEFAULT_SUITE = "robot/rlm-base/tests/setup/configure_billing_email_settings.robot"
+DEFAULT_OUTPUT_DIR = "robot/rlm-base/results"
+
+
+class ConfigureBillingEmailSettings(BaseSalesforceTask):
+    """Run the Robot test that cycles the Billing Email Delivery Settings toggle.
+
+    Navigates to /lightning/setup/BillingSettings/home and cycles the
+    "Configure Email Delivery Settings" toggle off→on to trigger auto-creation
+    of the default invoice email template. Skips if the template already exists.
+    """
+
+    task_options = {
+        "suite": {
+            "description": "Path to the Robot test suite.",
+            "required": False,
+        },
+        "outputdir": {
+            "description": "Directory for Robot output (log.html, report.html, output.xml).",
+            "required": False,
+        },
+    }
+
+    def _run_task(self):
+        check_urllib3_for_robot(task_name="ConfigureBillingEmailSettings")
+        org_name = getattr(self.org_config, "username", None)
+        if not org_name:
+            org_name = getattr(self.org_config, "name", None) or getattr(
+                self.org_config, "alias", None
+            )
+        if not org_name:
+            raise TaskOptionsError(
+                "ConfigureBillingEmailSettings requires an org (run as part of a flow "
+                "with --org, or set org_config)."
+            )
+
+        repo_root = Path(self.project_config.repo_root)
+        suite = self.options.get("suite") or DEFAULT_SUITE
+        suite_path = repo_root / suite
+        if not suite_path.exists():
+            raise FileNotFoundError(f"Robot suite not found: {suite_path}")
+
+        outputdir = self.options.get("outputdir") or DEFAULT_OUTPUT_DIR
+        out_path = repo_root / outputdir
+        out_path.mkdir(parents=True, exist_ok=True)
+
+        cmd = [
+            sys.executable,
+            "-m",
+            "robot",
+            "--variable",
+            f"ORG_ALIAS:{org_name}",
+            "--outputdir",
+            str(out_path),
+            str(suite_path),
+        ]
+
+        self.logger.info(
+            "Running configure billing email settings test for org %s: %s",
+            org_name,
+            " ".join(cmd),
+        )
+        result = subprocess.run(
+            cmd,
+            cwd=str(repo_root),
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode != 0:
+            self.logger.error("Robot stdout: %s", result.stdout)
+            self.logger.error("Robot stderr: %s", result.stderr)
+            raise RuntimeError(
+                f"Configure billing email settings test failed (exit code {result.returncode}). "
+                f"Check {out_path / 'log.html'} for details."
+            )
+        self.logger.info(
+            "Billing Email Delivery Settings configured: default invoice email template created."
+        )

--- a/tasks/rlm_configure_billing_email_settings.py
+++ b/tasks/rlm_configure_billing_email_settings.py
@@ -101,5 +101,5 @@ class ConfigureBillingEmailSettings(BaseSalesforceTask):
                 f"Check {out_path / 'log.html'} for details."
             )
         self.logger.info(
-            "Billing Email Delivery Settings configured: default invoice email template created."
+            "Billing Email Delivery Settings configured: default invoice email template created or already present."
         )


### PR DESCRIPTION
## Summary

- **Root cause:** \`prepare_billing\` steps 9→10 cycle \`enableInvoiceEmailDelivery\` via Metadata API (off then on), but this does not trigger the Salesforce backend that auto-creates \`BillingSettings.defaultEmailTemplate\`. Only a UI toggle cycle does.
- Adds \`configure_billing_email_settings\` robot task that navigates to Billing Settings and cycles the "Configure Email Delivery Settings" toggle off→on via the browser using headed Chrome (headless Chrome does not fire the Apex call that creates the template)
- Idempotent: toggle keywords check \`inp.checked\` before clicking (skip if already in target state); post-cycle polling verifies the Default Invoice Email Template field is populated before the suite passes
- Wired into \`prepare_billing\` as step 14 (\`when: billing=true\`), after the metadata cycling steps

## Test plan

- [ ] Run \`cci task run configure_billing_email_settings --org <alias>\` on a fresh billing org and confirm \`defaultEmailTemplate\` is populated in Billing Settings
- [ ] Run a second time and confirm the suite still passes (toggle already-on is skipped, template already-populated polling succeeds immediately)
- [ ] Run \`cci flow run prepare_billing --org <alias>\` end-to-end and confirm step 14 executes without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)