### PR TITLE
fix: correct shadow DOM toggle clicks and retry logic for setup robots

### DIFF
--- a/robot/rlm-base/resources/SetupToggles.robot
+++ b/robot/rlm-base/resources/SetupToggles.robot
@@ -324,7 +324,7 @@ _EnsureShadowDOMToggle
     ...                    if (!inp) continue;
     ...                    if (shouldEnable && inp.checked) return 'already_enabled';
     ...                    if (!shouldEnable && !inp.checked) return 'already_disabled';
-    ...                    inp.click();
+    ...                    (inp.closest('label') || inp).click();
     ...                    return 'clicked';
     ...                }
     ...                continue;

--- a/robot/rlm-base/tests/setup/configure_product_discovery_settings.robot
+++ b/robot/rlm-base/tests/setup/configure_product_discovery_settings.robot
@@ -55,29 +55,13 @@ Set Default Catalog
     ...    nested LWC shadow DOMs (lightning-combobox → lightning-base-combobox → button, with
     ...    option text read from lightning-base-combobox-item shadow roots). Clears any existing
     ...    selection first if a different catalog is already selected. Auto-saves on selection.
+    ...
+    ...    Uses Wait Until Keyword Succeeds to retry when the combobox is not yet rendered —
+    ...    reconfigure_pricing_discovery triggers background processing that delays LWC render.
     [Arguments]    ${target_value}
-    # Step 1: check current state; clear wrong selection; open dropdown
-    ${open_result}=    Execute JavaScript
-    ...    ${_JS_FIND_EL}
-    ...    return (function(targetValue) {
-    ...        var selEl = findEl(document, '[data-id="selectedCatalog"]', 0);
-    ...        if (selEl && selEl.textContent.trim() === targetValue) return 'already_set';
-    ...        if (selEl) {
-    ...            var removeBtn = findEl(document, 'button.slds-pill__remove', 0);
-    ...            if (!removeBtn) return 'remove_btn_not_found';
-    ...            removeBtn.click();
-    ...            return 'cleared';
-    ...        }
-    ...        var lc = findEl(document, 'lightning-combobox[data-id="defaultCatalog"]', 0);
-    ...        if (!lc) return 'combobox_not_found';
-    ...        var lbc = lc.shadowRoot && lc.shadowRoot.querySelector('lightning-base-combobox');
-    ...        if (!lbc) return 'lbc_not_found';
-    ...        var btn = lbc.shadowRoot && lbc.shadowRoot.querySelector('button[role="combobox"]');
-    ...        if (!btn) return 'btn_not_found';
-    ...        btn.click();
-    ...        return 'opened';
-    ...    })(arguments[0])
-    ...    ARGUMENTS    ${target_value}
+    # Step 1: check current state; clear wrong selection; open dropdown (retry on combobox_not_found)
+    ${open_result}=    Wait Until Keyword Succeeds    30s    3s
+    ...    _Open Default Catalog Combobox    ${target_value}
     IF    "${open_result}" == "already_set"
         Log    Default Catalog already set to "${target_value}". No change needed.
         RETURN
@@ -120,6 +104,38 @@ Set Default Catalog
     ...    msg=Option "${target_value}" not found in dropdown. ${select_result}
     Sleep    2s    reason=Allow selection to auto-save
     Log    Default Catalog set to "${target_value}".
+
+_Open Default Catalog Combobox
+    [Documentation]    Runs the state-check JS for Set Default Catalog.
+    ...    Returns 'opened' (combobox clicked open), 'already_set' (correct value present),
+    ...    'cleared' (wrong pill removed), or an error string. Fails with a retry-triggering
+    ...    message when 'combobox_not_found' — Salesforce background processing after
+    ...    reconfigure_pricing_discovery delays LWC render; Wait Until Keyword Succeeds retries.
+    [Arguments]    ${target_value}
+    ${result}=    Execute JavaScript
+    ...    ${_JS_FIND_EL}
+    ...    return (function(targetValue) {
+    ...        var selEl = findEl(document, '[data-id="selectedCatalog"]', 0);
+    ...        if (selEl && selEl.textContent.trim() === targetValue) return 'already_set';
+    ...        if (selEl) {
+    ...            var removeBtn = findEl(document, 'button.slds-pill__remove', 0);
+    ...            if (!removeBtn) return 'remove_btn_not_found';
+    ...            removeBtn.click();
+    ...            return 'cleared';
+    ...        }
+    ...        var lc = findEl(document, 'lightning-combobox[data-id="defaultCatalog"]', 0);
+    ...        if (!lc) return 'combobox_not_found';
+    ...        var lbc = lc.shadowRoot && lc.shadowRoot.querySelector('lightning-base-combobox');
+    ...        if (!lbc) return 'lbc_not_found';
+    ...        var btn = lbc.shadowRoot && lbc.shadowRoot.querySelector('button[role="combobox"]');
+    ...        if (!btn) return 'btn_not_found';
+    ...        btn.click();
+    ...        return 'opened';
+    ...    })(arguments[0])
+    ...    ARGUMENTS    ${target_value}
+    Should Not Be Equal    ${result}    combobox_not_found
+    ...    msg=Product Discovery combobox not yet rendered; retrying...
+    RETURN    ${result}
 
 Dismiss Toast If Present
     [Documentation]    Clicks the close button on any visible Salesforce toast messages.

--- a/robot/rlm-base/tests/setup/enable_document_builder.robot
+++ b/robot/rlm-base/tests/setup/enable_document_builder.robot
@@ -36,14 +36,56 @@ Enable Document Templates Export On General Settings
     [Documentation]    Reload General Settings and enable Document Templates Export.
     ...    Requires Design Document Templates to be enabled first (see previous test case).
     ...    The page is reopened so Salesforce reflects the updated prerequisite state before the click.
-    ...    Note: this toggle is a plain input[type="checkbox"] (data-name="MetadataPreference") in
-    ...    light DOM — not a lightning-input — so _EnsureShadowDOMToggle falls back to plain inputs
-    ...    when no lightning-input exists at that DOM depth.
+    ...    Note: this toggle is a plain input[type="checkbox"] (data-name="MetadataPreference") inside
+    ...    an LWC shadow root (setup_industries_docgen-preference-toggle). Enable Toggle By Label
+    ...    cannot reach it because document.createTreeWalker and querySelectorAll do not pierce
+    ...    shadow roots. Instead, we use findEl (recursive shadow-DOM traversal) to click directly —
+    ...    the same approach used in configure_core_pricing_setup and configure_product_discovery.
+    ...    Sleep 5s ensures the save handler is wired before the click fires. After clicking,
+    ...    the page is reloaded to confirm server-side persistence before the suite exits.
     Open Setup Page    ${GENERAL_SETTINGS_PATH}
-    Enable Toggle By Label    ${DOC_TEMPLATES_EXPORT_LABEL}
-    Log    Document Templates Export toggle enabled.
+    Sleep    5s    reason=Allow setup_industries_docgen-preference-toggle LWC to fully wire save handler
+    ${click_result}=    Wait Until Keyword Succeeds    20s    3s
+    ...    _Click Document Templates Export Toggle
+    IF    "${click_result}" == "already_on"
+        Log    Document Templates Export already enabled. No change needed.
+    ELSE
+        Should Be Equal    ${click_result}    clicked
+        ...    msg=Document Templates Export could not be clicked (got: ${click_result})
+    END
+    Sleep    3s    reason=Allow toggle change to reach Salesforce server
+    # Reload and re-verify server-side persistence
+    Open Setup Page    ${GENERAL_SETTINGS_PATH}
+    ${verified}=    Execute JavaScript
+    ...    return (function() {
+    ...        function findEl(root, sel, d) { if (d > 6) return null; var el = root.querySelector(sel); if (el) return el; var all = root.querySelectorAll('*'); for (var i=0;i<all.length;i++){if(all[i].shadowRoot){var f=findEl(all[i].shadowRoot,sel,d+1);if(f)return f;}} return null; }
+    ...        var pi = findEl(document, 'input[data-name="MetadataPreference"]', 0);
+    ...        if (!pi) return 'not_found';
+    ...        return pi.checked ? 'on' : 'off';
+    ...    })()
+    Should Be Equal    ${verified}    on
+    ...    msg=Document Templates Export toggle not persisted after page reload (got: ${verified})
+    Log    Document Templates Export toggle enabled and confirmed.
 
 *** Keywords ***
+_Click Document Templates Export Toggle
+    [Documentation]    Directly clicks input[data-name="MetadataPreference"] inside
+    ...    setup_industries_docgen-preference-toggle's shadow root, bypassing Enable Toggle By Label
+    ...    which uses querySelectorAll / createTreeWalker (neither pierce shadow DOM). Returns
+    ...    'clicked', 'already_on', or fails with 'not_found' to trigger Wait Until Keyword Succeeds retry.
+    ${result}=    Execute JavaScript
+    ...    return (function() {
+    ...        function findEl(root, sel, d) { if (d > 6) return null; var el = root.querySelector(sel); if (el) return el; var all = root.querySelectorAll('*'); for (var i=0;i<all.length;i++){if(all[i].shadowRoot){var f=findEl(all[i].shadowRoot,sel,d+1);if(f)return f;}} return null; }
+    ...        var pi = findEl(document, 'input[data-name="MetadataPreference"]', 0);
+    ...        if (!pi) return 'not_found';
+    ...        if (pi.checked) return 'already_on';
+    ...        pi.click();
+    ...        return 'clicked';
+    ...    })()
+    Should Not Be Equal    ${result}    not_found
+    ...    msg=Document Templates Export input[data-name="MetadataPreference"] not yet rendered; retrying...
+    RETURN    ${result}
+
 Enable Prerequisite Then Document Builder
     [Documentation]    Enable the prerequisite toggle (e.g. Revenue Management) so Document Builder becomes enabled, then enable Document Builder.
     Enable Toggle By Label    ${DOCUMENT_BUILDER_PREREQUISITE_LABEL}


### PR DESCRIPTION
## Summary

- **Fix 1 (closes #133) — `SetupToggles.robot`**: Click the wrapping `<label>` instead of the raw shadow-root `<input>` for `lightning-input` toggles so the LWC save handler fires. (`inp.click()` → `(inp.closest('label') || inp).click()`)

- **Fix 2 (closes #133) — `enable_document_builder.robot`**: Replace `Enable Toggle By Label` for Document Templates Export with a direct `findEl` JS click that pierces the `setup_industries_docgen-preference-toggle` shadow root. `document.createTreeWalker` and `querySelectorAll` do not pierce shadow roots so the old approach was clicking the wrong element. Also adds 5s render wait, post-click reload+verify, and missing `return` on the verification IIFE (was returning `None` instead of `'on'`/`'off'`).

- **Fix 3 (closes #134) — `configure_product_discovery_settings.robot`**: Extracts the combobox-open JS into a `_Open Default Catalog Combobox` helper keyword that fails on `combobox_not_found`, wrapped with `Wait Until Keyword Succeeds 30s/3s`. Salesforce background processing after `reconfigure_pricing_discovery` delays LWC render; without retry the test fails immediately.

## Test plan
- [x] `enable_document_builder_toggle` task run against pr137 org — all 3 test cases PASS
- [x] `configure_product_discovery_settings` task run against pr137 org — PASS
- [x] PR135 (`configure_core_pricing_setup`) confirmed unaffected — uses same retry pattern and was already passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)