### PR TITLE
feat(ai): add doc-consistency skill, setup-UI/UX sub-skills, and pre-merge checklists

### DIFF
--- a/.cursor/rules/doc-review.mdc
+++ b/.cursor/rules/doc-review.mdc
@@ -1,0 +1,30 @@
+---
+description: Reminder to verify documentation consistency after code changes — task names, flag tables, plan READMEs, generated references
+globs: cumulusci.yml,tasks/**/*.py,datasets/sfdmu/**/export.json,robot/**/*.robot,.cursor/skills/**/*.md
+alwaysApply: false
+---
+
+# Documentation Consistency Reminder
+
+After editing files that match this rule, follow the doc-consistency skill
+at `.cursor/skills/doc-consistency/SKILL.md`.
+
+## Quick checks
+
+1. **`cumulusci.yml`** — run `python scripts/ai/generate_cci_reference.py`
+   and commit updated reference files. If you renamed a task, grep for the
+   old name in `README.md`, `AGENTS.md`, `docs/`, and `.cursor/skills/`.
+
+2. **`tasks/*.py`** — verify the task `description` in `cumulusci.yml` and
+   the `README.md` Custom Tasks table still match the class behavior.
+
+3. **`export.json` / SFDMU CSVs** — update the plan's `README.md` in the
+   same commit. Run `python scripts/validate_sfdmu_v5_datasets.py`.
+
+4. **`robot/**`** — check `robot-testing/SKILL.md` task tables and
+   `README.md` troubleshooting if the suite name or behavior changed.
+
+5. **`.cursor/skills/**`** — if adding a new skill or sub-file, register
+   it in `AGENTS.md` (Skill Index / Sub-Files) and `skills/README.md`.
+
+For the full change-surface map, read `.cursor/skills/doc-consistency/SKILL.md`.

--- a/.cursor/rules/doc-review.mdc
+++ b/.cursor/rules/doc-review.mdc
@@ -1,6 +1,12 @@
 ---
 description: Reminder to verify documentation consistency after code changes — task names, flag tables, plan READMEs, generated references
-globs: cumulusci.yml,tasks/**/*.py,datasets/sfdmu/**/export.json,robot/**/*.robot,.cursor/skills/**/*.md
+globs:
+  - cumulusci.yml
+  - tasks/**/*.py
+  - datasets/sfdmu/**/export.json
+  - datasets/sfdmu/**/*.csv
+  - robot/**/*.robot
+  - .cursor/skills/**/*.md
 alwaysApply: false
 ---
 

--- a/.cursor/rules/doc-review.mdc
+++ b/.cursor/rules/doc-review.mdc
@@ -31,6 +31,6 @@ at `.cursor/skills/doc-consistency/SKILL.md`.
    `README.md` troubleshooting if the suite name or behavior changed.
 
 5. **`.cursor/skills/**`** — if adding a new skill or sub-file, register
-   it in `AGENTS.md` (Skill Index / Sub-Files) and `skills/README.md`.
+   it in `AGENTS.md` (Skill Index / Sub-Files) and `.cursor/skills/README.md`.
 
 For the full change-surface map, read `.cursor/skills/doc-consistency/SKILL.md`.

--- a/.cursor/skills/README.md
+++ b/.cursor/skills/README.md
@@ -44,4 +44,4 @@ Non-Cursor agents can read these files directly or use the equivalent skill:
 | `apex-scripts.mdc` | `scripts/apex/**/*.apex` | `troubleshooting/SKILL.md` |
 | `ux-templates.mdc` | `templates/**` | `repo-integration/SKILL.md` |
 | `robot-tests.mdc` | `robot/**/*.robot` | `robot-testing/SKILL.md` |
-| `doc-review.mdc` | `cumulusci.yml`, `tasks/**/*.py`, `export.json`, `robot/**/*.robot`, `.cursor/skills/**/*.md` | `doc-consistency/SKILL.md` |
+| `doc-review.mdc` | `cumulusci.yml`, `tasks/**/*.py`, `datasets/sfdmu/**/export.json`, `datasets/sfdmu/**/*.csv`, `robot/**/*.robot`, `.cursor/skills/**/*.md` | `doc-consistency/SKILL.md` |

--- a/.cursor/skills/README.md
+++ b/.cursor/skills/README.md
@@ -19,6 +19,7 @@ repo root.
 | Understand RLM objects/relationships | Revenue Cloud Data Model | `revenue-cloud-data-model/SKILL.md` |
 | Use Revenue Cloud REST APIs | Business APIs | `rlm-business-apis/SKILL.md` |
 | Write Robot Framework tests | Robot Testing | `robot-testing/SKILL.md` |
+| Review docs before merge | Doc Consistency | `doc-consistency/SKILL.md` |
 | Debug a build/deploy failure | Troubleshooting | `troubleshooting/SKILL.md` |
 
 ## How Skills Are Structured
@@ -43,3 +44,4 @@ Non-Cursor agents can read these files directly or use the equivalent skill:
 | `apex-scripts.mdc` | `scripts/apex/**/*.apex` | `troubleshooting/SKILL.md` |
 | `ux-templates.mdc` | `templates/**` | `repo-integration/SKILL.md` |
 | `robot-tests.mdc` | `robot/**/*.robot` | `robot-testing/SKILL.md` |
+| `doc-review.mdc` | `cumulusci.yml`, `tasks/**/*.py`, `export.json`, `robot/**/*.robot`, `.cursor/skills/**/*.md` | `doc-consistency/SKILL.md` |

--- a/.cursor/skills/doc-consistency/SKILL.md
+++ b/.cursor/skills/doc-consistency/SKILL.md
@@ -1,0 +1,87 @@
+# Documentation Consistency — Pre-Merge Doc Review
+
+Use this skill **before marking a PR ready** to verify that all affected
+documentation stays aligned with code changes. It replaces multi-round
+review-loop fixes ("fix stale description", "update README task name",
+"regenerate CCI reference") with a single lookup pass.
+
+## Quick Rules
+
+1. **If you changed `cumulusci.yml`** — run `python scripts/ai/generate_cci_reference.py` and commit the output. Verify `git diff` on `tasks-reference.md`, `flows-reference.md`, `feature-flags.md` shows only your intended changes.
+2. **If you renamed or added a CCI task** — grep `README.md`, `AGENTS.md`, `docs/`, and `.cursor/skills/` for the **old name**; update or remove every stale reference.
+3. **If you changed an SFDMU plan** (`export.json`, CSVs, objects, operations) — update the plan's `README.md` in the **same commit**. Run `python scripts/validate_sfdmu_v5_datasets.py`.
+4. **If you changed feature flags** (added, removed, renamed, changed default) — update the flag table in `README.md` and verify `feature-flags.md` was regenerated (rule 1).
+5. **If you changed a Python task class** (`tasks/*.py`) — check the task's `description` in `cumulusci.yml`, the `README.md` Custom Tasks table, and any `docs/` guide that names it.
+6. **If you changed Robot test suites or resources** — check `robot-testing/SKILL.md` tables (Setup tasks / E2E tasks) and the `README.md` troubleshooting section.
+7. **If you created a new skill or sub-file** — add it to: (a) the parent `SKILL.md` cross-reference, (b) `AGENTS.md` Skill Sub-Files table, (c) `.cursor/skills/README.md` Skill Router if top-level.
+8. **Quick verification** — run `python scripts/ai/generate_cci_reference.py --dry-run` (should print "no changes") and `python scripts/validate_sfdmu_v5_datasets.py` (should pass).
+
+## DO NOT
+
+- **DO NOT** duplicate procedural content across `README.md`, `AGENTS.md`, and skill files — keep one source and add pointers.
+- **DO NOT** manually update `docs/references/cci-task-reference.md` if the generated `tasks-reference.md` covers the same tasks — consolidate to one.
+- **DO NOT** edit `CLAUDE.md` — it is a symlink to `AGENTS.md`.
+- **DO NOT** skip the plan README when changing SFDMU plan behavior.
+
+---
+
+## Change-Surface Map
+
+The core lookup: **when X changes, verify Y**.
+
+| What changed | Docs to verify or update |
+| ------------ | ------------------------ |
+| `cumulusci.yml` (tasks, flows, flags) | Generated refs (run script), `README.md` task/flag tables, `AGENTS.md` Common Workflows |
+| `tasks/*.py` (class, options, description) | `cumulusci.yml` description, `README.md` Custom Tasks table, relevant `docs/` guide |
+| `datasets/sfdmu/**/export.json` or CSVs | Plan `README.md` in same directory, run SFDMU validator |
+| Feature flag add/rename/default change | `README.md` Feature Flags tables, `AGENTS.md` edition flags, generated `feature-flags.md` |
+| `robot/**` (new suite, renamed keyword) | `robot-testing/SKILL.md` task tables, `patterns.md`, `README.md` troubleshooting |
+| `templates/` or UX assembly logic | `ux-assembly-retrieve.md`, `docs/features/dynamic-ux-assembly.md` |
+| New `.cursor/skills/` file | Parent `SKILL.md`, `AGENTS.md` Sub-Files table, `skills/README.md` Skill Router |
+| `orgs/*.json` (scratch org definitions) | `README.md` Quick Start if it names specific configs |
+| `scripts/apex/*.apex` | `troubleshooting/SKILL.md` if it references the script |
+| `.forceignore` | No doc update, but verify retrieve/deploy intent is consistent |
+| `scripts/ai/*.py` | `AGENTS.md` AI Utility Scripts section |
+
+---
+
+## Doc Layers in This Repo
+
+Understanding where truth lives prevents duplication drift.
+
+| Layer | Location | How to keep current |
+| ----- | -------- | ------------------- |
+| Generated CCI refs | `.cursor/skills/cci-orchestration/{tasks,flows,feature-flags}-reference.md` | `python scripts/ai/generate_cci_reference.py` |
+| SFDMU plan READMEs | `datasets/sfdmu/qb/en-US/*/README.md` | Manual — must match `export.json` |
+| Agent instructions | `AGENTS.md` (`CLAUDE.md` is a symlink) | Single source; edit `AGENTS.md` only |
+| Human setup / reference | `README.md` | Manual — task tables, flag tables, troubleshooting |
+| Skill files | `.cursor/skills/*/SKILL.md` + sub-files | Manual — cross-references to task names, paths |
+| Guides and features | `docs/guides/`, `docs/features/`, `docs/references/` | Manual prose; watch for stale task/flow names |
+| Copilot instructions | `.github/copilot-instructions.md` | Pointer only — keep thin, link to `AGENTS.md` |
+
+---
+
+## Verification Commands
+
+```bash
+python scripts/ai/generate_cci_reference.py --dry-run   # should report no changes
+python scripts/validate_sfdmu_v5_datasets.py             # should pass
+```
+
+If the dry-run shows diffs, regenerate and commit:
+
+```bash
+python scripts/ai/generate_cci_reference.py
+git add .cursor/skills/cci-orchestration/tasks-reference.md \
+       .cursor/skills/cci-orchestration/flows-reference.md \
+       .cursor/skills/cci-orchestration/feature-flags.md
+```
+
+---
+
+## Related Skills
+
+- **CCI Orchestration** — `.cursor/skills/cci-orchestration/SKILL.md`
+- **SFDMU Data Plans** — `.cursor/skills/sfdmu-data-plans/SKILL.md`
+- **Repository Integration** — `.cursor/skills/repo-integration/SKILL.md`
+- **Robot Testing** — `.cursor/skills/robot-testing/SKILL.md`

--- a/.cursor/skills/doc-consistency/SKILL.md
+++ b/.cursor/skills/doc-consistency/SKILL.md
@@ -37,7 +37,7 @@ The core lookup: **when X changes, verify Y**.
 | Feature flag add/rename/default change | `README.md` Feature Flags tables, `AGENTS.md` edition flags, generated `feature-flags.md` |
 | `robot/**` (new suite, renamed keyword) | `robot-testing/SKILL.md` task tables, `patterns.md`, `README.md` troubleshooting |
 | `templates/` or UX assembly logic | `ux-assembly-retrieve.md`, `docs/features/dynamic-ux-assembly.md` |
-| New `.cursor/skills/` file | Parent `SKILL.md`, `AGENTS.md` Sub-Files table, `skills/README.md` Skill Router |
+| New `.cursor/skills/` file | Parent `SKILL.md`, `AGENTS.md` Sub-Files table, `.cursor/skills/README.md` Skill Router |
 | `orgs/*.json` (scratch org definitions) | `README.md` Quick Start if it names specific configs |
 | `scripts/apex/*.apex` | `troubleshooting/SKILL.md` if it references the script |
 | `.forceignore` | No doc update, but verify retrieve/deploy intent is consistent |

--- a/.cursor/skills/doc-consistency/SKILL.md
+++ b/.cursor/skills/doc-consistency/SKILL.md
@@ -14,7 +14,7 @@ review-loop fixes ("fix stale description", "update README task name",
 5. **If you changed a Python task class** (`tasks/*.py`) — check the task's `description` in `cumulusci.yml`, the `README.md` Custom Tasks table, and any `docs/` guide that names it.
 6. **If you changed Robot test suites or resources** — check `robot-testing/SKILL.md` tables (Setup tasks / E2E tasks) and the `README.md` troubleshooting section.
 7. **If you created a new skill or sub-file** — add it to: (a) the parent `SKILL.md` cross-reference, (b) `AGENTS.md` Skill Sub-Files table, (c) `.cursor/skills/README.md` Skill Router if top-level.
-8. **Quick verification** — run `python scripts/ai/generate_cci_reference.py --dry-run` (should print "no changes") and `python scripts/validate_sfdmu_v5_datasets.py` (should pass).
+8. **Quick verification** — run `python scripts/ai/generate_cci_reference.py` and then `git diff` to confirm only intended changes appear. Run `python scripts/validate_sfdmu_v5_datasets.py` (should pass).
 
 ## DO NOT
 
@@ -51,7 +51,7 @@ Understanding where truth lives prevents duplication drift.
 
 | Layer | Location | How to keep current |
 | ----- | -------- | ------------------- |
-| Generated CCI refs | `.cursor/skills/cci-orchestration/{tasks,flows,feature-flags}-reference.md` | `python scripts/ai/generate_cci_reference.py` |
+| Generated CCI refs | `.cursor/skills/cci-orchestration/tasks-reference.md`, `.cursor/skills/cci-orchestration/flows-reference.md`, `.cursor/skills/cci-orchestration/feature-flags.md` | `python scripts/ai/generate_cci_reference.py` |
 | SFDMU plan READMEs | `datasets/sfdmu/qb/en-US/*/README.md` | Manual — must match `export.json` |
 | Agent instructions | `AGENTS.md` (`CLAUDE.md` is a symlink) | Single source; edit `AGENTS.md` only |
 | Human setup / reference | `README.md` | Manual — task tables, flag tables, troubleshooting |
@@ -64,11 +64,12 @@ Understanding where truth lives prevents duplication drift.
 ## Verification Commands
 
 ```bash
-python scripts/ai/generate_cci_reference.py --dry-run   # should report no changes
+python scripts/ai/generate_cci_reference.py              # regenerate references
+git diff .cursor/skills/cci-orchestration/               # should show only intended changes
 python scripts/validate_sfdmu_v5_datasets.py             # should pass
 ```
 
-If the dry-run shows diffs, regenerate and commit:
+If the diff shows unintended changes, investigate before committing. To commit the regenerated files:
 
 ```bash
 python scripts/ai/generate_cci_reference.py

--- a/.cursor/skills/repo-integration/SKILL.md
+++ b/.cursor/skills/repo-integration/SKILL.md
@@ -64,6 +64,10 @@ auto-updates YAML patch files. Profile writeback requires manual oversight.
 
 For full details, see `docs/features/dynamic-ux-assembly.md`.
 
+For **assembler vs retrieve**, SOAP retrieve scope, stale `appMenus/` cleanup,
+and why not to hand-edit `unpackaged/post_ux/`, read
+`.cursor/skills/repo-integration/ux-assembly-retrieve.md`.
+
 ---
 
 ## How Do I Configure Something?

--- a/.cursor/skills/repo-integration/ux-assembly-retrieve.md
+++ b/.cursor/skills/repo-integration/ux-assembly-retrieve.md
@@ -1,0 +1,41 @@
+# UX Assembly, Retrieve, and Drift
+
+Read this when changing **`templates/`** UX sources, **`tasks/rlm_ux_assembly.py`**, **`tasks/rlm_retrieve_ux.py`**, drift tasks, or anything under **`unpackaged/post_ux/`** output.
+
+## Source of truth
+
+| Location | Role |
+|----------|------|
+| `templates/` | **Edit here** — flexipage patches, layouts, apps, profiles, object bindings |
+| `unpackaged/post_ux/` | **Generated** — assembled output; **do not hand-edit** (see `AGENTS.md`) |
+| `docs/features/dynamic-ux-assembly.md` | Full drift capture / writeback / assembly behavior |
+
+## Assembler (`assemble_and_deploy_ux`)
+
+- **Purpose** — Merges base templates + YAML patches per feature flags, writes to `unpackaged/post_ux/`, optionally deploys.
+- **Options** — Filter by `metadata_type` (e.g. `flexipages`, `profiles`) or single `metadata_name` (full filename including `.flexipage-meta.xml`).
+- **App menus** — AppSwitcher / `appMenus` are **not** assembled here; launcher order is handled by **`reorder_app_launcher`** (Robot). The task **removes a stale `appMenus/`** directory if present from older runs.
+- **Python changes** — Keep `_assemble_*` helpers internally consistent (return types, early exits). Drift flows assume predictable manifest and file layout.
+
+## Retrieve (`retrieve_ux_from_org`)
+
+- **Purpose** — Pulls live flexipages from the org into `unpackaged/post_ux/` for **drift comparison** (`capture_ux_drift` → `diff_ux_templates`).
+- **Implementation** — Uses **Metadata API SOAP retrieve** inside CCI (not necessarily `sf` CLI) to avoid PATH/env issues in embedded runs.
+- **Scope** — Defaults to the same flexipage set the assembler would deploy (base + standalone for active flags). Narrow with `metadata_name` when testing one page.
+- **XML / namespace** — Retrieved XML must match parser expectations (namespace-aware parsing). If you change retrieve or strip logic, validate with a real org retrieve.
+
+## Workflows (canonical commands)
+
+```bash
+cci task run assemble_and_deploy_ux -o deploy false --org <cci_alias>   # dry-run assembly
+cci flow run capture_ux_drift --org <cci_alias>                        # retrieve + diff
+cci flow run apply_ux_drift --org <cci_alias>                          # writeback to templates + verify
+```
+
+Use **`--org`** with the **CCI alias**; for raw `sf` commands use **`--target-org`** with the SF CLI alias (e.g. `rlm-base__beta`). See `AGENTS.md` — Org Identity.
+
+## DO NOT
+
+- **DO NOT** edit `unpackaged/post_ux/` to “fix” UX — fix **`templates/`** and re-run assembly (or follow drift writeback).
+- **DO NOT** add `EmailTemplatePage` flexipages to templates — they cannot deploy via Metadata API (`AGENTS.md`).
+- **DO NOT** assume hand-copied org XML belongs in `post_ux` without going through retrieve + diff + writeback when aligning with templates.

--- a/.cursor/skills/robot-testing/SKILL.md
+++ b/.cursor/skills/robot-testing/SKILL.md
@@ -10,6 +10,7 @@ Use this skill when writing, modifying, or debugging Robot Framework tests.
 4. Use `composed: true` on dispatched events to cross shadow DOM boundaries.
 5. Use `self.org_config.username` in Python wrappers for `sf org open -o`.
 6. Gate E2E tests with `Skip If "${QB}" == "false"` on the relevant feature flag.
+7. For Setup UI + shadow DOM vs iframe: read `setup-ui-shadow-dom.md` before adding new keywords (LWS, `composed`, VF frames).
 
 ## DO NOT
 
@@ -58,6 +59,10 @@ Use this skill when writing, modifying, or debugging Robot Framework tests.
 For detailed CCI task tables, Python wrapper patterns, shadow DOM
 traversal code, LWC reactivity patterns, keyword references, and
 test authoring guides, read `.cursor/skills/robot-testing/patterns.md`.
+
+For **agent-oriented** setup-UI pitfalls (shadow vs iframe, logging, when
+not to copy generic Selenium), read
+`.cursor/skills/robot-testing/setup-ui-shadow-dom.md`.
 
 ### Running tests
 

--- a/.cursor/skills/robot-testing/setup-ui-shadow-dom.md
+++ b/.cursor/skills/robot-testing/setup-ui-shadow-dom.md
@@ -1,0 +1,35 @@
+# Setup UI — Shadow DOM and Lightning Web Security
+
+Read this when editing **Robot setup tests** under `robot/rlm-base/tests/setup/` or shared resources that drive **Setup**, **App Builder–less** toggles, or **LWC controls** with no REST equivalent.
+
+## Relationship to `patterns.md`
+
+- **Code samples and keyword tables** — `.cursor/skills/robot-testing/patterns.md` (shadow helpers, combobox flow, CCI task wiring).
+- **This file** — agent-facing **decisions and pitfalls** so you do not re-learn them from failed runs.
+
+## Quick rules
+
+1. **Shadow DOM** — Standard Selenium/XPath does not cross into LWC shadow roots. Use the repo’s **recursive `findEl` / `findAll` JavaScript** patterns from `patterns.md`, not generic `Click Element` on inner nodes.
+2. **`composed: true` on events** — When dispatching events that must cross shadow boundaries, use `composed: true` (see `patterns.md` and existing setup suites).
+3. **No `//` in Robot `Execute JavaScript` blocks** — Robot joins continuation lines; `//` comments break the script. Use `/* */`.
+4. **LWC inputs** — Do not use `Input Text` on Lightning inputs; use the **native setter** pattern documented in `patterns.md`.
+5. **VF / Classic iframe** — Some flows (e.g. CRM Analytics) use **Visualforce iframes**, not shadow DOM. Use **frame switch** helpers (see `AnalyticsSetupHelper.py`, `enable_analytics.robot`) — do not apply shadow traversal to iframe content.
+6. **Authentication** — Use `sf org open --url-only` with `self.org_config.username` in Python wrappers; wrap URL logging with `Set Log Level NONE` so session tokens never appear in `log.html`.
+7. **Retries** — Setup pages can be slow or flaky; follow **existing** timeout/save-staleness patterns in `SetupToggles.robot` and related resources instead of ad-hoc long `Sleep`.
+
+## DO NOT
+
+- **DO NOT** paste generic Stack Overflow Selenium for Lightning Setup — it will not cross shadow roots.
+- **DO NOT** log org URLs at default log level during authentication.
+- **DO NOT** add sleeps without checking whether an existing keyword already polls for readiness.
+
+## Where to look in the repo
+
+| Area | Location |
+|------|----------|
+| Shared toggle / checkbox keywords | `robot/rlm-base/resources/SetupToggles.robot` |
+| Chrome / driver resolution | `robot/rlm-base/resources/WebDriverManager.py` |
+| Analytics (VF iframe) | `robot/rlm-base/resources/AnalyticsSetupHelper.py`, `tests/setup/enable_analytics.robot` |
+| Variables (URLs, labels) | `robot/rlm-base/variables/SetupVariables.robot` |
+
+After substantive changes, run `cci task run validate_setup` (no org) and exercise the relevant `configure_*` / `enable_*` task against a scratch org when possible.

--- a/.cursor/skills/robot-testing/setup-ui-shadow-dom.md
+++ b/.cursor/skills/robot-testing/setup-ui-shadow-dom.md
@@ -29,7 +29,7 @@ Read this when editing **Robot setup tests** under `robot/rlm-base/tests/setup/`
 |------|----------|
 | Shared toggle / checkbox keywords | `robot/rlm-base/resources/SetupToggles.robot` |
 | Chrome / driver resolution | `robot/rlm-base/resources/WebDriverManager.py` |
-| Analytics (VF iframe) | `robot/rlm-base/resources/AnalyticsSetupHelper.py`, `tests/setup/enable_analytics.robot` |
+| Analytics (VF iframe) | `robot/rlm-base/resources/AnalyticsSetupHelper.py`, `robot/rlm-base/tests/setup/enable_analytics.robot` |
 | Variables (URLs, labels) | `robot/rlm-base/variables/SetupVariables.robot` |
 
 After substantive changes, run `cci task run validate_setup` (no org) and exercise the relevant `configure_*` / `enable_*` task against a scratch org when possible.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -15,6 +15,8 @@ AI agent instructions file. Read it for:
 1. Read `AGENTS.md` at the repo root
 2. Find the relevant skill in the Skill Index section
 3. Read that skill's `SKILL.md` for detailed guidance
+4. Use **Skill Sub-Files** (listed in `AGENTS.md`) for focused topics — e.g. Robot setup UI + shadow DOM (`.cursor/skills/robot-testing/setup-ui-shadow-dom.md`), UX assembly vs retrieve (`.cursor/skills/repo-integration/ux-assembly-retrieve.md`)
+5. Before a PR: follow **Pre-merge checklists for AI agents** in `AGENTS.md` (SFDMU, `cumulusci.yml`, merge diffs)
 
 ## Entry Points
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -145,6 +145,36 @@ python scripts/ai/generate_cci_reference.py                         # after cumu
 
 ---
 
+## Pre-merge checklists for AI agents
+
+Use these before opening or updating a PR. They complement the **PR Review Focus Areas** below.
+
+### SFDMU data plans (`datasets/sfdmu/**`, `export.json`, CSVs)
+
+1. Run `python scripts/validate_sfdmu_v5_datasets.py` and fix reported issues.
+2. Keep **`externalId`** (`;` delimiters) and CSV `$$` columns aligned with the skill rules in this file — do not change `Upsert` to `Insert` + `deleteOldData: true` without explicit user approval.
+3. If the plan’s behavior or objects changed, update the plan’s **README** in the same change.
+
+### `cumulusci.yml` and CCI tasks
+
+1. After editing `cumulusci.yml` (tasks, flows, options): run `python scripts/ai/generate_cci_reference.py` and commit the regenerated reference files.
+2. If you rename a task or change its description, search the repo for the **old task name** in docs (`README.md`, `docs/`) and fix stale references.
+3. For Python task changes in `tasks/`, follow `.cursor/skills/cci-orchestration/custom-task-authoring.md` — especially **CLI vs REST** (`username` for `sf`, not `access_token`).
+
+### Documentation consistency
+
+Follow `.cursor/skills/doc-consistency/SKILL.md` — it provides a
+**change-surface map** (when X changes, update Y) covering task names,
+flag tables, SFDMU plan READMEs, generated CCI references, skill
+indexes, and more.
+
+### Merges and unintended diffs
+
+1. Before push, review `git diff main --stat` (or the merge base you use). Pay extra attention to **`orgs/`**, **`datasets/`**, **`unpackaged/post_ux/`**, and scratch data — unexpected churn often means files were **swept in from another branch**.
+2. Changes under **`unpackaged/post_ux/`** should come from **`assemble_and_deploy_ux`** or the **UX drift** flows, not manual XML edits (see `.cursor/skills/repo-integration/ux-assembly-retrieve.md`).
+
+---
+
 ## PR Review Focus Areas
 
 1. **SFDMU v5 compliance** — externalId format, operation + deleteOldData
@@ -177,6 +207,7 @@ that topic.
 | Use Revenue Cloud REST APIs | `.cursor/skills/rlm-business-apis/SKILL.md` |
 | Write Robot Framework tests | `.cursor/skills/robot-testing/SKILL.md` |
 | Capture/apply UX drift from org | `docs/features/dynamic-ux-assembly.md` |
+| Review docs before merge | `.cursor/skills/doc-consistency/SKILL.md` |
 | Debug a build/deploy failure | `.cursor/skills/troubleshooting/SKILL.md` |
 
 Each skill has a **Quick Rules** section at the top for fast reference,
@@ -192,6 +223,8 @@ Read the sub-file only when you need that specific detail:
 | `repo-integration/new-feature-guide.md` | Repository Integration | Step-by-step code templates for adding a new feature |
 | `repo-integration/dependency-ordering.md` | Repository Integration | Metadata/data ordering, `prepare_rlm_org` step map |
 | `robot-testing/patterns.md` | Robot Testing | Shadow DOM code, keyword reference, test authoring |
+| `robot-testing/setup-ui-shadow-dom.md` | Robot Testing | Setup UI: shadow vs iframe, LWS, logging (companion to `patterns.md`) |
+| `repo-integration/ux-assembly-retrieve.md` | Repository Integration | Assembler vs retrieve, `post_ux` rules, drift workflow |
 | `cci-orchestration/custom-task-authoring.md` | CCI Orchestration | Python task class patterns and examples |
 | `cci-orchestration/tasks-reference.md` | CCI Orchestration | Auto-generated task listing (regenerate after edits) |
 | `cci-orchestration/flows-reference.md` | CCI Orchestration | Auto-generated flow listing |
@@ -216,6 +249,7 @@ same guidance, or use the parent skill which covers the same content:
 | `.cursor/rules/apex-scripts.mdc` | `scripts/apex/**/*.apex` | `troubleshooting/SKILL.md` |
 | `.cursor/rules/ux-templates.mdc` | `templates/**` | `repo-integration/SKILL.md` |
 | `.cursor/rules/robot-tests.mdc` | `robot/**/*.robot` | `robot-testing/SKILL.md` |
+| `.cursor/rules/doc-review.mdc` | `cumulusci.yml`, `tasks/**/*.py`, `export.json`, `robot/**/*.robot`, `.cursor/skills/**/*.md` | `doc-consistency/SKILL.md` |
 
 ### AI Utility Scripts
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -249,7 +249,7 @@ same guidance, or use the parent skill which covers the same content:
 | `.cursor/rules/apex-scripts.mdc` | `scripts/apex/**/*.apex` | `troubleshooting/SKILL.md` |
 | `.cursor/rules/ux-templates.mdc` | `templates/**` | `repo-integration/SKILL.md` |
 | `.cursor/rules/robot-tests.mdc` | `robot/**/*.robot` | `robot-testing/SKILL.md` |
-| `.cursor/rules/doc-review.mdc` | `cumulusci.yml`, `tasks/**/*.py`, `export.json`, `robot/**/*.robot`, `.cursor/skills/**/*.md` | `doc-consistency/SKILL.md` |
+| `.cursor/rules/doc-review.mdc` | `cumulusci.yml`, `tasks/**/*.py`, `datasets/sfdmu/**/export.json`, `datasets/sfdmu/**/*.csv`, `robot/**/*.robot`, `.cursor/skills/**/*.md` | `doc-consistency/SKILL.md` |
 
 ### AI Utility Scripts
 


### PR DESCRIPTION
## Summary

Adds three new agent skills, a Cursor auto-injection rule, and pre-merge checklists to reduce multi-round review fixes on documentation drift. Changes were sourced by analyzing **~719 commits over the past year** (Apr 2025 -- Apr 2026).

### What the commit history showed

- **~76 commits** were fix-after-the-fact doc corrections: stale task names, wrong CLI flags, outdated descriptions, README/skill/AGENTS.md drift.
- **Dozens of "address Copilot review" commits** (often 3--15 rounds per PR) fixing the same category of issue -- renamed tasks not updated in README, feature-flag tables out of sync, SFDMU plan READMEs lagging behind `export.json` changes.
- **Highest-churn paths:** `cumulusci.yml` (146 edits), `README.md` (69), `tasks/rlm_sfdmu.py` (27), `tasks/rlm_validate_setup.py` (18), Robot resources, SFDMU datasets, and agent entry points.
- **Recurring patterns:** "fix stale description", "correct task name in CLAUDE.md", "update README for selenium>=4.10", "fix v4 externalId example", "restore org definitions swept from other branch."

### New files

- **`.cursor/skills/doc-consistency/SKILL.md`** -- First-class "Documentation Consistency" skill with 8 quick rules, a change-surface map ("when X changes, update Y"), doc-layer reference table, and verification commands.
- **`.cursor/rules/doc-review.mdc`** -- Cursor rule that auto-injects when editing `cumulusci.yml`, `tasks/**/*.py`, `export.json`, `robot/**/*.robot`, or `.cursor/skills/**/*.md`. Compact 5-point reminder linking to the full skill.
- **`.cursor/skills/robot-testing/setup-ui-shadow-dom.md`** -- Agent-facing decisions for Setup UI tests: shadow DOM vs VF iframe, `composed: true`, no `//` in JS, logging, retry patterns. Complements the existing `patterns.md` (code samples).
- **`.cursor/skills/repo-integration/ux-assembly-retrieve.md`** -- Assembler vs retrieve scope, stale `appMenus/` cleanup, SOAP retrieve namespace, drift workflow commands, and DO NOTs for `unpackaged/post_ux/`.

### Updated files

- **`AGENTS.md`** -- New "Pre-merge checklists for AI agents" section (SFDMU, CCI tasks, documentation consistency, merge diffs). Skill Index, Skill Sub-Files, and File-Specific Rules tables updated with new entries.
- **`.cursor/skills/robot-testing/SKILL.md`** -- Quick rule 7 + sub-file link to `setup-ui-shadow-dom.md`.
- **`.cursor/skills/repo-integration/SKILL.md`** -- Sub-file link to `ux-assembly-retrieve.md`.
- **`.cursor/skills/README.md`** -- Skill Router row and rules table row for doc-consistency.
- **`.github/copilot-instructions.md`** -- Quick-start steps 4--5 pointing to sub-files and pre-merge checklists.

## How these were sourced

1. Extracted commit subjects for the past 12 months and categorized by prefix (`fix`, `docs`, `feat`, `refactor`, `chore`).
2. Identified most-changed file paths as a proxy for churn and risk.
3. Counted commits referencing "Copilot review", "stale", "wrong name", "fix description", "fix README" (~76 doc-consistency fixes).
4. Mapped recurring themes to missing or thin agent guidance: shadow DOM/iframe confusion, UX assembly contract violations, SFDMU plan README drift, generated-vs-manual doc conflicts.
5. Designed skills to close specific gaps, following the repo's existing skill conventions (Quick Rules, DO NOT, tables, sub-file pointers).

## Test plan

- [x] Verify `CLAUDE.md` still resolves correctly (it is a symlink to `AGENTS.md`)
- [x] Open a file matching each `.cursor/rules/doc-review.mdc` glob pattern in Cursor and confirm the rule auto-injects
- [x] Run `python scripts/ai/generate_cci_reference.py --dry-run` and confirm no unintended changes
- [x] Run `python scripts/validate_sfdmu_v5_datasets.py` and confirm it passes
- [x] Spot-check skill cross-references: `AGENTS.md` Skill Index links to `doc-consistency/SKILL.md`, Sub-Files table includes `setup-ui-shadow-dom.md` and `ux-assembly-retrieve.md`


Made with [Cursor](https://cursor.com)