### PR TITLE
fix(billing-ui): correct account statement flow invocable token

### DIFF
--- a/scripts/build_billing_ui_module.py
+++ b/scripts/build_billing_ui_module.py
@@ -4,15 +4,21 @@ Build script for unpackaged/post_billing_ui/ module.
 Copies and renames LWC components, Apex classes, static resources, and flexipages
 from extracted/maaron-billinglwc/, applying RLM namespace prefixes throughout.
 """
-import os
 import re
 import shutil
 from pathlib import Path
 
-ROOT = Path("/Users/brian/Documents/GitHub/bgaldino/_bgaldino/rlm-base-dev")
+ROOT = Path(__file__).resolve().parents[1]
 SRC = ROOT / "extracted" / "maaron-billinglwc"
 DEST_MODULE = ROOT / "unpackaged" / "post_billing_ui"
 DEST_FLEXIPAGES = ROOT / "templates" / "flexipages" / "standalone" / "billing_ui"
+
+# Normalize known source token mismatches so regenerated metadata remains deployable.
+# Reference: Salesforce Revenue Cloud "Generate Account Statement" resource
+# https://developer.salesforce.com/docs/atlas.en-us.revenue_lifecycle_management_dev_guide.meta/revenue_lifecycle_management_dev_guide/connect_resources_generate_account_statement.htm
+TOKEN_FIXUPS = {
+    "generateStatementOfAccount": "generateAccountStatement",
+}
 
 # ── Rename maps ──────────────────────────────────────────────────────────────
 
@@ -69,6 +75,8 @@ def apply_all_renames(text: str) -> str:
     for old, new in sorted(LWC_MAP.items(), key=lambda x: -len(x[0])):
         text = text.replace(old, new)
     for old, new in sorted(APEX_MAP.items(), key=lambda x: -len(x[0])):
+        text = text.replace(old, new)
+    for old, new in TOKEN_FIXUPS.items():
         text = text.replace(old, new)
     return text
 

--- a/scripts/build_billing_ui_module.py
+++ b/scripts/build_billing_ui_module.py
@@ -70,7 +70,7 @@ FLEXIPAGE_MAP = {
 # ── Helpers ──────────────────────────────────────────────────────────────────
 
 def apply_all_renames(text: str) -> str:
-    """Apply all LWC and Apex rename substitutions to text content."""
+    """Apply LWC/Apex renames and token normalization to text content."""
     # Sort by length desc so longer keys don't get partially replaced first
     for old, new in sorted(LWC_MAP.items(), key=lambda x: -len(x[0])):
         text = text.replace(old, new)

--- a/unpackaged/post_billing_ui/flows/RLM_Generate_Statement_of_Account.flow-meta.xml
+++ b/unpackaged/post_billing_ui/flows/RLM_Generate_Statement_of_Account.flow-meta.xml
@@ -5,8 +5,8 @@
         <label>RLM Account Statement IA</label>
         <locationX>0</locationX>
         <locationY>0</locationY>
-        <actionName>generateStatementOfAccount</actionName>
-        <actionType>generateStatementOfAccount</actionType>
+        <actionName>generateAccountStatement</actionName>
+        <actionType>generateAccountStatement</actionType>
         <flowTransactionModel>CurrentTransaction</flowTransactionModel>
         <inputParameters>
             <name>accountId</name>
@@ -38,7 +38,7 @@
                 <elementReference>Sorting_Order</elementReference>
             </value>
         </inputParameters>
-        <nameSegment>generateStatementOfAccount</nameSegment>
+        <nameSegment>generateAccountStatement</nameSegment>
         <offset>0</offset>
         <storeOutputAutomatically>true</storeOutputAutomatically>
     </actionCalls>


### PR DESCRIPTION
## Summary
- Fix `RLM_Generate_Statement_of_Account` Flow metadata to use the valid `generateAccountStatement` invocable action token.
- Update `actionName`, `actionType`, and `nameSegment` consistently so Metadata API can parse the flow definition.
- Resolve the `prepare_billing.deploy_post_billing_ui` build failure caused by invalid `InvocableActionType` value.
- Add a guard in `scripts/build_billing_ui_module.py` so module regeneration normalizes the token and does not reintroduce the same deploy failure.

## Notes
- The `Account.RLM_Generate_Account_Statement` Quick Action error (`Required fields are missing: [Component]`) appears to be a downstream/cascade validation failure triggered by the flow parse error during the same deploy.
- Documentation reference for the correct action naming: [Salesforce Revenue Cloud - Generate Account Statement](https://developer.salesforce.com/docs/atlas.en-us.revenue_lifecycle_management_dev_guide.meta/revenue_lifecycle_management_dev_guide/connect_resources_generate_account_statement.htm).

## Test plan
- [x] Reproduced deploy error from CCI output in `deploy_post_billing_ui`.
- [x] Updated flow metadata token values in `unpackaged/post_billing_ui/flows/RLM_Generate_Statement_of_Account.flow-meta.xml`.
- [x] Updated `scripts/build_billing_ui_module.py` to normalize legacy token values during module generation.
- [x] Run `cci task run deploy_post_billing_ui --org <alias>` and confirm deploy succeeds.
- [x] Run `cci flow run prepare_billing --org <alias>` to verify full billing preparation path.

Made with [Cursor](https://cursor.com)