### PR TITLE
chore(ci): upgrade actions/checkout from v4 to v6

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -31,7 +31,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
 

--- a/.github/workflows/prepare-rlm-org.yml
+++ b/.github/workflows/prepare-rlm-org.yml
@@ -21,7 +21,7 @@ jobs:
     timeout-minutes: 120
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python 3.13
         uses: actions/setup-python@v5


### PR DESCRIPTION
## Summary
- Bumps `actions/checkout` from `@v4` to `@v6` in all three workflows (`claude.yml`, `claude-code-review.yml`, `prepare-rlm-org.yml`)
- Node.js 20 is deprecated on GitHub Actions runners starting June 2, 2026; v6 uses Node.js 24

## Test plan
- [ ] Verify CI runs cleanly after merge (no Node.js 20 deprecation warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)