### PR TITLE
chore: strengthen .gitignore for macOS Finder/zip artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,11 @@ node_modules/
 
 # MacOS system files
 .DS_Store
+**/.DS_Store
+__MACOSX/
+**/__MACOSX/
+._*
+**/._*
 
 # Windows system files
 Thumbs.db


### PR DESCRIPTION
## Summary
- Adds `__MACOSX/`, `**/__MACOSX/`, `._*`, `**/._*`, and `**/.DS_Store` patterns to `.gitignore`
- Prevents macOS extended attribute files and zip-generated `__MACOSX/` directories from ever being committed
- Companion to the cleanup on `mfg-260-dev-refactor` (PR #149) where 23 of these files were removed

## Test plan
- [ ] Verify no macOS metadata files appear in future PRs from macOS contributors

🤖 Generated with [Claude Code](https://claude.com/claude-code)