### PR TITLE
revert: undo PR #148 billing-ui invocable token fix

### DIFF
--- a/scripts/build_billing_ui_module.py
+++ b/scripts/build_billing_ui_module.py
@@ -4,21 +4,15 @@ Build script for unpackaged/post_billing_ui/ module.
 Copies and renames LWC components, Apex classes, static resources, and flexipages
 from extracted/maaron-billinglwc/, applying RLM namespace prefixes throughout.
 """
+import os
 import re
 import shutil
 from pathlib import Path
 
-ROOT = Path(__file__).resolve().parents[1]
+ROOT = Path("/Users/brian/Documents/GitHub/bgaldino/_bgaldino/rlm-base-dev")
 SRC = ROOT / "extracted" / "maaron-billinglwc"
 DEST_MODULE = ROOT / "unpackaged" / "post_billing_ui"
 DEST_FLEXIPAGES = ROOT / "templates" / "flexipages" / "standalone" / "billing_ui"
-
-# Normalize known source token mismatches so regenerated metadata remains deployable.
-# Reference: Salesforce Revenue Cloud "Generate Account Statement" resource
-# https://developer.salesforce.com/docs/atlas.en-us.revenue_lifecycle_management_dev_guide.meta/revenue_lifecycle_management_dev_guide/connect_resources_generate_account_statement.htm
-TOKEN_FIXUPS = {
-    "generateStatementOfAccount": "generateAccountStatement",
-}
 
 # ── Rename maps ──────────────────────────────────────────────────────────────
 
@@ -70,13 +64,11 @@ FLEXIPAGE_MAP = {
 # ── Helpers ──────────────────────────────────────────────────────────────────
 
 def apply_all_renames(text: str) -> str:
-    """Apply LWC/Apex renames and token normalization to text content."""
+    """Apply all LWC and Apex rename substitutions to text content."""
     # Sort by length desc so longer keys don't get partially replaced first
     for old, new in sorted(LWC_MAP.items(), key=lambda x: -len(x[0])):
         text = text.replace(old, new)
     for old, new in sorted(APEX_MAP.items(), key=lambda x: -len(x[0])):
-        text = text.replace(old, new)
-    for old, new in TOKEN_FIXUPS.items():
         text = text.replace(old, new)
     return text
 

--- a/unpackaged/post_billing_ui/flows/RLM_Generate_Statement_of_Account.flow-meta.xml
+++ b/unpackaged/post_billing_ui/flows/RLM_Generate_Statement_of_Account.flow-meta.xml
@@ -5,8 +5,8 @@
         <label>RLM Account Statement IA</label>
         <locationX>0</locationX>
         <locationY>0</locationY>
-        <actionName>generateAccountStatement</actionName>
-        <actionType>generateAccountStatement</actionType>
+        <actionName>generateStatementOfAccount</actionName>
+        <actionType>generateStatementOfAccount</actionType>
         <flowTransactionModel>CurrentTransaction</flowTransactionModel>
         <inputParameters>
             <name>accountId</name>
@@ -38,7 +38,7 @@
                 <elementReference>Sorting_Order</elementReference>
             </value>
         </inputParameters>
-        <nameSegment>generateAccountStatement</nameSegment>
+        <nameSegment>generateStatementOfAccount</nameSegment>
         <offset>0</offset>
         <storeOutputAutomatically>true</storeOutputAutomatically>
     </actionCalls>


### PR DESCRIPTION
Reverts #148.

## Reason

The `generateAccountStatement` token introduced in #148 targets the **262 (Summer '26) API rename**. The current release target is **260 (Spring '26)**, where the valid invocable action token is `generateStatementOfAccount`. Keeping the 262 token causes `prepare_billing.deploy_post_billing_ui` to fail on 260 orgs.

## What is reverted

- `unpackaged/post_billing_ui/flows/RLM_Generate_Statement_of_Account.flow-meta.xml` — restores `actionName`, `actionType`, and `nameSegment` back to `generateStatementOfAccount`
- `scripts/build_billing_ui_module.py` — removes the `TOKEN_FIXUPS` normalization guard and the `Path(__file__).resolve()` ROOT fix that were bundled in #148

## Note on ROOT path fix

The `ROOT` path correction (removing the hardcoded `/Users/brian/...` path) was a side-effect change bundled into #148. That fix is also reverted here. If that path fix is needed independently, it should be re-applied in a separate PR against the 260 baseline.

## Test plan
- [ ] Run `cci task run deploy_post_billing_ui --org <alias>` on a 260 org and confirm deploy succeeds
- [ ] Run `cci flow run prepare_billing --org <alias>` to verify the full billing preparation path

Made with [Cursor](https://cursor.com)