### PR TITLE
chore: add layered dev environment setup (direnv + update script + guide)

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -15,8 +15,12 @@ fi
 # ── Node via nvm ─────────────────────────────────────────────────────────────
 # `lts/*` tracks whichever line is currently the active LTS (today: Node 24).
 # When the next LTS lands, `nvm install --lts` + this line keeps you current.
+# nvm path is resolved via `brew --prefix nvm` to work on both Apple Silicon
+# (`/opt/homebrew`) and Intel macOS (`/usr/local`) — matches the README pattern.
 export NVM_DIR="$HOME/.nvm"
-if [ -s "/opt/homebrew/opt/nvm/nvm.sh" ]; then
-  . "/opt/homebrew/opt/nvm/nvm.sh" --no-use
+_NVM_PREFIX="$(brew --prefix nvm 2>/dev/null || true)"
+if [ -n "$_NVM_PREFIX" ] && [ -s "$_NVM_PREFIX/nvm.sh" ]; then
+  . "$_NVM_PREFIX/nvm.sh" --no-use
   nvm use --silent lts/\* >/dev/null 2>&1 || nvm use --silent default >/dev/null 2>&1
 fi
+unset _NVM_PREFIX

--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,22 @@
+# Project env for rlm-base-dev. Activated by direnv on entry; deactivated on exit.
+# Requires: brew install direnv ; eval "$(direnv hook zsh)" in ~/.zshrc.
+
+# ── Python via pyenv ─────────────────────────────────────────────────────────
+# Pin to the 3.13 major.minor line; auto-resolve to the latest installed patch.
+# After `pyenv install 3.13.x`, a fresh `cd` into this project picks it up.
+# Remember to `pipx reinstall cumulusci` after every 3.13.x patch bump.
+if command -v pyenv >/dev/null 2>&1; then
+  _PY_RESOLVED="$(pyenv latest 3.13 2>/dev/null)"
+  export PYENV_VERSION="${_PY_RESOLVED:-3.13.12}"
+  unset _PY_RESOLVED
+  PATH_add "$(pyenv root)/shims"
+fi
+
+# ── Node via nvm ─────────────────────────────────────────────────────────────
+# `lts/*` tracks whichever line is currently the active LTS (today: Node 24).
+# When the next LTS lands, `nvm install --lts` + this line keeps you current.
+export NVM_DIR="$HOME/.nvm"
+if [ -s "/opt/homebrew/opt/nvm/nvm.sh" ]; then
+  . "/opt/homebrew/opt/nvm/nvm.sh" --no-use
+  nvm use --silent lts/\* >/dev/null 2>&1 || nvm use --silent default >/dev/null 2>&1
+fi

--- a/.envrc
+++ b/.envrc
@@ -3,10 +3,10 @@
 
 # ── Python via pyenv ─────────────────────────────────────────────────────────
 # Pin to the 3.13 major.minor line; auto-resolve to the latest installed patch.
-# After `pyenv install 3.13.x`, a fresh `cd` into this project picks it up.
-# Run `scripts/bash/update-toolchain.sh` after every 3.13.x patch bump — it
-# reinstalls the CCI pipx venv under the new Python (the venv's python symlink
-# breaks otherwise).
+# To install a new 3.13.x patch, run `scripts/bash/update-toolchain.sh` — it
+# resolves the latest patch in the line, installs it, and reinstalls the CCI
+# pipx venv under the new Python (the venv's python symlink breaks otherwise).
+# Manual equivalent: `pyenv install $(pyenv latest -k 3.13)`.
 if command -v pyenv >/dev/null 2>&1; then
   _PY_RESOLVED="$(pyenv latest 3.13 2>/dev/null)"
   export PYENV_VERSION="${_PY_RESOLVED:-3.13.12}"

--- a/.envrc
+++ b/.envrc
@@ -9,9 +9,13 @@
 # Manual equivalent: `pyenv install $(pyenv latest -k 3.13)`.
 if command -v pyenv >/dev/null 2>&1; then
   _PY_RESOLVED="$(pyenv latest 3.13 2>/dev/null)"
-  export PYENV_VERSION="${_PY_RESOLVED:-3.13.12}"
+  if [ -n "$_PY_RESOLVED" ]; then
+    export PYENV_VERSION="$_PY_RESOLVED"
+    PATH_add "$(pyenv root)/shims"
+  else
+    echo ".envrc: no Python 3.13.x installed via pyenv. Run scripts/bash/update-toolchain.sh or 'pyenv install \$(pyenv latest -k 3.13)' to install the latest patch." >&2
+  fi
   unset _PY_RESOLVED
-  PATH_add "$(pyenv root)/shims"
 fi
 
 # ── Node via nvm ─────────────────────────────────────────────────────────────

--- a/.envrc
+++ b/.envrc
@@ -4,7 +4,9 @@
 # ── Python via pyenv ─────────────────────────────────────────────────────────
 # Pin to the 3.13 major.minor line; auto-resolve to the latest installed patch.
 # After `pyenv install 3.13.x`, a fresh `cd` into this project picks it up.
-# Remember to `pipx reinstall cumulusci` after every 3.13.x patch bump.
+# Run `scripts/bash/update-toolchain.sh` after every 3.13.x patch bump — it
+# reinstalls the CCI pipx venv under the new Python (the venv's python symlink
+# breaks otherwise).
 if command -v pyenv >/dev/null 2>&1; then
   _PY_RESOLVED="$(pyenv latest 3.13 2>/dev/null)"
   export PYENV_VERSION="${_PY_RESOLVED:-3.13.12}"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -200,6 +200,7 @@ that topic.
 
 | I need to... | Skill File (relative to repo root) |
 |-------------|-------------------------------------|
+| Set up / replicate / update the local dev toolchain | `docs/guides/dev-environment-setup.md` |
 | Add new features, code placement | `.cursor/skills/repo-integration/SKILL.md` |
 | Work with CCI tasks, flows, CLI | `.cursor/skills/cci-orchestration/SKILL.md` |
 | Write a Python CCI task class | `.cursor/skills/cci-orchestration/custom-task-authoring.md` |

--- a/README.md
+++ b/README.md
@@ -31,6 +31,13 @@ The main branch targets Salesforce Release 260 (Spring '26, GA). Other branches 
 
 > **Cursor users:** Open this README in [Cursor](https://www.cursor.com/), press `Cmd+L` to open the AI chat, and paste: *"Walk me through the macOS Environment Setup section of this README, running each command in the terminal."* The agent can execute each step interactively. Run the steps in order — each one builds on the previous.
 
+> **For the layered/canonical view** (shell config architecture, per-project
+> `.envrc` activation via direnv, major-line pin strategy, and the
+> `scripts/bash/update-toolchain.sh` maintenance routine), see
+> [`docs/guides/dev-environment-setup.md`](docs/guides/dev-environment-setup.md).
+> Steps 1–11 below are the first-time bootstrap; the guide describes the
+> target architecture and ongoing maintenance you'll move to after that.
+
 This section walks through a full, clean environment setup on macOS using [Homebrew](https://brew.sh/) for package management, [pyenv](https://github.com/pyenv/pyenv) for Python version management, and [nvm](https://github.com/nvm-sh/nvm) for Node.js version management. Using version managers (pyenv + nvm) keeps your tool installations isolated from the macOS system Python and Node, avoiding conflicts when multiple projects need different versions. Skip any step for tools you already have installed.
 
 ### Step 1 — Install Homebrew
@@ -294,6 +301,19 @@ node --version && sf --version && cci version && python --version
 If any command returns "not found", check that `~/.zshenv` contains the nvm and pyenv init blocks (see Steps 3 and 4), then **restart Claude Code** so it picks up the updated PATH.
 
 **After any PATH change** (new nvm version, new pyenv version, new pipx install), restart Claude Code — it inherits the PATH from the shell that launched it and does not reload `~/.zshenv` mid-session.
+
+### Ongoing toolchain maintenance
+
+Once the bootstrap above is complete, ongoing updates (new Python patches,
+Node LTS refreshes, sf/CCI/SFDMU upgrades) are handled by a single script:
+
+```bash
+scripts/bash/update-toolchain.sh
+```
+
+It walks `brew upgrade` → latest patch in your pinned Python line → latest LTS Node → `sf update` → CCI reinstall/upgrade → `sf plugins update` → `cci task run validate_setup`. Major-line pins (e.g. Python 3.13, Node `lts/*`) are configured at the top of the script.
+
+For the full architecture — shell config responsibilities, the per-project `.envrc` pattern via [direnv](https://direnv.net/), troubleshooting, and instructions for replicating on a new workstation — see [`docs/guides/dev-environment-setup.md`](docs/guides/dev-environment-setup.md).
 
 **Validating the full setup from Claude Code:** Ask Claude to run `cci task run validate_setup`. This checks all required tools and — when the relevant auto-fix options are enabled — can auto-fix missing robot deps (default on) and update the SFDMU version (default on). urllib3 is upgraded as a side-effect of the robot dep fix, or independently with `auto_fix_urllib3=true`. No org connection needed. It is the fastest way to confirm your environment is ready before running flows.
 
@@ -1028,6 +1048,7 @@ For details on exporting new models, importing into target orgs, polymorphic ID 
 
 | Document | Description |
 |----------|-------------|
+| [Dev Environment Setup](docs/guides/dev-environment-setup.md) | Canonical local toolchain architecture — shell config layout, direnv `.envrc` per-project pinning, major-line update strategy, replication on new workstations |
 | [Constraints Utility Guide](datasets/constraints/README.md) | CML constraint model export, import, validate -- architecture, workflows, polymorphic resolution |
 | [Constraints Setup](docs/guides/constraints-setup.md) | `prepare_constraints` flow order, feature flags, deployment phases |
 | [Decision Table Examples](docs/references/decision-table-examples.md) | Comprehensive examples for Decision Table management tasks |

--- a/README.md
+++ b/README.md
@@ -311,7 +311,7 @@ Node LTS refreshes, sf/CCI/SFDMU upgrades) are handled by a single script:
 scripts/bash/update-toolchain.sh
 ```
 
-It walks `brew upgrade` → latest patch in your pinned Python line → latest LTS Node → `sf update` → CCI reinstall/upgrade → `sf plugins update` → `cci task run validate_setup`. Major-line pins (e.g. Python 3.13, Node `lts/*`) are configured at the top of the script.
+It walks `brew update && brew upgrade` → latest patch in your pinned Python line → latest LTS Node → `sf update` → CCI reinstall/upgrade → `sf plugins update` → `cci task run validate_setup`. Major-line pins (e.g. Python 3.13, Node `lts/*`) are configured at the top of the script.
 
 For the full architecture — shell config responsibilities, the per-project `.envrc` pattern via [direnv](https://direnv.net/), troubleshooting, and instructions for replicating on a new workstation — see [`docs/guides/dev-environment-setup.md`](docs/guides/dev-environment-setup.md).
 

--- a/docs/guides/dev-environment-setup.md
+++ b/docs/guides/dev-environment-setup.md
@@ -34,7 +34,7 @@ ends up with the same layered structure — not the same exact patch versions.
 | **pipx** | `$(pyenv prefix)/bin/python3 -m pip install --user pipx` | Isolated CLI installs (CCI) | latest |
 | **CumulusCI** | `pipx install cumulusci --python "$(pyenv prefix)/bin/python3"` | Orchestration engine | latest; ensure `setuptools>=75.4,<77` (snowfakery 4.x requirement) |
 | **Salesforce CLI (`sf`)** | `npm install -g @salesforce/cli` | Salesforce metadata + data | latest (built-in auto-updater) |
-| **SFDMU plugin** | `sf plugins install sfdmu@5` | Bulk data import/export | v5.x (pin major) |
+| **SFDMU plugin** | `sf plugins install sfdmu` | Bulk data import/export | v5+ required (enforced by `cci task run validate_setup`) |
 | **gh, git, GCM** | `brew install gh git git-credential-manager` | Source control + PR workflow | latest |
 
 **Pin philosophy:**
@@ -290,7 +290,7 @@ Installing 3.13.13 doesn't replace 3.13.12, but if you uninstall the old
 patch the venv dies. The update script handles this; manually:
 
 ```bash
-pipx install --force cumulusci --python "$(pyenv prefix 3.13)/bin/python"
+pipx install --force cumulusci --python "$(pyenv prefix 3.13)/bin/python3"
 pipx inject --force cumulusci "setuptools>=75.4,<77"
 ```
 

--- a/docs/guides/dev-environment-setup.md
+++ b/docs/guides/dev-environment-setup.md
@@ -32,7 +32,7 @@ ends up with the same layered structure — not the same exact patch versions.
 | **pyenv** | `brew install pyenv` | Python version manager | latest |
 | **Python** | `pyenv install 3.13.x` | Runtime for CumulusCI + scripts | major.minor line (`3.13`) |
 | **pipx** | `python -m pip install --user pipx` | Isolated CLI installs (CCI) | latest |
-| **CumulusCI** | `pipx install cumulusci` | Orchestration engine | latest; ensure `setuptools>=75.4` (snowfakery 4.x requirement) |
+| **CumulusCI** | `pipx install cumulusci` | Orchestration engine | latest; ensure `setuptools>=75.4,<77` (snowfakery 4.x requirement) |
 | **Salesforce CLI (`sf`)** | `npm install -g @salesforce/cli` | Salesforce metadata + data | latest (built-in auto-updater) |
 | **SFDMU plugin** | `sf plugins install @forcedotcom/sfdmu` | Bulk data import/export | v5.x |
 | **gh, git, GCM** | `brew install gh git git-credential-manager` | Source control + PR workflow | latest |
@@ -210,7 +210,7 @@ The script handles:
 5. `pipx install --force cumulusci` (if Python patch bumped) **or**
    `pipx upgrade cumulusci` — required because patch upgrades break the
    venv's python symlink
-6. `pipx inject --force cumulusci "setuptools>=75.4"` — snowfakery 4.x
+6. `pipx inject --force cumulusci "setuptools>=75.4,<77"` — snowfakery 4.x
    requires modern setuptools (the historical `<71` pin documented in
    earlier guides is **incompatible** with current CCI; see README's
    *Note on setuptools*)
@@ -279,7 +279,7 @@ patch the venv dies. The update script handles this; manually:
 
 ```bash
 pipx install --force cumulusci --python "$(pyenv prefix 3.13)/bin/python"
-pipx inject --force cumulusci "setuptools>=75.4"
+pipx inject --force cumulusci "setuptools>=75.4,<77"
 ```
 
 ### `python3` resolves to `/usr/bin/python3` instead of pyenv shim

--- a/docs/guides/dev-environment-setup.md
+++ b/docs/guides/dev-environment-setup.md
@@ -291,12 +291,16 @@ launch Claude Code from a terminal, **or** restart Claude Code after
 fixing `~/.zshenv`.
 
 ### `pipx` venv broken after Python patch bump
-The CCI venv's python is a symlink to `~/.pyenv/versions/3.13.12/bin/python`.
-Installing 3.13.13 doesn't replace 3.13.12, but if you uninstall the old
-patch the venv dies. The update script handles this; manually:
+The CCI venv's python is a symlink to a specific pyenv patch dir
+(`~/.pyenv/versions/<old-patch>/bin/python3`). Installing a newer patch
+doesn't replace the old one, but if you uninstall the old patch the venv
+dies. The update script handles this; manually:
 
 ```bash
-pipx install --force cumulusci --python "$(pyenv prefix 3.13)/bin/python3"
+# Refresh pipx under the new patch (in case pipx's own shebang was tied
+# to the old patch), then reinstall CCI under it.
+"$(pyenv prefix "$(pyenv latest 3.13)")/bin/python3" -m pip install --user --upgrade pipx
+pipx install --force cumulusci --python "$(pyenv prefix "$(pyenv latest 3.13)")/bin/python3"
 pipx inject --force cumulusci "setuptools>=75.4"
 ```
 

--- a/docs/guides/dev-environment-setup.md
+++ b/docs/guides/dev-environment-setup.md
@@ -166,7 +166,7 @@ if command -v pyenv >/dev/null 2>&1; then
     export PYENV_VERSION="$_PY_RESOLVED"
     PATH_add "$(pyenv root)/shims"
   else
-    echo ".envrc: no Python 3.13.x installed via pyenv. Run 'pyenv install \$(pyenv latest -k 3.13)' first." >&2
+    echo ".envrc: no Python 3.13.x installed via pyenv. Run scripts/bash/update-toolchain.sh or 'pyenv install \$(pyenv latest -k 3.13)' to install the latest patch." >&2
   fi
   unset _PY_RESOLVED
 fi

--- a/docs/guides/dev-environment-setup.md
+++ b/docs/guides/dev-environment-setup.md
@@ -32,7 +32,7 @@ ends up with the same layered structure — not the same exact patch versions.
 | **pyenv** | `brew install pyenv` | Python version manager | latest |
 | **Python** | `pyenv install $(pyenv latest -k 3.13)` | Runtime for CumulusCI + scripts | major.minor line (`3.13`) |
 | **pipx** | `$(pyenv prefix)/bin/python3 -m pip install --user pipx` | Isolated CLI installs (CCI) | latest |
-| **CumulusCI** | `pipx install cumulusci --python "$(pyenv prefix)/bin/python3"` | Orchestration engine | latest; ensure `setuptools>=75.4,<77` (snowfakery 4.x requirement) |
+| **CumulusCI** | `pipx install cumulusci --python "$(pyenv prefix)/bin/python3"` | Orchestration engine | latest; ensure `setuptools>=75.4` (snowfakery 4.x requirement) |
 | **Salesforce CLI (`sf`)** | `npm install -g @salesforce/cli` | Salesforce metadata + data | latest (built-in auto-updater) |
 | **SFDMU plugin** | `sf plugins install sfdmu` | Bulk data import/export | v5+ required (enforced by `cci task run validate_setup`) |
 | **gh, git, GCM** | `brew install gh git git-credential-manager` | Source control + PR workflow | latest |
@@ -162,9 +162,13 @@ pins. For **rlm-base-dev** it lives at the repo root:
 # Python via pyenv — major.minor line, auto-resolve latest patch
 if command -v pyenv >/dev/null 2>&1; then
   _PY_RESOLVED="$(pyenv latest 3.13 2>/dev/null)"
-  export PYENV_VERSION="${_PY_RESOLVED:-3.13.12}"
+  if [ -n "$_PY_RESOLVED" ]; then
+    export PYENV_VERSION="$_PY_RESOLVED"
+    PATH_add "$(pyenv root)/shims"
+  else
+    echo ".envrc: no Python 3.13.x installed via pyenv. Run 'pyenv install \$(pyenv latest -k 3.13)' first." >&2
+  fi
   unset _PY_RESOLVED
-  PATH_add "$(pyenv root)/shims"
 fi
 
 # Node via nvm — track active LTS line. brew --prefix nvm resolves to
@@ -222,10 +226,12 @@ The script handles:
 5. `pipx install --force cumulusci` (if Python patch bumped) **or**
    `pipx upgrade cumulusci` — required because patch upgrades break the
    venv's python symlink
-6. `pipx inject --force cumulusci "setuptools>=75.4,<77"` — snowfakery 4.x
-   requires modern setuptools (the historical `<71` pin documented in
-   earlier guides is **incompatible** with current CCI; see README's
-   *Note on setuptools*)
+6. `pipx inject --force cumulusci "setuptools>=75.4"` — snowfakery 4.x
+   requires modern setuptools. The historical `<71` pin (older docs)
+   is **incompatible**; see README's *Note on setuptools*. Note CI
+   adds `<77` as well (`.github/workflows/prepare-rlm-org.yml`) because
+   it's pinned to CCI 4.8.1; modern CCI 4.10+ works with setuptools
+   77+ so this guide doesn't enforce the upper bound.
 7. `sf plugins update`
 8. `cci task run validate_setup` — verifies all 12 checks still pass
 
@@ -291,7 +297,7 @@ patch the venv dies. The update script handles this; manually:
 
 ```bash
 pipx install --force cumulusci --python "$(pyenv prefix 3.13)/bin/python3"
-pipx inject --force cumulusci "setuptools>=75.4,<77"
+pipx inject --force cumulusci "setuptools>=75.4"
 ```
 
 ### `python3` resolves to `/usr/bin/python3` instead of pyenv shim

--- a/docs/guides/dev-environment-setup.md
+++ b/docs/guides/dev-environment-setup.md
@@ -1,0 +1,295 @@
+# Developer Environment Setup
+
+Canonical reference for setting up a local dev environment to work on
+**rlm-base-dev** (and similar Salesforce / CumulusCI projects) on macOS.
+
+This document captures **two layers**:
+
+1. **System layer** — versioned toolchain shared across all projects on the
+   workstation (Homebrew, nvm, pyenv, pipx, direnv).
+2. **Project layer** — per-project pins via `.envrc`, activated automatically
+   when you `cd` into the project directory.
+
+The goal is one inventory you can share with teammates so every workstation
+ends up with the same layered structure — not the same exact patch versions.
+
+> **Audience:** new contributors bootstrapping a workstation, or existing
+> contributors replicating the setup on a second machine. For the very first
+> install steps (Homebrew, git, nvm, pyenv), follow the README's
+> *macOS Environment Setup* (Steps 1–11). This doc describes the **target
+> architecture** and **ongoing maintenance** once those are in place.
+
+---
+
+## 1. Toolchain inventory
+
+| Tool | Installer | Purpose | Pin strategy |
+|------|-----------|---------|--------------|
+| **Homebrew** | macOS pkg installer (one-time) | Package manager for everything below | latest |
+| **direnv** | `brew install direnv` | Per-project env activation on `cd` | latest |
+| **nvm** | `brew install nvm` | Node version manager | latest |
+| **Node.js** | `nvm install --lts` | JavaScript runtime for `sf` CLI | major LTS line (`lts/*`) |
+| **pyenv** | `brew install pyenv` | Python version manager | latest |
+| **Python** | `pyenv install 3.13.x` | Runtime for CumulusCI + scripts | major.minor line (`3.13`) |
+| **pipx** | `python -m pip install --user pipx` | Isolated CLI installs (CCI) | latest |
+| **CumulusCI** | `pipx install cumulusci` | Orchestration engine | latest, `setuptools<71` |
+| **Salesforce CLI (`sf`)** | `npm install -g @salesforce/cli` | Salesforce metadata + data | latest (built-in auto-updater) |
+| **SFDMU plugin** | `sf plugins install @forcedotcom/sfdmu` | Bulk data import/export | v5.x |
+| **gh, git, GCM** | `brew install gh git git-credential-manager` | Source control + PR workflow | latest |
+
+**Pin philosophy:**
+- **Major line, not minor.** Patch versions move forward automatically. Bumping
+  a major line (Python 3.13 → 3.14, Node 24 → 26) is a deliberate, tested
+  change tracked in `scripts/bash/update-toolchain.sh`.
+- **pyenv and nvm are version managers, not version pickers.** Let them
+  resolve the latest installed patch via `pyenv latest 3.13` and `nvm use lts/*`.
+
+---
+
+## 2. System layout
+
+```
+~/.zshenv                            All zsh shells (login, interactive, scripts, Claude Code Bash)
+~/.zprofile                          Login shells only
+~/.zshrc                             Interactive shells only
+
+/opt/homebrew/                       Homebrew prefix (Apple Silicon)
+~/.nvm/                              nvm dir; node versions under versions/node/
+~/.pyenv/                            pyenv dir; python versions under versions/
+~/.local/bin/                        pipx-installed CLIs (cci, etc.)
+
+<project>/.envrc                     direnv config — per-project pyenv + nvm pins
+```
+
+### Shell config responsibilities
+
+Each file does one job. No duplication.
+
+#### `~/.zshenv` — runs in **every** shell
+Must be **fast** (~70ms target). No interactive features.
+
+```sh
+# Core PATH
+export PATH="/opt/homebrew/bin:/opt/homebrew/sbin:$PATH"
+export PATH="$HOME/.local/bin:$PATH"
+
+# NVM — function definitions + default node bin on PATH (no slow `nvm use`)
+export NVM_DIR="$HOME/.nvm"
+if [ -s "/opt/homebrew/opt/nvm/nvm.sh" ]; then
+  . "/opt/homebrew/opt/nvm/nvm.sh" --no-use
+  if [ -s "$NVM_DIR/alias/default" ]; then
+    _NVM_DEF="$(cat "$NVM_DIR/alias/default")"
+    while [ -s "$NVM_DIR/alias/$_NVM_DEF" ]; do
+      _NVM_DEF="$(cat "$NVM_DIR/alias/$_NVM_DEF")"
+    done
+    _NVM_VER="v${_NVM_DEF#v}"
+    [ -d "$NVM_DIR/versions/node/$_NVM_VER/bin" ] && \
+      export PATH="$NVM_DIR/versions/node/$_NVM_VER/bin:$PATH"
+    unset _NVM_DEF _NVM_VER
+  fi
+fi
+
+# pyenv binary on PATH — but NO global init. Per-project init via direnv.
+export PYENV_ROOT="$HOME/.pyenv"
+[ -d "$PYENV_ROOT/bin" ] && export PATH="$PYENV_ROOT/bin:$PATH"
+
+# direnv export — activates project .envrc in non-interactive shells too
+command -v direnv >/dev/null 2>&1 && eval "$(direnv export zsh 2>/dev/null)"
+```
+
+#### `~/.zprofile` — runs in **login** shells only
+
+```sh
+eval "$(/opt/homebrew/bin/brew shellenv)"
+export PATH="$PATH:$HOME/Library/Application Support/JetBrains/Toolbox/scripts"
+```
+
+#### `~/.zshrc` — runs in **interactive** shells only
+
+```sh
+# direnv hook: auto-reload .envrc on cd between dirs
+command -v direnv >/dev/null 2>&1 && eval "$(direnv hook zsh)"
+
+# nvm completions (interactive nicety)
+[ -s "/opt/homebrew/opt/nvm/etc/bash_completion.d/nvm" ] && \
+  . "/opt/homebrew/opt/nvm/etc/bash_completion.d/nvm"
+
+# Project / org env vars (Anthropic, Vertex, etc.) go here
+```
+
+### Why this layout
+
+- **`~/.zshenv` runs for everything** — including Claude Code's Bash tool,
+  IDE-spawned shells, and cron. Putting toolchain PATH here means `sf`,
+  `node`, `cci`, etc. are available even in non-interactive contexts.
+- **No global `pyenv init`** — that's the historical source of stale
+  `.pyenv-shim` lock files when multiple shells start concurrently. direnv
+  handles pyenv per-project, only where needed.
+- **direnv is sourced from both `.zshenv` and `.zshrc`.**
+  - `.zshenv` runs `direnv export zsh` — activates `.envrc` on shell startup
+    (the only path non-interactive shells get).
+  - `.zshrc` adds `direnv hook zsh` — adds a `precmd` for interactive
+    auto-reload when you `cd` between projects.
+
+---
+
+## 3. Per-project activation (direnv `.envrc`)
+
+Each project owns its `.envrc`. Commit it to git so teammates get the same
+pins. For **rlm-base-dev** it lives at the repo root:
+
+```sh
+# .envrc
+
+# Python via pyenv — major.minor line, auto-resolve latest patch
+if command -v pyenv >/dev/null 2>&1; then
+  _PY_RESOLVED="$(pyenv latest 3.13 2>/dev/null)"
+  export PYENV_VERSION="${_PY_RESOLVED:-3.13.12}"
+  unset _PY_RESOLVED
+  PATH_add "$(pyenv root)/shims"
+fi
+
+# Node via nvm — track active LTS line
+export NVM_DIR="$HOME/.nvm"
+if [ -s "/opt/homebrew/opt/nvm/nvm.sh" ]; then
+  . "/opt/homebrew/opt/nvm/nvm.sh" --no-use
+  nvm use --silent lts/\* >/dev/null 2>&1 || nvm use --silent default >/dev/null 2>&1
+fi
+```
+
+### First-time activation
+
+```bash
+cd path/to/rlm-base-dev
+direnv allow              # one-time per workstation per .envrc revision
+```
+
+### Verify
+
+```bash
+python --version          # → Python 3.13.x  (whatever latest installed patch is)
+pyenv version             # → 3.13.x (set by PYENV_VERSION environment variable)
+node --version            # → v24.x (latest LTS)
+cci --version             # → CumulusCI 4.x
+sf --version              # → @salesforce/cli/2.x
+```
+
+### Adapting to another project
+
+Copy `.envrc`, edit the python/node lines (e.g. `pyenv latest 3.12` if the
+project still needs 3.12), `direnv allow`. The system layer doesn't change.
+
+---
+
+## 4. Maintaining the toolchain
+
+### Update routine
+
+```bash
+cd rlm-base-dev
+scripts/bash/update-toolchain.sh
+```
+
+The script handles:
+
+1. `brew update && brew upgrade`
+2. `pyenv install --skip-existing $(pyenv latest -k 3.13)` — installs newest
+   patch in the pinned major.minor line, **only if** there's a newer one
+3. `nvm install --lts --reinstall-packages-from=current --latest-npm` —
+   keeps `sf` and other npm globals carried forward
+4. `sf update` — uses the CLI's built-in updater
+5. `pipx install --force cumulusci` (if Python patch bumped) **or**
+   `pipx upgrade cumulusci` — required because patch upgrades break the
+   venv's python symlink
+6. `pipx inject --force cumulusci "setuptools<71"` — CCI 4.x dependency pin
+7. `sf plugins update`
+8. `cci task run validate_setup` — verifies all 12 checks still pass
+
+### Bumping a major line
+
+When Python 3.14 stabilizes for CCI, or Node 26 becomes LTS:
+
+1. Edit `PY_LINE` / `NODE_LINE` at the top of `scripts/bash/update-toolchain.sh`
+2. Edit the `pyenv latest <line>` call in `.envrc`
+3. Run the script. It installs the new line, reinstalls CCI under the new
+   Python, and verifies via `validate_setup`.
+4. Commit `.envrc` + the script changes.
+5. Optionally `pyenv uninstall <old.line>.x` and `nvm uninstall <old-node>`.
+
+---
+
+## 5. Replicating on a new workstation
+
+For a clean macOS workstation, in order:
+
+1. **System bootstrap** — follow `README.md` § *macOS Environment Setup*
+   Steps 1–11. That installs Homebrew, git, gh, GCM, nvm + Node LTS,
+   pyenv + Python 3.13.x, pipx, CumulusCI, sf CLI, and SFDMU.
+2. **Add direnv** — `brew install direnv`.
+3. **Restructure shell configs** — replace `~/.zshenv`, `~/.zprofile`,
+   `~/.zshrc` with the templates in §2 above. Save backups first
+   (`cp ~/.zshenv ~/.zshenv.bak.$(date +%Y%m%d)` etc.).
+4. **Clone and activate** —
+   ```bash
+   gh repo clone bgaldino/rlm-base-dev
+   cd rlm-base-dev
+   direnv allow
+   cci task run validate_setup
+   ```
+5. **Restart your terminal app** (and Claude Code, IDEs) so they regenerate
+   any cached shell snapshot from the new configs.
+
+---
+
+## 6. Troubleshooting
+
+### `pyenv: cannot rehash: couldn't acquire lock`
+Stale shim lock from a previous interrupted rehash. Usually caused by
+duplicated `eval "$(pyenv init -)"` in shell configs.
+
+```bash
+pkill -9 -f pyenv-rehash
+rm -f ~/.pyenv/shims/.pyenv-shim
+```
+
+Prevented by the layout above (no global `pyenv init`).
+
+### `cci` not found in Claude Code Bash tool
+Claude Code captures a shell snapshot at startup. If it was launched from
+Spotlight/Dock (minimal PATH), the snapshot misses your shell config. Fix:
+launch Claude Code from a terminal, **or** restart Claude Code after
+fixing `~/.zshenv`.
+
+### `pipx` venv broken after Python patch bump
+The CCI venv's python is a symlink to `~/.pyenv/versions/3.13.12/bin/python`.
+Installing 3.13.13 doesn't replace 3.13.12, but if you uninstall the old
+patch the venv dies. The update script handles this; manually:
+
+```bash
+pipx install --force cumulusci --python "$(pyenv prefix 3.13)/bin/python"
+pipx inject --force cumulusci "setuptools<71"
+```
+
+### `python3` resolves to `/usr/bin/python3` instead of pyenv shim
+Cosmetic — `python` (no `3`) resolves correctly because the system doesn't
+ship one. CCI invokes `python`, so this won't break anything. If you need
+the pyenv `python3` specifically, use `pyenv exec python3`.
+
+### `direnv` doesn't activate when cd'ing in
+- Did you `direnv allow` in the project? (Run from inside the dir.)
+- Is the `direnv hook zsh` line in `~/.zshrc`?
+- Is your shell interactive? Non-interactive shells activate via the
+  `direnv export zsh` line in `~/.zshenv` at startup, not on cd.
+
+---
+
+## 7. Reference
+
+- Backup files (created during the 2026-05-12 refactor):
+  `~/.zshenv.bak.20260512`, `~/.zshrc.bak.20260512`, `~/.zprofile.bak.20260512`
+- Update script: `scripts/bash/update-toolchain.sh`
+- Project .envrc: `.envrc` at repo root
+- Validation: `cci task run validate_setup` (no org required)
+- direnv docs: https://direnv.net/
+- pyenv docs: https://github.com/pyenv/pyenv
+- nvm docs: https://github.com/nvm-sh/nvm

--- a/docs/guides/dev-environment-setup.md
+++ b/docs/guides/dev-environment-setup.md
@@ -42,7 +42,7 @@ ends up with the same layered structure — not the same exact patch versions.
   a major line (Python 3.13 → 3.14, Node 24 → 26) is a deliberate, tested
   change tracked in `scripts/bash/update-toolchain.sh`.
 - **pyenv and nvm are version managers, not version pickers.** Let them
-  resolve the latest installed patch via `pyenv latest 3.13` and `nvm use lts/*`.
+  resolve the latest installed patch via `pyenv latest 3.13` and `nvm use 'lts/*'` (quote the glob so zsh doesn't expand it).
 
 ---
 

--- a/docs/guides/dev-environment-setup.md
+++ b/docs/guides/dev-environment-setup.md
@@ -32,7 +32,7 @@ ends up with the same layered structure — not the same exact patch versions.
 | **pyenv** | `brew install pyenv` | Python version manager | latest |
 | **Python** | `pyenv install 3.13.x` | Runtime for CumulusCI + scripts | major.minor line (`3.13`) |
 | **pipx** | `python -m pip install --user pipx` | Isolated CLI installs (CCI) | latest |
-| **CumulusCI** | `pipx install cumulusci` | Orchestration engine | latest, `setuptools<71` |
+| **CumulusCI** | `pipx install cumulusci` | Orchestration engine | latest; ensure `setuptools>=75.4` (snowfakery 4.x requirement) |
 | **Salesforce CLI (`sf`)** | `npm install -g @salesforce/cli` | Salesforce metadata + data | latest (built-in auto-updater) |
 | **SFDMU plugin** | `sf plugins install @forcedotcom/sfdmu` | Bulk data import/export | v5.x |
 | **gh, git, GCM** | `brew install gh git git-credential-manager` | Source control + PR workflow | latest |
@@ -73,10 +73,13 @@ Must be **fast** (~70ms target). No interactive features.
 export PATH="/opt/homebrew/bin:/opt/homebrew/sbin:$PATH"
 export PATH="$HOME/.local/bin:$PATH"
 
-# NVM — function definitions + default node bin on PATH (no slow `nvm use`)
+# NVM — function definitions + default node bin on PATH (no slow `nvm use`).
+# `brew --prefix nvm` resolves to /opt/homebrew/opt/nvm (Apple Silicon)
+# or /usr/local/opt/nvm (Intel) — works on both architectures.
 export NVM_DIR="$HOME/.nvm"
-if [ -s "/opt/homebrew/opt/nvm/nvm.sh" ]; then
-  . "/opt/homebrew/opt/nvm/nvm.sh" --no-use
+_NVM_PREFIX="$(brew --prefix nvm 2>/dev/null || true)"
+if [ -n "$_NVM_PREFIX" ] && [ -s "$_NVM_PREFIX/nvm.sh" ]; then
+  . "$_NVM_PREFIX/nvm.sh" --no-use
   if [ -s "$NVM_DIR/alias/default" ]; then
     _NVM_DEF="$(cat "$NVM_DIR/alias/default")"
     while [ -s "$NVM_DIR/alias/$_NVM_DEF" ]; do
@@ -88,6 +91,7 @@ if [ -s "/opt/homebrew/opt/nvm/nvm.sh" ]; then
     unset _NVM_DEF _NVM_VER
   fi
 fi
+unset _NVM_PREFIX
 
 # pyenv binary on PATH — but NO global init. Per-project init via direnv.
 export PYENV_ROOT="$HOME/.pyenv"
@@ -111,8 +115,10 @@ export PATH="$PATH:$HOME/Library/Application Support/JetBrains/Toolbox/scripts"
 command -v direnv >/dev/null 2>&1 && eval "$(direnv hook zsh)"
 
 # nvm completions (interactive nicety)
-[ -s "/opt/homebrew/opt/nvm/etc/bash_completion.d/nvm" ] && \
-  . "/opt/homebrew/opt/nvm/etc/bash_completion.d/nvm"
+_NVM_PREFIX="$(brew --prefix nvm 2>/dev/null || true)"
+[ -n "$_NVM_PREFIX" ] && [ -s "$_NVM_PREFIX/etc/bash_completion.d/nvm" ] && \
+  . "$_NVM_PREFIX/etc/bash_completion.d/nvm"
+unset _NVM_PREFIX
 
 # Project / org env vars (Anthropic, Vertex, etc.) go here
 ```
@@ -149,12 +155,15 @@ if command -v pyenv >/dev/null 2>&1; then
   PATH_add "$(pyenv root)/shims"
 fi
 
-# Node via nvm — track active LTS line
+# Node via nvm — track active LTS line. brew --prefix nvm resolves to
+# /opt/homebrew/opt/nvm (Apple Silicon) or /usr/local/opt/nvm (Intel).
 export NVM_DIR="$HOME/.nvm"
-if [ -s "/opt/homebrew/opt/nvm/nvm.sh" ]; then
-  . "/opt/homebrew/opt/nvm/nvm.sh" --no-use
+_NVM_PREFIX="$(brew --prefix nvm 2>/dev/null || true)"
+if [ -n "$_NVM_PREFIX" ] && [ -s "$_NVM_PREFIX/nvm.sh" ]; then
+  . "$_NVM_PREFIX/nvm.sh" --no-use
   nvm use --silent lts/\* >/dev/null 2>&1 || nvm use --silent default >/dev/null 2>&1
 fi
+unset _NVM_PREFIX
 ```
 
 ### First-time activation
@@ -201,7 +210,10 @@ The script handles:
 5. `pipx install --force cumulusci` (if Python patch bumped) **or**
    `pipx upgrade cumulusci` — required because patch upgrades break the
    venv's python symlink
-6. `pipx inject --force cumulusci "setuptools<71"` — CCI 4.x dependency pin
+6. `pipx inject --force cumulusci "setuptools>=75.4"` — snowfakery 4.x
+   requires modern setuptools (the historical `<71` pin documented in
+   earlier guides is **incompatible** with current CCI; see README's
+   *Note on setuptools*)
 7. `sf plugins update`
 8. `cci task run validate_setup` — verifies all 12 checks still pass
 
@@ -267,7 +279,7 @@ patch the venv dies. The update script handles this; manually:
 
 ```bash
 pipx install --force cumulusci --python "$(pyenv prefix 3.13)/bin/python"
-pipx inject --force cumulusci "setuptools<71"
+pipx inject --force cumulusci "setuptools>=75.4"
 ```
 
 ### `python3` resolves to `/usr/bin/python3` instead of pyenv shim

--- a/docs/guides/dev-environment-setup.md
+++ b/docs/guides/dev-environment-setup.md
@@ -30,7 +30,7 @@ ends up with the same layered structure — not the same exact patch versions.
 | **nvm** | `brew install nvm` | Node version manager | latest |
 | **Node.js** | `nvm install --lts` | JavaScript runtime for `sf` CLI | major LTS line (`lts/*`) |
 | **pyenv** | `brew install pyenv` | Python version manager | latest |
-| **Python** | `pyenv install 3.13.x` | Runtime for CumulusCI + scripts | major.minor line (`3.13`) |
+| **Python** | `pyenv install $(pyenv latest -k 3.13)` | Runtime for CumulusCI + scripts | major.minor line (`3.13`) |
 | **pipx** | `$(pyenv prefix)/bin/python3 -m pip install --user pipx` | Isolated CLI installs (CCI) | latest |
 | **CumulusCI** | `pipx install cumulusci --python "$(pyenv prefix)/bin/python3"` | Orchestration engine | latest; ensure `setuptools>=75.4,<77` (snowfakery 4.x requirement) |
 | **Salesforce CLI (`sf`)** | `npm install -g @salesforce/cli` | Salesforce metadata + data | latest (built-in auto-updater) |

--- a/docs/guides/dev-environment-setup.md
+++ b/docs/guides/dev-environment-setup.md
@@ -69,8 +69,17 @@ Each file does one job. No duplication.
 Must be **fast** (~70ms target). No interactive features.
 
 ```sh
-# Core PATH
-export PATH="/opt/homebrew/bin:/opt/homebrew/sbin:$PATH"
+# Homebrew — detect prefix on Apple Silicon (/opt/homebrew) and Intel (/usr/local).
+# Using `brew shellenv` here (rather than just adding bin to PATH) sets MANPATH,
+# INFOPATH, and HOMEBREW_* env vars too, so later `brew --prefix nvm` works
+# in non-login shells.
+if [ -x /opt/homebrew/bin/brew ]; then
+  eval "$(/opt/homebrew/bin/brew shellenv)"
+elif [ -x /usr/local/bin/brew ]; then
+  eval "$(/usr/local/bin/brew shellenv)"
+fi
+
+# pipx-installed CLIs
 export PATH="$HOME/.local/bin:$PATH"
 
 # NVM — function definitions + default node bin on PATH (no slow `nvm use`).
@@ -104,7 +113,14 @@ command -v direnv >/dev/null 2>&1 && eval "$(direnv export zsh 2>/dev/null)"
 #### `~/.zprofile` — runs in **login** shells only
 
 ```sh
-eval "$(/opt/homebrew/bin/brew shellenv)"
+# Re-evaluate brew shellenv for login shells (idempotent — .zshenv already did
+# this for all shells; this line is here in case a contributor's .zshenv differs
+# or they're on a system where login is the only chance to set up Homebrew).
+if [ -x /opt/homebrew/bin/brew ]; then
+  eval "$(/opt/homebrew/bin/brew shellenv)"
+elif [ -x /usr/local/bin/brew ]; then
+  eval "$(/usr/local/bin/brew shellenv)"
+fi
 export PATH="$PATH:$HOME/Library/Application Support/JetBrains/Toolbox/scripts"
 ```
 

--- a/docs/guides/dev-environment-setup.md
+++ b/docs/guides/dev-environment-setup.md
@@ -31,10 +31,10 @@ ends up with the same layered structure — not the same exact patch versions.
 | **Node.js** | `nvm install --lts` | JavaScript runtime for `sf` CLI | major LTS line (`lts/*`) |
 | **pyenv** | `brew install pyenv` | Python version manager | latest |
 | **Python** | `pyenv install 3.13.x` | Runtime for CumulusCI + scripts | major.minor line (`3.13`) |
-| **pipx** | `python -m pip install --user pipx` | Isolated CLI installs (CCI) | latest |
-| **CumulusCI** | `pipx install cumulusci` | Orchestration engine | latest; ensure `setuptools>=75.4,<77` (snowfakery 4.x requirement) |
+| **pipx** | `$(pyenv prefix)/bin/python3 -m pip install --user pipx` | Isolated CLI installs (CCI) | latest |
+| **CumulusCI** | `pipx install cumulusci --python "$(pyenv prefix)/bin/python3"` | Orchestration engine | latest; ensure `setuptools>=75.4,<77` (snowfakery 4.x requirement) |
 | **Salesforce CLI (`sf`)** | `npm install -g @salesforce/cli` | Salesforce metadata + data | latest (built-in auto-updater) |
-| **SFDMU plugin** | `sf plugins install @forcedotcom/sfdmu` | Bulk data import/export | v5.x |
+| **SFDMU plugin** | `sf plugins install sfdmu@5` | Bulk data import/export | v5.x (pin major) |
 | **gh, git, GCM** | `brew install gh git git-credential-manager` | Source control + PR workflow | latest |
 
 **Pin philosophy:**
@@ -297,8 +297,8 @@ the pyenv `python3` specifically, use `pyenv exec python3`.
 
 ## 7. Reference
 
-- Backup files (created during the 2026-05-12 refactor):
-  `~/.zshenv.bak.20260512`, `~/.zshrc.bak.20260512`, `~/.zprofile.bak.20260512`
+- Before editing shell configs, always save a dated backup:
+  `cp ~/.zshenv ~/.zshenv.bak.$(date +%Y%m%d)` (repeat for `~/.zshrc`, `~/.zprofile`)
 - Update script: `scripts/bash/update-toolchain.sh`
 - Project .envrc: `.envrc` at repo root
 - Validation: `cci task run validate_setup` (no org required)

--- a/docs/guides/dev-environment-setup.md
+++ b/docs/guides/dev-environment-setup.md
@@ -112,15 +112,11 @@ command -v direnv >/dev/null 2>&1 && eval "$(direnv export zsh 2>/dev/null)"
 
 #### `~/.zprofile` — runs in **login** shells only
 
+`.zshenv` already runs for every shell (including login), so it handles
+Homebrew setup. `.zprofile` is reserved for login-only extras.
+
 ```sh
-# Re-evaluate brew shellenv for login shells (idempotent — .zshenv already did
-# this for all shells; this line is here in case a contributor's .zshenv differs
-# or they're on a system where login is the only chance to set up Homebrew).
-if [ -x /opt/homebrew/bin/brew ]; then
-  eval "$(/opt/homebrew/bin/brew shellenv)"
-elif [ -x /usr/local/bin/brew ]; then
-  eval "$(/usr/local/bin/brew shellenv)"
-fi
+# Login-only PATH additions (Homebrew + nvm + pyenv all live in .zshenv).
 export PATH="$PATH:$HOME/Library/Application Support/JetBrains/Toolbox/scripts"
 ```
 

--- a/scripts/bash/update-toolchain.sh
+++ b/scripts/bash/update-toolchain.sh
@@ -74,18 +74,32 @@ else
 fi
 
 # ── 5. CCI (pipx) ───────────────────────────────────────────────────────────
-command -v pipx >/dev/null || die "pipx not found"
+# Re-bootstrap pipx under $PY_TARGET first. A Python patch bump can break the
+# existing pipx script's shebang (it pointed at the old patch's python3, which
+# may have been uninstalled). `command -v pipx` would still succeed in that
+# case but invocations would fail with a broken interpreter. Reinstalling pipx
+# under the current target Python (idempotent) repairs this proactively.
+PY_TARGET_BIN="$(pyenv prefix "$PY_TARGET")/bin/python3"
+[ -x "$PY_TARGET_BIN" ] || die "Target Python not found: $PY_TARGET_BIN"
+log "pipx: refresh under Python $PY_TARGET"
+"$PY_TARGET_BIN" -m pip install --user --upgrade pipx
+"$PY_TARGET_BIN" -m pipx ensurepath >/dev/null 2>&1 || true
+
+# Pin pipx invocation to the target Python so subsequent calls aren't subject
+# to PATH ordering surprises.
+PIPX=( "$PY_TARGET_BIN" -m pipx )
+command -v pipx >/dev/null || die "pipx still not found after refresh"
 
 cci_reinstall() {
   log "CCI: reinstalling under Python $PY_TARGET"
-  pipx install --force cumulusci --python "$(pyenv prefix "$PY_TARGET")/bin/python3"
+  "${PIPX[@]}" install --force cumulusci --python "$PY_TARGET_BIN"
 }
 
-if [ "$PY_UPGRADED" -eq 1 ] || ! pipx list --short 2>/dev/null | grep -q '^cumulusci'; then
+if [ "$PY_UPGRADED" -eq 1 ] || ! "${PIPX[@]}" list --short 2>/dev/null | grep -q '^cumulusci'; then
   cci_reinstall
 else
   log "CCI: upgrade in place"
-  if ! pipx upgrade cumulusci; then
+  if ! "${PIPX[@]}" upgrade cumulusci; then
     warn "pipx upgrade failed — reinstalling"
     cci_reinstall
   fi
@@ -99,7 +113,7 @@ fi
 # CCI 4.10+ (what this script installs) works with setuptools 77+, so we
 # don't enforce an upper bound here.
 log "CCI: ensuring setuptools>=75.4"
-pipx inject --force cumulusci "setuptools>=75.4"
+"${PIPX[@]}" inject --force cumulusci "setuptools>=75.4"
 
 # ── 6. sf plugins ───────────────────────────────────────────────────────────
 log "sf plugins: update"

--- a/scripts/bash/update-toolchain.sh
+++ b/scripts/bash/update-toolchain.sh
@@ -90,11 +90,14 @@ else
   fi
 fi
 
-# Modern CCI 4.8+ with snowfakery 4.x requires setuptools>=75.4 (the historical
-# `<71` pin documented in earlier guides is incompatible — see README line ~219).
-# Force the modern minimum to repair any stale legacy injection.
-log "CCI: ensuring setuptools>=75.4"
-pipx inject --force cumulusci "setuptools>=75.4"
+# Modern CCI 4.8+ with snowfakery 4.x requires setuptools>=75.4,<77.
+# - Historical `<71` pin (older docs) is incompatible — see README ~line 219.
+# - Upper bound `<77` matches .github/workflows/prepare-rlm-org.yml: setuptools 77
+#   introduced license-metadata changes that broke CCI 4.8.1 transitive deps.
+#   Loosen when CI is bumped to a newer CCI.
+# Force-inject to repair any stale legacy install.
+log "CCI: ensuring setuptools>=75.4,<77"
+pipx inject --force cumulusci "setuptools>=75.4,<77"
 
 # ── 6. sf plugins ───────────────────────────────────────────────────────────
 log "sf plugins: update"

--- a/scripts/bash/update-toolchain.sh
+++ b/scripts/bash/update-toolchain.sh
@@ -18,9 +18,11 @@ set -euo pipefail
 PY_LINE="3.13"
 NODE_LINE="lts/*"
 
-# Ensure pipx-managed bins (cci, sfdmu, etc.) are findable. pipx ensurepath
-# only updates shell rc files for future shells; we need PATH in *this* shell
-# so the final `cci task run validate_setup` works from a minimal env.
+# Ensure pipx-managed bins (cci, snowfakery, etc.) are findable. pipx
+# ensurepath only updates shell rc files for future shells; we need PATH in
+# *this* shell so the final `cci task run validate_setup` works from a
+# minimal env. (Note: sf CLI lives under nvm's node bin, not here, and the
+# sfdmu plugin lives inside sf's plugin tree — neither passes through pipx.)
 export PATH="$HOME/.local/bin:$PATH"
 
 log()  { printf '\n\033[1;34m[update]\033[0m %s\n' "$*"; }

--- a/scripts/bash/update-toolchain.sh
+++ b/scripts/bash/update-toolchain.sh
@@ -32,7 +32,7 @@ command -v pyenv >/dev/null || die "pyenv not found"
 
 LATEST_KNOWN="$(pyenv latest -k "$PY_LINE" 2>/dev/null || true)"
 LATEST_INSTALLED="$(pyenv latest "$PY_LINE" 2>/dev/null || true)"
-[ -n "$LATEST_KNOWN" ] || die "pyenv can't resolve latest Python $PY_LINE — run 'pyenv update' or upgrade pyenv"
+[ -n "$LATEST_KNOWN" ] || die "pyenv can't resolve latest Python $PY_LINE — run 'brew upgrade pyenv' to refresh python-build definitions"
 
 log "Python: latest known $PY_LINE = $LATEST_KNOWN ; installed = ${LATEST_INSTALLED:-none}"
 if [ "$LATEST_KNOWN" != "$LATEST_INSTALLED" ]; then

--- a/scripts/bash/update-toolchain.sh
+++ b/scripts/bash/update-toolchain.sh
@@ -91,14 +91,15 @@ else
   fi
 fi
 
-# Modern CCI 4.8+ with snowfakery 4.x requires setuptools>=75.4,<77.
-# - Historical `<71` pin (older docs) is incompatible — see README ~line 219.
-# - Upper bound `<77` matches .github/workflows/prepare-rlm-org.yml: setuptools 77
-#   introduced license-metadata changes that broke CCI 4.8.1 transitive deps.
-#   Loosen when CI is bumped to a newer CCI.
+# Modern CCI 4.8+ with snowfakery 4.x requires setuptools>=75.4.
+# Historical `<71` pin (older docs) is incompatible — see README ~line 219.
 # Force-inject to repair any stale legacy install.
-log "CCI: ensuring setuptools>=75.4,<77"
-pipx inject --force cumulusci "setuptools>=75.4,<77"
+# Note: CI (.github/workflows/prepare-rlm-org.yml) adds `<77` because it's
+# pinned to CCI 4.8.1; setuptools 77+ broke transitive deps on that version.
+# CCI 4.10+ (what this script installs) works with setuptools 77+, so we
+# don't enforce an upper bound here.
+log "CCI: ensuring setuptools>=75.4"
+pipx inject --force cumulusci "setuptools>=75.4"
 
 # ── 6. sf plugins ───────────────────────────────────────────────────────────
 log "sf plugins: update"

--- a/scripts/bash/update-toolchain.sh
+++ b/scripts/bash/update-toolchain.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# update-toolchain.sh — refresh the local dev toolchain for rlm-base-dev.
+#
+# Updates, in order:
+#   1. Homebrew packages (direnv, nvm, pyenv, pipx, etc.)
+#   2. Python — latest patch in the 3.13 line (via pyenv)
+#   3. Node — latest LTS (via nvm), carrying npm globals forward
+#   4. sf CLI — npm-installed under the active nvm Node
+#   5. CCI — pipx (reinstall is required after any Python patch bump)
+#   6. sf plugins (SFDMU, etc.)
+#   7. cci task run validate_setup
+#
+# Designed to be idempotent. Re-run after any tool emits a "new version" notice.
+# Major-line pins live in this script (PY_LINE, NODE_LINE) — edit them to bump.
+
+set -euo pipefail
+
+PY_LINE="3.13"
+NODE_LINE="lts/*"
+
+log()  { printf '\n\033[1;34m[update]\033[0m %s\n' "$*"; }
+warn() { printf '\n\033[1;33m[warn]\033[0m  %s\n' "$*" >&2; }
+die()  { printf '\n\033[1;31m[fail]\033[0m  %s\n' "$*" >&2; exit 1; }
+
+# ── 1. Homebrew ─────────────────────────────────────────────────────────────
+log "Homebrew: update + upgrade"
+brew update
+brew upgrade
+
+# ── 2. Python (pyenv) ───────────────────────────────────────────────────────
+command -v pyenv >/dev/null || die "pyenv not found"
+
+LATEST_KNOWN="$(pyenv latest -k "$PY_LINE" 2>/dev/null || true)"
+LATEST_INSTALLED="$(pyenv latest "$PY_LINE" 2>/dev/null || true)"
+[ -n "$LATEST_KNOWN" ] || die "pyenv can't resolve latest Python $PY_LINE — run 'pyenv update' or upgrade pyenv"
+
+log "Python: latest known $PY_LINE = $LATEST_KNOWN ; installed = ${LATEST_INSTALLED:-none}"
+if [ "$LATEST_KNOWN" != "$LATEST_INSTALLED" ]; then
+  log "Installing Python $LATEST_KNOWN"
+  pyenv install --skip-existing "$LATEST_KNOWN"
+  PY_UPGRADED=1
+else
+  log "Python $LATEST_INSTALLED already latest"
+  PY_UPGRADED=0
+fi
+PY_TARGET="$(pyenv latest "$PY_LINE")"
+export PYENV_VERSION="$PY_TARGET"
+
+# ── 3. Node (nvm) ───────────────────────────────────────────────────────────
+export NVM_DIR="$HOME/.nvm"
+# shellcheck disable=SC1091
+. "/opt/homebrew/opt/nvm/nvm.sh"
+
+OLD_NODE="$(nvm current 2>/dev/null || echo none)"
+log "Node: installing latest in $NODE_LINE (current: $OLD_NODE)"
+# --reinstall-packages-from=current carries `sf` and other globals forward.
+nvm install --lts --reinstall-packages-from=current --latest-npm
+nvm alias default "$NODE_LINE" >/dev/null
+NEW_NODE="$(nvm current)"
+log "Node: now on $NEW_NODE"
+
+# ── 4. sf CLI ───────────────────────────────────────────────────────────────
+log "sf CLI: update channel"
+if command -v sf >/dev/null 2>&1; then
+  sf update || warn "sf update failed — try: npm install -g @salesforce/cli@latest"
+else
+  warn "sf not found on PATH for $NEW_NODE — installing"
+  npm install -g @salesforce/cli@latest
+fi
+
+# ── 5. CCI (pipx) ───────────────────────────────────────────────────────────
+command -v pipx >/dev/null || die "pipx not found"
+
+if [ "$PY_UPGRADED" -eq 1 ] || ! pipx list --short 2>/dev/null | grep -q '^cumulusci'; then
+  log "CCI: reinstalling under Python $PY_TARGET"
+  pipx install --force cumulusci --python "$(pyenv prefix "$PY_TARGET")/bin/python"
+else
+  log "CCI: upgrade in place"
+  pipx upgrade cumulusci || warn "pipx upgrade failed — falling back to reinstall"
+fi
+
+# CCI 4.x needs setuptools<71 (pyfilesystem2 / pkg_resources removed in 71+).
+log "CCI: pinning setuptools<71"
+pipx inject --force cumulusci "setuptools<71"
+
+# ── 6. sf plugins ───────────────────────────────────────────────────────────
+log "sf plugins: update"
+sf plugins update || warn "sf plugins update failed"
+
+# ── 7. Verify ───────────────────────────────────────────────────────────────
+log "Running validate_setup"
+cci task run validate_setup
+
+log "Done."

--- a/scripts/bash/update-toolchain.sh
+++ b/scripts/bash/update-toolchain.sh
@@ -18,6 +18,11 @@ set -euo pipefail
 PY_LINE="3.13"
 NODE_LINE="lts/*"
 
+# Ensure pipx-managed bins (cci, sfdmu, etc.) are findable. pipx ensurepath
+# only updates shell rc files for future shells; we need PATH in *this* shell
+# so the final `cci task run validate_setup` works from a minimal env.
+export PATH="$HOME/.local/bin:$PATH"
+
 log()  { printf '\n\033[1;34m[update]\033[0m %s\n' "$*"; }
 warn() { printf '\n\033[1;33m[warn]\033[0m  %s\n' "$*" >&2; }
 die()  { printf '\n\033[1;31m[fail]\033[0m  %s\n' "$*" >&2; exit 1; }
@@ -86,9 +91,10 @@ log "pipx: refresh under Python $PY_TARGET"
 "$PY_TARGET_BIN" -m pipx ensurepath >/dev/null 2>&1 || true
 
 # Pin pipx invocation to the target Python so subsequent calls aren't subject
-# to PATH ordering surprises.
+# to PATH ordering surprises or shebang breakage from previous patch installs.
+# We never invoke bare `pipx` after this point, so no PATH check is needed —
+# this works even from a minimal env where ~/.local/bin isn't yet on PATH.
 PIPX=( "$PY_TARGET_BIN" -m pipx )
-command -v pipx >/dev/null || die "pipx still not found after refresh"
 
 cci_reinstall() {
   log "CCI: reinstalling under Python $PY_TARGET"

--- a/scripts/bash/update-toolchain.sh
+++ b/scripts/bash/update-toolchain.sh
@@ -48,13 +48,17 @@ export PYENV_VERSION="$PY_TARGET"
 
 # ── 3. Node (nvm) ───────────────────────────────────────────────────────────
 export NVM_DIR="$HOME/.nvm"
+NVM_PREFIX="$(brew --prefix nvm 2>/dev/null || true)"
+[ -n "$NVM_PREFIX" ] && [ -s "$NVM_PREFIX/nvm.sh" ] || die "nvm.sh not found via 'brew --prefix nvm' — is nvm installed?"
 # shellcheck disable=SC1091
-. "/opt/homebrew/opt/nvm/nvm.sh"
+. "$NVM_PREFIX/nvm.sh"
 
 OLD_NODE="$(nvm current 2>/dev/null || echo none)"
-log "Node: installing latest in $NODE_LINE (current: $OLD_NODE)"
+log "Node: installing $NODE_LINE (current: $OLD_NODE)"
+# Drive install from NODE_LINE so changes at the top of this script take effect.
+# `lts/*` resolves to the active LTS line; explicit majors (e.g. `24`) also work.
 # --reinstall-packages-from=current carries `sf` and other globals forward.
-nvm install --lts --reinstall-packages-from=current --latest-npm
+nvm install "$NODE_LINE" --reinstall-packages-from=current --latest-npm
 nvm alias default "$NODE_LINE" >/dev/null
 NEW_NODE="$(nvm current)"
 log "Node: now on $NEW_NODE"
@@ -71,17 +75,26 @@ fi
 # ── 5. CCI (pipx) ───────────────────────────────────────────────────────────
 command -v pipx >/dev/null || die "pipx not found"
 
-if [ "$PY_UPGRADED" -eq 1 ] || ! pipx list --short 2>/dev/null | grep -q '^cumulusci'; then
+cci_reinstall() {
   log "CCI: reinstalling under Python $PY_TARGET"
   pipx install --force cumulusci --python "$(pyenv prefix "$PY_TARGET")/bin/python"
+}
+
+if [ "$PY_UPGRADED" -eq 1 ] || ! pipx list --short 2>/dev/null | grep -q '^cumulusci'; then
+  cci_reinstall
 else
   log "CCI: upgrade in place"
-  pipx upgrade cumulusci || warn "pipx upgrade failed — falling back to reinstall"
+  if ! pipx upgrade cumulusci; then
+    warn "pipx upgrade failed — reinstalling"
+    cci_reinstall
+  fi
 fi
 
-# CCI 4.x needs setuptools<71 (pyfilesystem2 / pkg_resources removed in 71+).
-log "CCI: pinning setuptools<71"
-pipx inject --force cumulusci "setuptools<71"
+# Modern CCI 4.8+ with snowfakery 4.x requires setuptools>=75.4 (the historical
+# `<71` pin documented in earlier guides is incompatible — see README line ~219).
+# Force the modern minimum to repair any stale legacy injection.
+log "CCI: ensuring setuptools>=75.4"
+pipx inject --force cumulusci "setuptools>=75.4"
 
 # ── 6. sf plugins ───────────────────────────────────────────────────────────
 log "sf plugins: update"

--- a/scripts/bash/update-toolchain.sh
+++ b/scripts/bash/update-toolchain.sh
@@ -23,6 +23,7 @@ warn() { printf '\n\033[1;33m[warn]\033[0m  %s\n' "$*" >&2; }
 die()  { printf '\n\033[1;31m[fail]\033[0m  %s\n' "$*" >&2; exit 1; }
 
 # ── 1. Homebrew ─────────────────────────────────────────────────────────────
+command -v brew >/dev/null || die "brew not found — install Homebrew from https://brew.sh first"
 log "Homebrew: update + upgrade"
 brew update
 brew upgrade

--- a/scripts/bash/update-toolchain.sh
+++ b/scripts/bash/update-toolchain.sh
@@ -78,7 +78,7 @@ command -v pipx >/dev/null || die "pipx not found"
 
 cci_reinstall() {
   log "CCI: reinstalling under Python $PY_TARGET"
-  pipx install --force cumulusci --python "$(pyenv prefix "$PY_TARGET")/bin/python"
+  pipx install --force cumulusci --python "$(pyenv prefix "$PY_TARGET")/bin/python3"
 }
 
 if [ "$PY_UPGRADED" -eq 1 ] || ! pipx list --short 2>/dev/null | grep -q '^cumulusci'; then


### PR DESCRIPTION
## Summary

- Introduce a **layered local dev architecture**: system-level toolchain (Homebrew/nvm/pyenv/pipx) with major-line pins + per-project activation via [direnv](https://direnv.net/) `.envrc`. Eliminates global `pyenv init` (historical source of stale `.pyenv-shim` lock issues) and brings shell startup to ~70ms.
- Add `scripts/bash/update-toolchain.sh` — one command refreshes brew, pyenv (latest patch in pinned 3.13 line), nvm LTS, sf CLI, CCI (handles pipx venv reinstall after Python patch bumps), SFDMU, and ends with `cci task run validate_setup`.
- Add `docs/guides/dev-environment-setup.md` as the canonical architecture reference — toolchain inventory, shell config layout (`.zshenv`/`.zprofile`/`.zshrc`), replication steps for new workstations, troubleshooting for the gotchas we hit.

## What changed

| File | Change |
|---|---|
| `.envrc` | **new** — `PYENV_VERSION="$(pyenv latest 3.13)"` + `nvm use lts/*` |
| `scripts/bash/update-toolchain.sh` | **new** (executable) — toolchain refresh routine |
| `docs/guides/dev-environment-setup.md` | **new** — canonical architecture doc |
| `README.md` | pointer to guide at top of macOS Setup; "Ongoing toolchain maintenance" subsection after Step 11; new entry in Primary Guides |
| `AGENTS.md` | new row in Skill Index pointing future agents to the guide |

## Pin strategy

- **Major-line, not minor.** `.envrc` resolves `pyenv latest 3.13` so installing `3.13.13` is picked up automatically — no `.envrc` edit needed for patch bumps.
- **Node** follows the active LTS line via `lts/*` — no edit needed when the LTS line bumps within the line.
- **Bumping a major line** (Python 3.13 → 3.14, Node 24 → 26) is a deliberate, tracked change: edit `PY_LINE` / `NODE_LINE` at the top of the update script.

## Test plan

- [x] `direnv allow` succeeds; `python --version` → 3.13.12, `PYENV_VERSION` set correctly inside project
- [x] Clean-env `zsh -c` test outside project: no `python` on PATH (pyenv not initialized globally)
- [x] Clean-env `zsh -c` test inside project: `python`, `node`, `sf`, `cci` all resolve to expected versions
- [x] Shell startup time: ~70ms inside and outside project
- [x] `cci task run validate_setup` — 12/12 PASS
- [x] `bash -n scripts/bash/update-toolchain.sh` — syntax clean
- [ ] Reviewer: walk through `docs/guides/dev-environment-setup.md` §5 replication steps mentally; flag any missing prerequisites

## Notes for reviewer

- The existing README Steps 1–11 are unchanged in substance — they remain the from-scratch bootstrap. The new guide is the target architecture you graduate to.
- `.envrc` is committed (not gitignored) so teammates get the same pins. They run `direnv allow` once per workstation.
- No code-path or org-impacting changes; documentation + dev tooling only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)