### PR TITLE
chore(ci): bump Node.js from 22 to 24 (current LTS)

### DIFF
--- a/.github/workflows/prepare-rlm-org.yml
+++ b/.github/workflows/prepare-rlm-org.yml
@@ -28,16 +28,16 @@ jobs:
         with:
           python-version: "3.13"
 
-      - name: Set up Node.js 22
+      - name: Set up Node.js 24
         uses: actions/setup-node@v4
         with:
-          node-version: "22"
+          node-version: "24"
 
       - name: Cache npm download cache
         uses: actions/cache@v4
         with:
           path: ~/.npm
-          key: npm-cache-${{ runner.os }}-node22
+          key: npm-cache-${{ runner.os }}-node24
 
       - name: Install sf CLI and SFDMU plugin
         run: |


### PR DESCRIPTION
## Summary

- Bump `prepare-rlm-org.yml` from Node 22 → Node 24 to align CI with the recommended local toolchain.
- Node 24 (krypton, even-numbered) is the current active LTS line and what `nvm use lts/*` resolves to today.
- Cache key changes from `node22` → `node24` so existing caches expire naturally instead of being reused under the new Node major.

## Why

The local dev environment uses Node 24 LTS (per `~/.nvm`, README *macOS Environment Setup* Step 3, and the new `docs/guides/dev-environment-setup.md` from #161). CI was still pinned to Node 22 — the previous LTS line. Aligning them eliminates dev/CI version skew that can hide compatibility issues with `sf` CLI, npm globals, and node_modules behavior.

Node 24 is supported by:
- `sf` CLI 2.x (current channel)
- CumulusCI 4.x (no direct Node dependency, but uses `sf` underneath)
- `actions/setup-node@v4`

## Diff

```diff
-      - name: Set up Node.js 22
+      - name: Set up Node.js 24
         uses: actions/setup-node@v4
         with:
-          node-version: "22"
+          node-version: "24"

-          key: npm-cache-${{ runner.os }}-node22
+          key: npm-cache-${{ runner.os }}-node24
```

## Test plan

- [ ] Trigger `workflow_dispatch` on this branch and verify Node 24.x.x installs and the workflow proceeds past the "Verify environment" step
- [ ] Compare elapsed time vs. last successful Node 22 run (2026-03-19 success ran 30m29s) — no significant regression expected
- [ ] If `sf plugins install sfdmu@5` succeeds and CCI install completes, Node 24 is good to go

## Notes for reviewer

- This does **not** touch `actions/setup-node@v4` itself. `setup-node@v4` is current and supports Node 24.
- This does **not** touch the unrelated CI failure in `reorder_app_launcher` (the Aura saveOrder "Unknown token" issue) — that's a separate problem and a separate PR.
- This does **not** touch the Node version in `claude-code-review.yml` or `claude.yml` (those don't run Node-based workflows; they use Anthropic actions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)