### PR TITLE
chore(ci): bump Node.js from 22 to 24 (current LTS) — 262

### DIFF
--- a/.github/workflows/prepare-rlm-org.yml
+++ b/.github/workflows/prepare-rlm-org.yml
@@ -28,16 +28,16 @@ jobs:
         with:
           python-version: "3.13"
 
-      - name: Set up Node.js 22
+      - name: Set up Node.js 24
         uses: actions/setup-node@v4
         with:
-          node-version: "22"
+          node-version: "24"
 
       - name: Cache npm download cache
         uses: actions/cache@v4
         with:
           path: ~/.npm
-          key: npm-cache-${{ runner.os }}-node22
+          key: npm-cache-${{ runner.os }}-node24
 
       - name: Install sf CLI and SFDMU plugin
         run: |


### PR DESCRIPTION
## Summary

Forward-port of main PR #162 (`0b067e09`) onto the `262` branch.

Bumps GitHub Actions Node.js from 22 → 24 (krypton LTS) in `prepare-rlm-org.yml`, and bumps the npm cache key from `node22` → `node24` so existing caches expire naturally. Matches the recommended local toolchain (`nvm use lts/*` resolves to 24 today) and is a supported upgrade path for `sf` CLI 2.x + CCI 4.x.

Single clean cherry-pick from main — no 262-specific edits needed.

## Part of the 262 → main merge-readiness sweep

Sibling PRs:

- **#166** — `docs: skills + enablement catalog + Help snapshot tooling — 262` (split from #163 for reviewability)
- **#167** — `docs(salesforce/262/help): land 262 Help portal snapshot (840 articles)` (split from #163)
- **#165** — `feat(setup): configure_core_pricing_setup + configure_product_discovery_settings; auto-detect Developer Edition — 262`

(#163 closed; replaced by #166 + #167.)

## Test plan

- [ ] CI run on this PR uses Node 24 cleanly (`sf` CLI install + SFDMU plugin install succeed)
- [ ] npm cache miss on first run (expected — key changed), populates `node24` cache for subsequent runs
- [ ] No other workflow files on 262 reference Node 22 (verified locally — only `prepare-rlm-org.yml` touches Node)