### PR TITLE
feat(setup): configure_core_pricing_setup + configure_product_discovery_settings; auto-detect Developer Edition — 262

### DIFF
--- a/.cursor/rules/robot-tests.mdc
+++ b/.cursor/rules/robot-tests.mdc
@@ -27,12 +27,28 @@ globs:
 - **Never use `//` comments in JS blocks** — Robot joins continuation
   lines with spaces, so `//` comments out everything after it on the
   joined line. Use `/* */` if comments are needed.
-- Shadow DOM traversal is the primary interaction pattern — use recursive
-  `findInShadows(root, selector)` for elements behind shadow boundaries.
+- Shadow DOM traversal is the primary interaction pattern — use the canonical
+  `findEl`/`findAll` helpers (see below), not XPath or standard Selenium locators.
 - Use `composed: true` on dispatched events to cross shadow DOM boundaries.
 - For LWC input reactivity, use `Object.getOwnPropertyDescriptor(
   HTMLInputElement.prototype, 'value').set` instead of Selenium's
   `input_text`.
+
+## Shadow DOM — Canonical Patterns
+
+Define shared JS helpers as Robot variables and prepend them to `Execute JavaScript` blocks:
+
+```robot
+${_JS_FIND_EL}    function findEl(root, sel, d) { if (d > 6) return null; var el = root.querySelector(sel); if (el) return el; var all = root.querySelectorAll('*'); for (var i=0;i<all.length;i++){if(all[i].shadowRoot){var f=findEl(all[i].shadowRoot,sel,d+1);if(f)return f;}} return null; }
+```
+
+**Lightning combobox** — 3-level shadow: `lightning-combobox` → `lightning-base-combobox` → `button[role="combobox"]`. Options are `lightning-base-combobox-item[role="option"]` with text in their shadow roots. Identify comboboxes by `data-id` attribute or class (e.g. `lightning-combobox.procedure-combobox`).
+
+**Lightning toggle** — 2-level shadow: `lightning-input` → `lightning-primitive-input-toggle` → `input[role="switch"]`. At each DOM depth check `lightning-input` first; only fall back to plain `input[type="checkbox"]` when no `lightning-input` exists at that depth. Always click the wrapping `<label>`, not the raw input: `(pi.closest('label') || pi).click()`.
+
+**Pill detection** — when a combobox value is set, Salesforce replaces the combobox with a `.slds-pill__label` element. Check for pill presence to detect already-set state before trying to open the combobox.
+
+**Render timing** — some setup pages render LWC components after the page load event. Return `'page_not_ready'` from JS and wrap the check in `Wait Until Keyword Succeeds 20s 3s` to retry. Treat `lbc_not_found` and `btn_not_found` as `page_not_ready` (inner shadow not yet rendered), not hard failures.
 
 ## Multi-Tier Fallback
 

--- a/.cursor/skills/cci-orchestration/feature-flags.md
+++ b/.cursor/skills/cci-orchestration/feature-flags.md
@@ -3,7 +3,7 @@
 > **Auto-generated** by `scripts/ai/generate_cci_reference.py` from `cumulusci.yml`.  
 > Do not edit manually — re-run the script after changing `cumulusci.yml`.
 
-**39 feature flags**, **78 configuration values**, **30 YAML anchors** under `project.custom`.
+**39 feature flags**, **78 configuration values**, **32 YAML anchors** under `project.custom`.
 
 ---
 
@@ -27,30 +27,30 @@ Boolean flags that gate task/flow execution via `when:` clauses.
 | `commerce` | `False` | 2 flow step(s) |
 | `constraints` | `True` | 10 flow step(s) |
 | `constraints_data` | `True` | 6 flow step(s) |
-| `dev_ed` | `False` | 1 flow step(s) |
 | `docgen` | `True` | 10 flow step(s) |
 | `dro` | `True` | 7 flow step(s) |
 | `einstein` | `True` | 3 flow step(s) |
 | `guidedselling` | `False` | 2 flow step(s) |
-| `large_stx` | `True` | 2 flow step(s) |
+| `large_stx` | `True` | 3 flow step(s) |
 | `payments` | `True` | 6 flow step(s) |
 | `pde` | `False` | — |
-| `personas` | `True` | 7 flow step(s) |
+| `personas` | `True` | 8 flow step(s) |
 | `prm` | `True` | 8 flow step(s) |
-| `prm_exp_bundle` | `True` | 4 flow step(s) |
+| `prm_exp_bundle` | `False` | 4 flow step(s) |
 | `procedure_plan_definition_version_active` | `False` | — |
 | `procedureplans` | `True` | 5 flow step(s) |
 | `q3` | `False` | 7 flow step(s) |
-| `qb` | `True` | 20 flow step(s) |
+| `qb` | `True` | 21 flow step(s) |
 | `qbrix` | `False` | — |
 | `quantumbit` | `True` | 10 flow step(s) |
 | `ramps` | `True` | 3 flow step(s) |
 | `rates` | `True` | 5 flow step(s) |
 | `rating` | `True` | 13 flow step(s) |
 | `refresh` | `False` | 11 flow step(s) |
+| `sample_data` | `True` | 1 flow step(s) |
 | `tax` | `True` | 4 flow step(s) |
 | `trial` | `False` | — |
-| `tso` | `False` | 15 flow step(s) |
+| `tso` | `False` | 14 flow step(s) |
 | `ux` | `True` | 3 flow step(s) |
 
 ---
@@ -162,10 +162,6 @@ Boolean flags that gate task/flow execution via `when:` clauses.
 - `prepare_constraints` step 9 → `import_cml`
 - `prepare_constraints` step 10 → `manage_expression_sets`
 
-### `dev_ed` (default: `False`)
-
-- `assign_feature_permission_sets` step 3 → `assign_permission_sets`
-
 ### `docgen` (default: `True`)
 
 - `prepare_docgen` step 1 → `create_docgen_library`
@@ -204,6 +200,7 @@ Boolean flags that gate task/flow execution via `when:` clauses.
 
 - `prepare_rlm_org` step 27 → `prepare_large_stx`
 - `prepare_large_stx` step 1 → `deploy_post_large_stx`
+- `prepare_large_stx` step 2 → `assign_permission_sets`
 
 ### `payments` (default: `True`)
 
@@ -223,6 +220,7 @@ Boolean flags that gate task/flow execution via `when:` clauses.
 - `prepare_personas` step 4 → `create_personas_sales_rep_user`
 - `prepare_personas` step 5 → `assign_personas_sales_rep_psg`
 - `prepare_personas` step 6 → `assign_permission_sets`
+- `prepare_personas` step 7 → `assign_permission_sets`
 
 ### `prm` (default: `True`)
 
@@ -235,7 +233,7 @@ Boolean flags that gate task/flow execution via `when:` clauses.
 - `prepare_prm` step 8 → `insert_quantumbit_prm_data`
 - `prepare_prm` step 9 → `manage_context_definition`
 
-### `prm_exp_bundle` (default: `True`)
+### `prm_exp_bundle` (default: `False`)
 
 - `prepare_prm` step 2 → `patch_network_email_for_deploy`
 - `prepare_prm` step 3 → `deploy_post_prm`
@@ -282,6 +280,7 @@ Boolean flags that gate task/flow execution via `when:` clauses.
 - `prepare_constraints` step 10 → `manage_expression_sets`
 - `prepare_approvals` step 4 → `insert_qb_approvals_data`
 - `prepare_guidedselling` step 1 → `insert_qb_guidedselling_data`
+- `prepare_pricing_discovery` step 2 → `configure_product_discovery_settings`
 
 ### `quantumbit` (default: `True`)
 
@@ -340,6 +339,10 @@ Boolean flags that gate task/flow execution via `when:` clauses.
 - `prepare_rating` step 5 → `insert_qb_rates_data`
 - `prepare_rating` step 6 → `insert_q3_rates_data`
 
+### `sample_data` (default: `True`)
+
+- `prepare_scratch` step 1 → `insert_scratch_data`
+
 ### `tax` (default: `True`)
 
 - `prepare_tax` step 1 → `create_tax_engine`
@@ -353,7 +356,6 @@ Boolean flags that gate task/flow execution via `when:` clauses.
 - `prepare_core` step 11 → `assign_permission_set_groups_tolerant`
 - `assign_feature_psls` step 4 → `assign_permission_set_licenses`
 - `assign_feature_permission_sets` step 1 → `assign_permission_sets`
-- `prepare_scratch` step 1 → `insert_scratch_data`
 - `prepare_tso` step 1 → `assign_permission_set_groups`
 - `prepare_tso` step 2 → `deploy_post_utils`
 - `prepare_tso` step 3 → `deploy_post_tso`
@@ -373,7 +375,6 @@ Boolean flags that gate task/flow execution via `when:` clauses.
 
 ### `org_config.scratch` (runtime)
 
-- `prepare_scratch` step 1 → `insert_scratch_data`
 - `prepare_dro` step 3 → `insert_q3_dro_data_scratch`
 - `prepare_dro` step 4 → `insert_q3_dro_data_prod`
 
@@ -589,6 +590,18 @@ These `project.custom` entries are YAML anchors (lists or maps) reused throughou
 *1 items:*
 
 - `RLM_DocGen`
+
+### `ps_large_stx`
+
+*1 items:*
+
+- `RLM_LargeSalesTransaction`
+
+### `ps_persona_sales_rep`
+
+*1 items:*
+
+- `RLM_QuantumBit_Sales_Representative`
 
 ### `ps_prm`
 

--- a/.cursor/skills/cci-orchestration/flows-reference.md
+++ b/.cursor/skills/cci-orchestration/flows-reference.md
@@ -72,7 +72,7 @@ Assign feature-gated permission sets after PSGs are updated
    - `api_names`: `['IndustriesConfiguratorPlatformApi', 'ProductConfigurationRulesDesigner', 'ProductCatalogManagem...`
 2. **task** `assign_permission_sets`  `when: project_config.project__custom__einstein`
    - `api_names`: `['EinsteinGPTPromptTemplateManager']`
-3. **task** `assign_permission_sets`  `when: project_config.project__custom__einstein and not (project_config.project__custom__dev_ed or org_config.name in ["dev", "dev-sb0", "dev-r1"])`
+3. **task** `assign_permission_sets`  `when: project_config.project__custom__einstein and org_config.org_type != "Developer Edition"`
    - `api_names`: `['SalesCloudEinsteinAll']`
 4. **task** `assign_permission_sets`  `when: project_config.project__custom__billing and project_config.project__custom__psg_debug`
    - `api_names`: `['AnalyticsStoreUser', 'RevenueLifecycleManagementAccountingAdmin', 'RevenueLifecycleManagementBi...`
@@ -320,6 +320,8 @@ Create Self-Service Billing Portal community and optionally deploy site content.
 **Steps:**
 
 1. **task** `deploy_post_large_stx`  `when: project_config.project__custom__large_stx`
+2. **task** `assign_permission_sets`  `when: project_config.project__custom__large_stx`
+   - `api_names`: `['RLM_LargeSalesTransaction']`
 
 ---
 
@@ -351,6 +353,9 @@ Deploy persona metadata (profiles, permission set groups, permission sets) from 
 6. **task** `assign_permission_sets`  `when: project_config.project__custom__personas`
    - `api_names`: `['RLM_QuantumBit_Sales_Representative']`
    - `user_alias`: `salesrep`
+7. **task** `assign_permission_sets`  `when: project_config.project__custom__personas`
+   - `api_names`: `['RLM_LargeSalesTransaction']`
+   - `user_alias`: `salesrep`
 
 ---
 
@@ -376,6 +381,7 @@ Deploy persona metadata (profiles, permission set groups, permission sets) from 
 **Steps:**
 
 1. **task** `reconfigure_pricing_discovery`
+2. **task** `configure_product_discovery_settings`  `when: project_config.project__custom__qb`
 
 ---
 
@@ -471,6 +477,7 @@ Deploy Create Ramp Schedule V4 feature into the target org. Deploys QuoteLineGro
 1. **task** `configure_revenue_settings`  `when: not (project_config.project__custom__quantumbit or project_config.project__custom__tso)`
 2. **task** `configure_revenue_settings`  `when: project_config.project__custom__quantumbit or project_config.project__custom__tso`
    - `manage_assets_flow`: `RLM_ARC_Assets`
+3. **task** `configure_core_pricing_setup`
 
 ---
 
@@ -517,7 +524,7 @@ Deploy Create Ramp Schedule V4 feature into the target org. Deploys QuoteLineGro
 
 **Steps:**
 
-1. **task** `insert_scratch_data`  `when: org_config.scratch and not project_config.project__custom__tso`
+1. **task** `insert_scratch_data`  `when: project_config.project__custom__sample_data`
 
 ---
 

--- a/.cursor/skills/cci-orchestration/tasks-reference.md
+++ b/.cursor/skills/cci-orchestration/tasks-reference.md
@@ -3,7 +3,7 @@
 > **Auto-generated** by `scripts/ai/generate_cci_reference.py` from `cumulusci.yml`.  
 > Do not edit manually — re-run the script after changing `cumulusci.yml`.
 
-**201 tasks** across **9 groups**.
+**203 tasks** across **9 groups**.
 
 ---
 
@@ -546,7 +546,7 @@
 
 ## Revenue Lifecycle Management
 
-*127 task(s)*
+*129 task(s)*
 
 ### `activate_and_deploy_expression_sets`
 
@@ -794,6 +794,34 @@
 
 - `path`: `unpackaged/pre`
 - `remove_for_scratch`: `True`
+
+---
+
+### `configure_core_pricing_setup`
+
+**Description:** Configure Salesforce Pricing Setup (CorePricingSetup) page: set the default Pricing Procedure (Robot test). Must run after the Pricing Procedure expression set is deployed and activated.
+
+**Class:** `tasks.rlm_configure_core_pricing_setup.ConfigureCorePricingSetup`
+
+**Options:**
+
+- `suite`: `robot/rlm-base/tests/setup/configure_core_pricing_setup.robot`
+- `outputdir`: `robot/rlm-base/results`
+- `pricing_procedure`: `RLM Revenue Management Default Pricing Procedure`
+
+---
+
+### `configure_product_discovery_settings`
+
+**Description:** Set the Default Catalog in Product Discovery Settings to 'QuantumBit Software' (Robot test). Must run after QB product catalog data is loaded. Only relevant when qb=true.
+
+**Class:** `tasks.rlm_configure_product_discovery_settings.ConfigureProductDiscoverySettings`
+
+**Options:**
+
+- `suite`: `robot/rlm-base/tests/setup/configure_product_discovery_settings.robot`
+- `outputdir`: `robot/rlm-base/results`
+- `default_catalog`: `QuantumBit Software`
 
 ---
 

--- a/.cursor/skills/robot-testing/SKILL.md
+++ b/.cursor/skills/robot-testing/SKILL.md
@@ -36,6 +36,8 @@ Use this skill when writing, modifying, or debugging Robot Framework tests.
 | Robot File | What | Why Robot? |
 |-----------|------|-----------|
 | `configure_revenue_settings` | Pricing Procedure, Usage Rating, Instant Pricing, flows | Shadow DOM controls, no API |
+| `configure_core_pricing_setup` | Default Pricing Procedure on CorePricingSetup page | Shadow DOM combobox, no API |
+| `configure_product_discovery_settings` | Default Catalog on Product Discovery Settings page | Shadow DOM combobox, no API |
 | `enable_analytics` | CRM Analytics + Data Sync toggle | VF iframe, no API |
 | `enable_document_builder` | Document Builder toggle | Shadow DOM, no API |
 | `enable_constraints_settings` | Transaction Type, Asset Context, Constraints Engine | Shadow DOM, no API |

--- a/.cursor/skills/robot-testing/patterns.md
+++ b/.cursor/skills/robot-testing/patterns.md
@@ -16,6 +16,8 @@ robot/rlm-base/
 │   │   └── reset_account.robot
 │   └── setup/                        # Org setup automation
 │       ├── configure_revenue_settings.robot
+│       ├── configure_core_pricing_setup.robot
+│       ├── configure_product_discovery_settings.robot
 │       ├── enable_analytics.robot
 │       ├── enable_document_builder.robot
 │       ├── enable_constraints_settings.robot
@@ -43,6 +45,8 @@ robot/rlm-base/
 | CCI Task | Python Class | Suite |
 |----------|-------------|-------|
 | `configure_revenue_settings` | `ConfigureRevenueSettings` | `tests/setup/configure_revenue_settings.robot` |
+| `configure_core_pricing_setup` | `ConfigureCorePricingSetup` | `tests/setup/configure_core_pricing_setup.robot` |
+| `configure_product_discovery_settings` | `ConfigureProductDiscoverySettings` | `tests/setup/configure_product_discovery_settings.robot` |
 | `enable_analytics_replication` | `EnableAnalyticsReplication` | `tests/setup/enable_analytics.robot` |
 | `enable_document_builder_toggle` | `EnableDocumentBuilderToggle` | `tests/setup/enable_document_builder.robot` |
 | `enable_constraints_settings` | `EnableConstraintsSettings` | `tests/setup/enable_constraints_settings.robot` |
@@ -92,49 +96,118 @@ session tokens from appearing in `log.html`.
 ## Shadow DOM Traversal
 
 Salesforce Lightning uses LWC synthetic shadow DOM. Standard Selenium
-locators cannot pierce shadow boundaries. The repo uses recursive
-JavaScript traversal:
+locators and XPath cannot pierce shadow boundaries. The repo uses recursive
+JavaScript traversal via two canonical helper functions shared as Robot
+variables (prepend them to `Execute JavaScript` blocks that need them).
 
-### Find single element
+### Shared helpers (Robot variables)
 
-```javascript
-function findInShadows(root, name) {
-    var all = root.querySelectorAll('*');
-    for (var i = 0; i < all.length; i++) {
-        if (all[i].matches && all[i].matches(name)) return all[i];
-        if (all[i].shadowRoot) {
-            var found = findInShadows(all[i].shadowRoot, name);
-            if (found) return found;
-        }
-    }
-    return null;
-}
+Define in `*** Variables ***` and prepend to JS blocks that need them:
+
+```robot
+# Find single element — depth-limited to 6 shadow levels
+${_JS_FIND_EL}    function findEl(root, sel, d) { if (d > 6) return null; var el = root.querySelector(sel); if (el) return el; var all = root.querySelectorAll('*'); for (var i=0;i<all.length;i++){if(all[i].shadowRoot){var f=findEl(all[i].shadowRoot,sel,d+1);if(f)return f;}} return null; }
+
+# Find all elements matching selector (used for options, pills, etc.)
+# Define inline in JS block as a named function expression — see examples below
 ```
 
-### Find all buttons (common variant)
+### findEl usage in Execute JavaScript
 
-```javascript
-function findAllButtons(root) {
-    var btns = [];
-    var all = root.querySelectorAll('*');
-    for (var i = 0; i < all.length; i++) {
-        if (all[i].tagName === 'BUTTON') btns.push(all[i]);
-        if (all[i].shadowRoot)
-            btns = btns.concat(findAllButtons(all[i].shadowRoot));
-    }
-    return btns;
-}
+```robot
+${result}=    Execute JavaScript
+...    ${_JS_FIND_EL}
+...    return (function(targetValue) {
+...        var el = findEl(document, 'lightning-combobox[data-id="myField"]', 0);
+...        if (!el) return 'not_found';
+...        ...
+...    })(arguments[0])
+...    ARGUMENTS    ${my_var}
 ```
 
-### Slot traversal (for LWC slots)
+### findAll (inline variant for collecting multiple elements)
 
 ```javascript
-if (all[i].tagName === 'SLOT') {
-    var assigned = all[i].assignedElements({flatten: true});
-    for (var j = 0; j < assigned.length; j++)
-        results = results.concat(deepQueryAll(assigned[j], selector));
+function findAll(root, sel, d, acc) {
+    if (d > 6) return;
+    root.querySelectorAll(sel).forEach(function(el){acc.push(el);});
+    root.querySelectorAll('*').forEach(function(el){if(el.shadowRoot)findAll(el.shadowRoot,sel,d+1,acc);});
 }
+var items = []; findAll(document, '[role="option"]', 0, items);
 ```
+
+### Lightning combobox interaction pattern
+
+Salesforce comboboxes have a 3-level shadow structure:
+`lightning-combobox` → shadowRoot → `lightning-base-combobox` → shadowRoot → `button[role="combobox"]`
+
+Options are `lightning-base-combobox-item[role="option"]` with text in their own shadow roots.
+
+```robot
+# Step 1: open the dropdown
+${open_result}=    Execute JavaScript
+...    ${_JS_FIND_EL}
+...    return (function() {
+...        var lc = findEl(document, 'lightning-combobox[data-id="myField"]', 0);
+...        if (!lc) return 'combobox_not_found';
+...        var lbc = lc.shadowRoot && lc.shadowRoot.querySelector('lightning-base-combobox');
+...        if (!lbc) return 'page_not_ready';
+...        var btn = lbc.shadowRoot && lbc.shadowRoot.querySelector('button[role="combobox"]');
+...        if (!btn) return 'page_not_ready';
+...        btn.click(); return 'opened';
+...    })()
+
+# Step 2: click the matching option
+${select_result}=    Execute JavaScript
+...    return (function(targetValue) {
+...        function findAll(root, sel, d, acc) {
+...            if (d > 6) return;
+...            root.querySelectorAll(sel).forEach(function(el){acc.push(el);});
+...            root.querySelectorAll('*').forEach(function(el){if(el.shadowRoot)findAll(el.shadowRoot,sel,d+1,acc);});
+...        }
+...        var opts = []; findAll(document, '[role="option"]', 0, opts);
+...        for (var i=0; i<opts.length; i++) {
+...            var text = opts[i].shadowRoot ? opts[i].shadowRoot.textContent.trim() : opts[i].textContent.trim();
+...            if (text === targetValue) { opts[i].click(); return 'clicked'; }
+...        }
+...        return 'not_found';
+...    })(arguments[0])
+...    ARGUMENTS    ${target_value}
+```
+
+### Toggle interaction (SetupToggles.robot)
+
+Lightning toggles nest two shadow levels:
+`lightning-input` → shadowRoot → `lightning-primitive-input-toggle` → shadowRoot → `input[role="switch"]`
+
+Plain checkboxes (`input[type="checkbox"]` in light DOM) also exist — check `lightning-input` first
+at each DOM depth; only fall back to plain inputs when no `lightning-input` is found at that depth.
+Always click the wrapping `<label>` (not the raw `<input>`) to trigger LWC save handlers:
+
+```javascript
+(pi.closest('label') || pi).click();
+```
+
+### Render timing — Wait Until Keyword Succeeds
+
+Some setup pages (e.g. CorePricingSetup) render LWC components slowly. Return a
+`'page_not_ready'` sentinel from JS when the expected element is absent, then use
+`Wait Until Keyword Succeeds` to retry:
+
+```robot
+${result}=    Wait Until Keyword Succeeds    20s    3s    _My Helper Keyword    ${arg}
+...
+
+_My Helper Keyword
+    [Arguments]    ${arg}
+    ${result}=    Execute JavaScript    ...
+    Should Not Be Equal    ${result}    page_not_ready
+    ...    msg=Page LWC components not yet rendered; retrying...
+    RETURN    ${result}
+```
+
+Return `'page_not_ready'` from JS for: element absent, inner shadow not yet rendered (`lbc_not_found`,
+`btn_not_found`), or no pills/content found at all.
 
 ---
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -185,8 +185,9 @@ indexes, and more.
 6. **UX templates** — edits in `templates/`, never `unpackaged/post_ux/`
 7. **Profile/object rules** — force-app profiles stay classAccesses-only
 8. **PRM Network email** — repo uses placeholder only; patch/revert in order
-9. **Edition flags** — `pde`, `trial`, `dev_ed` change PSL/PS assignments
-   and feature availability; verify `when:` guards match the target edition
+9. **Edition flags** — `pde`, `trial` change PSL/PS assignments and feature
+   availability; verify `when:` guards match the target edition. Developer Edition
+   detection is now automatic via `org_config.org_type`
 
 ---
 

--- a/cumulusci.yml
+++ b/cumulusci.yml
@@ -1929,6 +1929,15 @@ tasks:
       usage_rating_procedure: RLM Default Rating Discovery Procedure
       create_orders_flow: RLM_CreateOrdersFromQuote
 
+  configure_product_discovery_settings:
+    group: Revenue Lifecycle Management
+    description: "Set the Default Catalog in Product Discovery Settings to 'QuantumBit Software' (Robot test). Must run after QB product catalog data is loaded. Only relevant when qb=true."
+    class_path: tasks.rlm_configure_product_discovery_settings.ConfigureProductDiscoverySettings
+    options:
+      suite: robot/rlm-base/tests/setup/configure_product_discovery_settings.robot
+      outputdir: robot/rlm-base/results
+      default_catalog: QuantumBit Software
+
   reconfigure_pricing_discovery:
     group: Revenue Lifecycle Management
     description: "Reconfigure the autoproc Salesforce_Default_Pricing_Discovery_Procedure expression set: fix context definition, set rank and start date, and reactivate. When the autoproc expression set does not exist (e.g. tso=true orgs), activates the fallback RLM_DefaultPricingDiscoveryProcedure instead. Required before decision table refresh."
@@ -3244,6 +3253,9 @@ flows:
     steps:
       1:
         task: reconfigure_pricing_discovery
+      2:
+        task: configure_product_discovery_settings
+        when: project_config.project__custom__qb
 
   prepare_ramp_builder:
     group: Revenue Lifecycle Management

--- a/cumulusci.yml
+++ b/cumulusci.yml
@@ -113,7 +113,6 @@ project:
     tso: false                # Trialforce Source Org (set true when targeting a TSO scratch org)
     pde: false                # Partner Development Environment (DE, no qbrix or custom UX)
     trial: false              # Public Trial org (EE, no qbrix or custom UX)
-    dev_ed: false             # Developer Edition org — set true for non-standard dev orgs to suppress Enterprise-only PS assignments
     refresh: false            # Data refresh mode — skips insert steps during re-runs
 
     # ── Core Revenue Cloud Features ────────────────────────────────────────────
@@ -236,7 +235,8 @@ project:
       - EinsteinGPTPromptTemplateManager
 
     rlm_ai_ps_enterprise_api_names: &rlm_ai_ps_enterprise_api_names
-      # AI permission sets — Enterprise edition only (not assignable on Developer edition)
+      # AI permission sets — Enterprise edition only
+      # Automatically skipped on Developer Edition orgs via org_config.org_type detection
       - SalesCloudEinsteinAll
 
     rlm_tso_psl_api_names: &rlm_tso_psl_api_names
@@ -2696,7 +2696,7 @@ flows:
           api_names: *rlm_ai_ps_api_names
       3:
         task: assign_permission_sets
-        when: project_config.project__custom__einstein and not (project_config.project__custom__dev_ed or org_config.name in ["dev", "dev-sb0", "dev-r1"])
+        when: project_config.project__custom__einstein and org_config.org_type != "Developer Edition"
         options:
           api_names: *rlm_ai_ps_enterprise_api_names
       4:

--- a/cumulusci.yml
+++ b/cumulusci.yml
@@ -1929,6 +1929,15 @@ tasks:
       usage_rating_procedure: RLM Default Rating Discovery Procedure
       create_orders_flow: RLM_CreateOrdersFromQuote
 
+  configure_core_pricing_setup:
+    group: Revenue Lifecycle Management
+    description: "Configure Salesforce Pricing Setup (CorePricingSetup) page: set the default Pricing Procedure (Robot test). Must run after the Pricing Procedure expression set is deployed and activated."
+    class_path: tasks.rlm_configure_core_pricing_setup.ConfigureCorePricingSetup
+    options:
+      suite: robot/rlm-base/tests/setup/configure_core_pricing_setup.robot
+      outputdir: robot/rlm-base/results
+      pricing_procedure: RLM Revenue Management Default Pricing Procedure
+
   configure_product_discovery_settings:
     group: Revenue Lifecycle Management
     description: "Set the Default Catalog in Product Discovery Settings to 'QuantumBit Software' (Robot test). Must run after QB product catalog data is loaded. Only relevant when qb=true."
@@ -3247,6 +3256,8 @@ flows:
         when: "project_config.project__custom__quantumbit or project_config.project__custom__tso"
         options:
           manage_assets_flow: RLM_ARC_Assets
+      3:
+        task: configure_core_pricing_setup
 
   prepare_pricing_discovery:
     group: Revenue Lifecycle Management

--- a/robot/rlm-base/resources/SetupToggles.robot
+++ b/robot/rlm-base/resources/SetupToggles.robot
@@ -11,6 +11,10 @@ Library           ${EXECDIR}/robot/rlm-base/resources/ChromeOptionsHelper.py
 # Default timeout for waiting for setup page and toggle elements
 ${SETUP_PAGE_LOAD_TIMEOUT}    20s
 ${TOGGLE_CLICK_TIMEOUT}       10s
+# Shared JS helper — pierces lightning-input → lightning-primitive-input-toggle → input.
+# Prepended to both _EnsureShadowDOMToggle and _VerifyToggleViaShadowDOM JS blocks so
+# the implementation lives in one place.
+${_JS_GET_INPUT_FROM_TOGGLE}    function getInputFromToggle(li){if(!li.shadowRoot)return null;var inp=li.shadowRoot.querySelector('input[role="switch"],input[type="checkbox"]');if(inp)return inp;var n=li.shadowRoot.querySelector('lightning-primitive-input-toggle');if(n&&n.shadowRoot)return n.shadowRoot.querySelector('input[role="switch"],input[type="checkbox"]');return null;}
 
 *** Keywords ***
 Get Authenticated Setup Page Url
@@ -150,6 +154,7 @@ _VerifyToggleViaShadowDOM
     ...    lightning-input toggle, reads the checked state from the shadow root.
     [Arguments]    ${label}    ${expected_on}=True
     ${state}=    Execute Javascript
+    ...    ${_JS_GET_INPUT_FROM_TOGGLE}
     ...    return (function(label) {
     ...        var walker = document.createTreeWalker(document.body, NodeFilter.SHOW_TEXT);
     ...        var headingEl = null;
@@ -165,13 +170,15 @@ _VerifyToggleViaShadowDOM
     ...            section = section.parentElement;
     ...            if (!section || section === document.body) return 'section_not_found';
     ...            var toggles = section.querySelectorAll('lightning-input');
-    ...            for (var j = 0; j < toggles.length; j++) {
-    ...                if (!toggles[j].shadowRoot) continue;
-    ...                var inp = toggles[j].shadowRoot.querySelector(
-    ...                    'input[role="switch"],input[type="checkbox"]');
-    ...                if (!inp) continue;
-    ...                return inp.checked ? 'on' : 'off';
+    ...            if (toggles.length > 0) {
+    ...                for (var j = 0; j < toggles.length; j++) {
+    ...                    var inp = getInputFromToggle(toggles[j]);
+    ...                    if (inp) return inp.checked ? 'on' : 'off';
+    ...                }
+    ...                continue;
     ...            }
+    ...            var plainInputs = section.querySelectorAll('input[type="checkbox"],input[role="switch"]');
+    ...            if (plainInputs.length > 0) return plainInputs[0].checked ? 'on' : 'off';
     ...        }
     ...        return 'not_found';
     ...    })(arguments[0])
@@ -286,13 +293,16 @@ _EnsureDocumentBuilderToggle
     Sleep    3s    reason=Allow toggle state to update after JS click
 
 _EnsureShadowDOMToggle
-    [Documentation]    For LWC shadow-DOM toggles where aria-checked/checked are inaccessible.
-    ...    Uses pure JavaScript to find the label heading, walk up to the nearest
-    ...    ancestor that contains a lightning-input toggle, pierce its shadow root,
-    ...    check the input's checked state, and click only if needed.
-    ...    This avoids XPath-based section scoping which cannot see into shadow DOM.
+    [Documentation]    For LWC toggles where aria-checked/checked attributes are inaccessible.
+    ...    Uses pure JavaScript to find the label heading via a text walker, then walks up
+    ...    ancestor elements looking for the toggle at the narrowest possible scope.
+    ...    At each depth, lightning-input elements are checked first (piercing nested shadow
+    ...    roots via getInputFromToggle). Plain input[type="checkbox"] (light DOM, e.g.
+    ...    MetadataPreference) are only checked at depths where no lightning-input exists,
+    ...    preventing cross-row interference in cards that contain both toggle types.
     [Arguments]    ${label}    ${toggle_locator}    ${turn_on}=True
     ${result}=    Execute Javascript
+    ...    ${_JS_GET_INPUT_FROM_TOGGLE}
     ...    return (function(label, shouldEnable) {
     ...        var walker = document.createTreeWalker(document.body, NodeFilter.SHOW_TEXT);
     ...        var headingEl = null;
@@ -308,14 +318,23 @@ _EnsureShadowDOMToggle
     ...            section = section.parentElement;
     ...            if (!section || section === document.body) return 'section_not_found';
     ...            var toggles = section.querySelectorAll('lightning-input');
-    ...            for (var j = 0; j < toggles.length; j++) {
-    ...                if (!toggles[j].shadowRoot) continue;
-    ...                var inp = toggles[j].shadowRoot.querySelector(
-    ...                    'input[role="switch"],input[type="checkbox"]');
-    ...                if (!inp) continue;
-    ...                if (shouldEnable && inp.checked) return 'already_enabled';
-    ...                if (!shouldEnable && !inp.checked) return 'already_disabled';
-    ...                inp.click();
+    ...            if (toggles.length > 0) {
+    ...                for (var j = 0; j < toggles.length; j++) {
+    ...                    var inp = getInputFromToggle(toggles[j]);
+    ...                    if (!inp) continue;
+    ...                    if (shouldEnable && inp.checked) return 'already_enabled';
+    ...                    if (!shouldEnable && !inp.checked) return 'already_disabled';
+    ...                    inp.click();
+    ...                    return 'clicked';
+    ...                }
+    ...                continue;
+    ...            }
+    ...            var plainInputs = section.querySelectorAll('input[type="checkbox"],input[role="switch"]');
+    ...            if (plainInputs.length > 0) {
+    ...                var pi = plainInputs[0];
+    ...                if (shouldEnable && pi.checked) return 'already_enabled';
+    ...                if (!shouldEnable && !pi.checked) return 'already_disabled';
+    ...                (pi.closest('label') || pi).click();
     ...                return 'clicked';
     ...            }
     ...        }

--- a/robot/rlm-base/resources/SetupToggles.robot
+++ b/robot/rlm-base/resources/SetupToggles.robot
@@ -324,7 +324,7 @@ _EnsureShadowDOMToggle
     ...                    if (!inp) continue;
     ...                    if (shouldEnable && inp.checked) return 'already_enabled';
     ...                    if (!shouldEnable && !inp.checked) return 'already_disabled';
-    ...                    inp.click();
+    ...                    (inp.closest('label') || inp).click();
     ...                    return 'clicked';
     ...                }
     ...                continue;

--- a/robot/rlm-base/tests/setup/README.md
+++ b/robot/rlm-base/tests/setup/README.md
@@ -6,7 +6,7 @@ Robot Framework tests that configure Salesforce Revenue Settings page options th
 
 | Suite | CCI Task | Description |
 |-------|----------|-------------|
-| `enable_document_builder.robot` | `enable_document_builder_toggle` | Enable Document Builder on Revenue Settings, Document Templates Export and Design Document Templates in Salesforce on General Settings (Document Generation) |
+| `enable_document_builder.robot` | `enable_document_builder_toggle` | Enable Document Builder on Revenue Settings, then Design Document Templates in Salesforce and Document Templates Export on General Settings (Design must run before Export — it is a prerequisite) |
 | `enable_constraints_settings.robot` | `enable_constraints_settings` | Set Default Transaction Type, Asset Context picklist, and enable Constraints Engine toggle |
 | `configure_revenue_settings.robot` | `configure_revenue_settings` | Set Pricing Procedure, Usage Rating Procedure, enable Instant Pricing toggle, set Create Orders Flow |
 

--- a/robot/rlm-base/tests/setup/README.md
+++ b/robot/rlm-base/tests/setup/README.md
@@ -1,6 +1,6 @@
 # Setup Automation (Robot Framework)
 
-Robot Framework tests that configure Salesforce Revenue Settings page options that cannot be set via Metadata API. These include toggles, picklist selections, and text inputs on the Revenue Settings Lightning Setup page.
+Robot Framework tests that configure Salesforce Setup page options that cannot be set via Metadata API. These include toggles, picklist selections, and text inputs across multiple Lightning Setup pages (Revenue Settings, General Settings, Pricing Setup, and more).
 
 ## Test Suites
 
@@ -9,6 +9,7 @@ Robot Framework tests that configure Salesforce Revenue Settings page options th
 | `enable_document_builder.robot` | `enable_document_builder_toggle` | Enable Document Builder on Revenue Settings, then Design Document Templates in Salesforce and Document Templates Export on General Settings (Design must run before Export — it is a prerequisite) |
 | `enable_constraints_settings.robot` | `enable_constraints_settings` | Set Default Transaction Type, Asset Context picklist, and enable Constraints Engine toggle |
 | `configure_revenue_settings.robot` | `configure_revenue_settings` | Set Pricing Procedure, Usage Rating Procedure, enable Instant Pricing toggle, set Create Orders Flow |
+| `configure_core_pricing_setup.robot` | `configure_core_pricing_setup` | Set default Pricing Procedure on Salesforce Pricing Setup page (CorePricingSetup) |
 
 ## Prerequisites
 
@@ -32,6 +33,7 @@ From the repo root. **Recommended:** pass an org alias so the test uses `sf org 
 cci task run enable_document_builder_toggle --org my-scratch
 cci task run enable_constraints_settings --org my-scratch
 cci task run configure_revenue_settings --org my-scratch
+cci task run configure_core_pricing_setup --org my-scratch
 
 # As part of the full org build
 cci flow run prepare_rlm_org --org my-scratch
@@ -48,9 +50,12 @@ robot -v ORG_ALIAS:my-scratch robot/rlm-base/tests/setup/enable_constraints_sett
 
 # Revenue Settings (Pricing, Usage Rating, Instant Pricing, Create Orders Flow)
 robot -v ORG_ALIAS:my-scratch robot/rlm-base/tests/setup/configure_revenue_settings.robot
+
+# Salesforce Pricing Setup (CorePricingSetup default Pricing Procedure)
+robot -v ORG_ALIAS:my-scratch robot/rlm-base/tests/setup/configure_core_pricing_setup.robot
 ```
 
-If you don't set `ORG_ALIAS` and the browser opens on a Salesforce login page, log in within the configured wait (default 90s); the test will then reload the Revenue Settings page.
+If you don't set `ORG_ALIAS` and the browser opens on a Salesforce login page, log in within the configured wait (default 90s); the test will then reload the target Setup page.
 
 ## Variables
 
@@ -85,6 +90,12 @@ If you don't set `ORG_ALIAS` and the browser opens on a Salesforce login page, l
 | `PRICING_PROCEDURE` | Default pricing procedure name (default: "RLM Revenue Management Default Pricing Procedure"). |
 | `USAGE_RATING_PROCEDURE` | Default usage rating procedure name (default: "RLM Default Rating Discovery Procedure"). |
 | `CREATE_ORDERS_FLOW` | API name of the Create Orders from Quotes flow (default: "RLM_CreateOrdersFromQuote"). |
+
+### configure_core_pricing_setup.robot
+
+| Variable | Description |
+|----------|-------------|
+| `PRICING_PROCEDURE` | Default pricing procedure name for CorePricingSetup (default: "RLM Revenue Management Default Pricing Procedure"). |
 
 ## Implementation Notes
 
@@ -127,7 +138,8 @@ All tests detect current state before making changes:
 |------|------|------|
 | `enable_document_builder_toggle` | `prepare_docgen` | Step 2 |
 | `enable_constraints_settings` | `prepare_constraints` | Step 5 (when `constraints_data` is true) |
-| `configure_revenue_settings` | `prepare_rlm_org` | Step 27 |
+| `configure_revenue_settings` | `prepare_rlm_org` | Step 24 (via `prepare_revenue_settings`) |
+| `configure_core_pricing_setup` | `prepare_rlm_org` | Step 24 (via `prepare_revenue_settings`, step 3) |
 
 ## Generated Output
 

--- a/robot/rlm-base/tests/setup/README.md
+++ b/robot/rlm-base/tests/setup/README.md
@@ -10,6 +10,7 @@ Robot Framework tests that configure Salesforce Setup page options that cannot b
 | `enable_constraints_settings.robot` | `enable_constraints_settings` | Set Default Transaction Type, Asset Context picklist, and enable Constraints Engine toggle |
 | `configure_revenue_settings.robot` | `configure_revenue_settings` | Set Pricing Procedure, Usage Rating Procedure, enable Instant Pricing toggle, set Create Orders Flow |
 | `configure_core_pricing_setup.robot` | `configure_core_pricing_setup` | Set default Pricing Procedure on Salesforce Pricing Setup page (CorePricingSetup) |
+| `configure_product_discovery_settings.robot` | `configure_product_discovery_settings` | Set the Default Catalog on Product Discovery Settings (`/lightning/setup/ProductDiscoverySettings/home`) via JS shadow-DOM traversal; gated by `project__custom__qb` in `prepare_pricing_discovery` |
 
 ## Prerequisites
 
@@ -34,6 +35,7 @@ cci task run enable_document_builder_toggle --org my-scratch
 cci task run enable_constraints_settings --org my-scratch
 cci task run configure_revenue_settings --org my-scratch
 cci task run configure_core_pricing_setup --org my-scratch
+cci task run configure_product_discovery_settings --org my-scratch
 
 # As part of the full org build
 cci flow run prepare_rlm_org --org my-scratch
@@ -53,6 +55,9 @@ robot -v ORG_ALIAS:my-scratch robot/rlm-base/tests/setup/configure_revenue_setti
 
 # Salesforce Pricing Setup (CorePricingSetup default Pricing Procedure)
 robot -v ORG_ALIAS:my-scratch robot/rlm-base/tests/setup/configure_core_pricing_setup.robot
+
+# Product Discovery Settings (Default Catalog)
+robot -v ORG_ALIAS:my-scratch robot/rlm-base/tests/setup/configure_product_discovery_settings.robot
 ```
 
 If you don't set `ORG_ALIAS` and the browser opens on a Salesforce login page, log in within the configured wait (default 90s); the test will then reload the target Setup page.
@@ -97,6 +102,12 @@ If you don't set `ORG_ALIAS` and the browser opens on a Salesforce login page, l
 |----------|-------------|
 | `PRICING_PROCEDURE` | Default pricing procedure name for CorePricingSetup (default: "RLM Revenue Management Default Pricing Procedure"). |
 
+### configure_product_discovery_settings.robot
+
+| Variable | Description |
+|----------|-------------|
+| `DEFAULT_CATALOG` | Catalog name to set as the Default Catalog on Product Discovery Settings (default: "QuantumBit Software"). |
+
 ## Implementation Notes
 
 ### Shadow DOM Toggles
@@ -140,6 +151,7 @@ All tests detect current state before making changes:
 | `enable_constraints_settings` | `prepare_constraints` | Step 5 (when `constraints_data` is true) |
 | `configure_revenue_settings` | `prepare_rlm_org` | Step 24 (via `prepare_revenue_settings`) |
 | `configure_core_pricing_setup` | `prepare_rlm_org` | Step 24 (via `prepare_revenue_settings`, step 3) |
+| `configure_product_discovery_settings` | `prepare_rlm_org` | Via `prepare_pricing_discovery`, step 2 (gated by `project__custom__qb`) |
 
 ## Generated Output
 

--- a/robot/rlm-base/tests/setup/configure_core_pricing_setup.robot
+++ b/robot/rlm-base/tests/setup/configure_core_pricing_setup.robot
@@ -1,0 +1,128 @@
+*** Settings ***
+Documentation     Configure Salesforce Pricing Setup page (CorePricingSetup): set the default
+...               Pricing Procedure. Must run after all data and metadata has been deployed
+...               (the Pricing Procedure expression set must be active) and before any
+...               automated pricing transactions are tested.
+...
+...               The "Select a Pricing Procedure" combobox (lightning-combobox.procedure-combobox)
+...               is present when no value is set. After selection it is replaced by a pill that
+...               persists across reloads — no explicit Save button is needed.
+Resource          ../../resources/SetupToggles.robot
+Suite Setup       Open Browser For Setup
+Suite Teardown    Close Browser After Setup
+
+*** Variables ***
+${ORG_ALIAS}              ${EMPTY}
+${MANUAL_LOGIN_WAIT}      90s
+${PRICING_PROCEDURE}      RLM Revenue Management Default Pricing Procedure
+# Shared shadow-DOM traversal helper prepended to each Execute JavaScript block.
+${_JS_FIND_EL}    function findEl(root, sel, d) { if (d > 6) return null; var el = root.querySelector(sel); if (el) return el; var all = root.querySelectorAll('*'); for (var i=0;i<all.length;i++){if(all[i].shadowRoot){var f=findEl(all[i].shadowRoot,sel,d+1);if(f)return f;}} return null; }
+
+*** Test Cases ***
+Configure Core Pricing Setup
+    [Documentation]    Navigates to Salesforce Pricing Setup (CorePricingSetup) and sets
+    ...    the default Pricing Procedure if it is not already configured. Reloads the page
+    ...    after setting to confirm server-side persistence.
+    Open Setup Page    /lightning/setup/CorePricingSetup/home
+    Set Core Pricing Procedure    ${PRICING_PROCEDURE}
+    Capture Page Screenshot
+    # Reload and re-verify to confirm the value was saved server-side
+    Open Setup Page    /lightning/setup/CorePricingSetup/home
+    ${verified}=    Execute JavaScript
+    ...    return (function(targetValue) {
+    ...        var pills = [];
+    ...        (function findAll(root, d) {
+    ...            if (d > 6) return;
+    ...            root.querySelectorAll('.slds-pill__label').forEach(function(el){pills.push(el);});
+    ...            root.querySelectorAll('*').forEach(function(el){if(el.shadowRoot)findAll(el.shadowRoot,d+1);});
+    ...        })(document, 0);
+    ...        var pillValues = [];
+    ...        for (var i=0; i<pills.length; i++) {
+    ...            var pillValue = pills[i].textContent.trim();
+    ...            pillValues.push(pillValue);
+    ...            if (pillValue === targetValue) return targetValue;
+    ...        }
+    ...        if (pillValues.length > 0) return pillValues.join(', ');
+    ...        return 'not_set';
+    ...    })(arguments[0])
+    ...    ARGUMENTS    ${PRICING_PROCEDURE}
+    Should Be Equal    ${verified}    ${PRICING_PROCEDURE}
+    ...    msg=Pricing Procedure not persisted after page reload: expected "${PRICING_PROCEDURE}", got "${verified}"
+    Log    CorePricingSetup: Pricing Procedure confirmed as "${PRICING_PROCEDURE}" after reload.
+
+*** Keywords ***
+Set Core Pricing Procedure
+    [Documentation]    Sets the "Select a Pricing Procedure" combobox on CorePricingSetup
+    ...    via JavaScript, piercing nested LWC shadow DOMs
+    ...    (lightning-combobox.procedure-combobox > lightning-base-combobox > button, with
+    ...    option text read from lightning-base-combobox-item shadow roots).
+    ...
+    ...    When a value is already set, lightning-combobox is replaced by a pill — this
+    ...    keyword detects that state and skips if the pill matches the target value.
+    [Arguments]    ${target_value}
+    # Retry until LWC components have rendered (page_not_ready causes retry)
+    ${open_result}=    Wait Until Keyword Succeeds    20s    3s
+    ...    _Open Pricing Procedure Combobox    ${target_value}
+    IF    "${open_result}" == "already_set"
+        Log    Pricing Procedure already set to "${target_value}". No change needed.
+        RETURN
+    END
+    Should Be Equal    ${open_result}    opened
+    ...    msg=Could not open Pricing Procedure combobox: ${open_result}
+    Sleep    1s    reason=Allow dropdown options to populate
+    # Click the matching option (text is inside each option's shadow root)
+    ${select_result}=    Execute JavaScript
+    ...    return (function(targetValue) {
+    ...        function findAll(root, sel, d, acc) {
+    ...            if (d > 6) return;
+    ...            root.querySelectorAll(sel).forEach(function(el){acc.push(el);});
+    ...            root.querySelectorAll('*').forEach(function(el){if(el.shadowRoot)findAll(el.shadowRoot,sel,d+1,acc);});
+    ...        }
+    ...        var opts = []; findAll(document, '[role="option"]', 0, opts);
+    ...        for (var i=0; i<opts.length; i++) {
+    ...            var text = opts[i].shadowRoot ? opts[i].shadowRoot.textContent.trim() : opts[i].textContent.trim();
+    ...            if (text === targetValue) { opts[i].click(); return 'clicked'; }
+    ...        }
+    ...        return 'not_found:[' + opts.map(function(o){return o.shadowRoot ? o.shadowRoot.textContent.trim() : o.textContent.trim();}).join(',') + ']';
+    ...    })(arguments[0])
+    ...    ARGUMENTS    ${target_value}
+    Should Be Equal    ${select_result}    clicked
+    ...    msg=Option "${target_value}" not found in dropdown. ${select_result}
+    Sleep    2s    reason=Allow selection to auto-save
+    Log    Pricing Procedure set to "${target_value}".
+
+_Open Pricing Procedure Combobox
+    [Documentation]    Runs the state-check JS for Set Core Pricing Procedure.
+    ...    Returns 'opened' (combobox clicked open), 'already_set' (correct pill present),
+    ...    or a wrong_value:... string (wrong pill). Fails with page_not_ready when the
+    ...    combobox or its inner shadow elements are not yet rendered, or when no pill is
+    ...    found — triggering Wait Until Keyword Succeeds to retry.
+    [Arguments]    ${target_value}
+    ${result}=    Execute JavaScript
+    ...    ${_JS_FIND_EL}
+    ...    return (function(targetValue) {
+    ...        var lc = findEl(document, 'lightning-combobox.procedure-combobox', 0);
+    ...        if (lc) {
+    ...            var lbc = lc.shadowRoot && lc.shadowRoot.querySelector('lightning-base-combobox');
+    ...            if (!lbc) return 'page_not_ready';
+    ...            var btn = lbc.shadowRoot && lbc.shadowRoot.querySelector('button[role="combobox"]');
+    ...            if (!btn) return 'page_not_ready';
+    ...            btn.click();
+    ...            return 'opened';
+    ...        }
+    ...        var pills = [];
+    ...        (function findAll(root, d) {
+    ...            if (d > 6) return;
+    ...            root.querySelectorAll('.slds-pill__label').forEach(function(el){pills.push(el);});
+    ...            root.querySelectorAll('*').forEach(function(el){if(el.shadowRoot)findAll(el.shadowRoot,d+1);});
+    ...        })(document, 0);
+    ...        for (var i=0; i<pills.length; i++) {
+    ...            if (pills[i].textContent.trim() === targetValue) return 'already_set';
+    ...        }
+    ...        if (pills.length === 0) return 'page_not_ready';
+    ...        return 'wrong_value:' + pills.map(function(p){return p.textContent.trim();}).join('|');
+    ...    })(arguments[0])
+    ...    ARGUMENTS    ${target_value}
+    Should Not Be Equal    ${result}    page_not_ready
+    ...    msg=Page LWC components not yet rendered; retrying...
+    RETURN    ${result}

--- a/robot/rlm-base/tests/setup/configure_product_discovery_settings.robot
+++ b/robot/rlm-base/tests/setup/configure_product_discovery_settings.robot
@@ -1,0 +1,131 @@
+*** Settings ***
+Documentation     Configure the Product Discovery Settings page: set the Default Catalog
+...               to the specified catalog name. Must run after QB product catalog data
+...               has been loaded (insert_quantumbit_pcm_data) so the catalog record
+...               exists to be selected.
+...
+...               The "Select Default Catalog" field is a Lightning combobox. Selecting a
+...               value auto-saves and triggers a "Default Catalog Updated" toast — no
+...               explicit Save button is needed.
+Resource          ../../resources/SetupToggles.robot
+Suite Setup       Open Browser For Setup
+Suite Teardown    Close Browser After Setup
+
+*** Variables ***
+${ORG_ALIAS}                    ${EMPTY}
+${PRODUCT_DISCOVERY_URL}        ${EMPTY}
+${MANUAL_LOGIN_WAIT}            90s
+${DEFAULT_CATALOG}              QuantumBit Software
+# Shared shadow-DOM traversal helper prepended to Execute JavaScript blocks that need findEl.
+${_JS_FIND_EL}    function findEl(root, sel, d) { if (d > 6) return null; var el = root.querySelector(sel); if (el) return el; var all = root.querySelectorAll('*'); for (var i=0;i<all.length;i++){if(all[i].shadowRoot){var f=findEl(all[i].shadowRoot,sel,d+1);if(f)return f;}} return null; }
+
+*** Test Cases ***
+Configure Product Discovery Default Catalog
+    [Documentation]    Navigates to Product Discovery Settings and sets the Default Catalog
+    ...    to the value specified by ${DEFAULT_CATALOG}. Skips if the catalog is already set
+    ...    to the correct value. Reloads the page after setting to confirm server-side persistence.
+    Open Product Discovery Settings Page
+    Set Default Catalog    ${DEFAULT_CATALOG}
+    Dismiss Toast If Present
+    Capture Page Screenshot
+    # Reload and re-verify to confirm the value was saved server-side
+    Open Product Discovery Settings Page
+    ${verified}=    Execute JavaScript
+    ...    ${_JS_FIND_EL}
+    ...    return findEl(document, '[data-id="selectedCatalog"]', 0)?.textContent.trim() || 'not_set'
+    Should Be Equal    ${verified}    ${DEFAULT_CATALOG}
+    ...    msg=Default Catalog not persisted after page reload: expected "${DEFAULT_CATALOG}", got "${verified}"
+    Log    Product Discovery Settings: Default Catalog confirmed as "${DEFAULT_CATALOG}" after reload.
+
+*** Keywords ***
+Open Product Discovery Settings Page
+    [Documentation]    Opens the Product Discovery Settings setup page using sf org open
+    ...    when ORG_ALIAS is set, or falls back to PRODUCT_DISCOVERY_URL.
+    ${path}=    Set Variable    /lightning/setup/ProductDiscoverySettings/home
+    IF    """${ORG_ALIAS}""" != ""
+        Open Setup Page    ${path}
+    ELSE IF    """${PRODUCT_DISCOVERY_URL}""" != ""
+        Open Setup Page    url=${PRODUCT_DISCOVERY_URL}
+    ELSE
+        Fail    msg=Set ORG_ALIAS (e.g. -v ORG_ALIAS:my-scratch) or PRODUCT_DISCOVERY_URL
+    END
+
+Set Default Catalog
+    [Documentation]    Sets the "Select Default Catalog" combobox via JavaScript, piercing the
+    ...    nested LWC shadow DOMs (lightning-combobox → lightning-base-combobox → button, with
+    ...    option text read from lightning-base-combobox-item shadow roots). Clears any existing
+    ...    selection first if a different catalog is already selected. Auto-saves on selection.
+    [Arguments]    ${target_value}
+    # Step 1: check current state; clear wrong selection; open dropdown
+    ${open_result}=    Execute JavaScript
+    ...    ${_JS_FIND_EL}
+    ...    return (function(targetValue) {
+    ...        var selEl = findEl(document, '[data-id="selectedCatalog"]', 0);
+    ...        if (selEl && selEl.textContent.trim() === targetValue) return 'already_set';
+    ...        if (selEl) {
+    ...            var removeBtn = findEl(document, 'button.slds-pill__remove', 0);
+    ...            if (!removeBtn) return 'remove_btn_not_found';
+    ...            removeBtn.click();
+    ...            return 'cleared';
+    ...        }
+    ...        var lc = findEl(document, 'lightning-combobox[data-id="defaultCatalog"]', 0);
+    ...        if (!lc) return 'combobox_not_found';
+    ...        var lbc = lc.shadowRoot && lc.shadowRoot.querySelector('lightning-base-combobox');
+    ...        if (!lbc) return 'lbc_not_found';
+    ...        var btn = lbc.shadowRoot && lbc.shadowRoot.querySelector('button[role="combobox"]');
+    ...        if (!btn) return 'btn_not_found';
+    ...        btn.click();
+    ...        return 'opened';
+    ...    })(arguments[0])
+    ...    ARGUMENTS    ${target_value}
+    IF    "${open_result}" == "already_set"
+        Log    Default Catalog already set to "${target_value}". No change needed.
+        RETURN
+    END
+    # If a selection was cleared, wait for the combobox to reappear then re-open it
+    IF    "${open_result}" == "cleared"
+        Sleep    2s    reason=Allow pill removal to complete and combobox to reappear
+        ${open_result}=    Execute JavaScript
+        ...    ${_JS_FIND_EL}
+        ...    return (function() {
+        ...        var lc = findEl(document, 'lightning-combobox[data-id="defaultCatalog"]', 0);
+        ...        if (!lc) return 'combobox_not_found';
+        ...        var lbc = lc.shadowRoot && lc.shadowRoot.querySelector('lightning-base-combobox');
+        ...        if (!lbc) return 'lbc_not_found';
+        ...        var btn = lbc.shadowRoot && lbc.shadowRoot.querySelector('button[role="combobox"]');
+        ...        if (!btn) return 'btn_not_found';
+        ...        btn.click();
+        ...        return 'opened';
+        ...    })()
+    END
+    Should Be Equal    ${open_result}    opened    msg=Could not prepare/open Default Catalog combobox: ${open_result}
+    Sleep    1s    reason=Allow dropdown options to populate
+    # Step 2: click the matching option (text is inside each option's shadow root)
+    ${select_result}=    Execute JavaScript
+    ...    return (function(targetValue) {
+    ...        function findAll(root, sel, d, acc) {
+    ...            if (d > 6) return;
+    ...            root.querySelectorAll(sel).forEach(function(el){acc.push(el);});
+    ...            root.querySelectorAll('*').forEach(function(el){if(el.shadowRoot)findAll(el.shadowRoot,sel,d+1,acc);});
+    ...        }
+    ...        var opts = []; findAll(document, '[role="option"]', 0, opts);
+    ...        for (var i=0;i<opts.length;i++) {
+    ...            var text = opts[i].shadowRoot ? opts[i].shadowRoot.textContent.trim() : '';
+    ...            if (text === targetValue) { opts[i].click(); return 'clicked'; }
+    ...        }
+    ...        return 'not_found:[' + opts.map(function(o){return o.shadowRoot?o.shadowRoot.textContent.trim():'?';}).join(',') + ']';
+    ...    })(arguments[0])
+    ...    ARGUMENTS    ${target_value}
+    Should Be Equal    ${select_result}    clicked
+    ...    msg=Option "${target_value}" not found in dropdown. ${select_result}
+    Sleep    2s    reason=Allow selection to auto-save
+    Log    Default Catalog set to "${target_value}".
+
+Dismiss Toast If Present
+    [Documentation]    Clicks the close button on any visible Salesforce toast messages.
+    ${close_btns}=    Get WebElements    xpath=//button[contains(@class, 'toastClose') or (@title='Close' and ancestor::*[contains(@class, 'toast')])]
+    FOR    ${btn}    IN    @{close_btns}
+        ${visible}=    Run Keyword And Return Status    Element Should Be Visible    ${btn}
+        Run Keyword If    ${visible}    Click Element    ${btn}
+    END
+    Sleep    0.5s

--- a/robot/rlm-base/tests/setup/configure_product_discovery_settings.robot
+++ b/robot/rlm-base/tests/setup/configure_product_discovery_settings.robot
@@ -55,29 +55,13 @@ Set Default Catalog
     ...    nested LWC shadow DOMs (lightning-combobox → lightning-base-combobox → button, with
     ...    option text read from lightning-base-combobox-item shadow roots). Clears any existing
     ...    selection first if a different catalog is already selected. Auto-saves on selection.
+    ...
+    ...    Uses Wait Until Keyword Succeeds to retry when the combobox is not yet rendered —
+    ...    reconfigure_pricing_discovery triggers background processing that delays LWC render.
     [Arguments]    ${target_value}
-    # Step 1: check current state; clear wrong selection; open dropdown
-    ${open_result}=    Execute JavaScript
-    ...    ${_JS_FIND_EL}
-    ...    return (function(targetValue) {
-    ...        var selEl = findEl(document, '[data-id="selectedCatalog"]', 0);
-    ...        if (selEl && selEl.textContent.trim() === targetValue) return 'already_set';
-    ...        if (selEl) {
-    ...            var removeBtn = findEl(document, 'button.slds-pill__remove', 0);
-    ...            if (!removeBtn) return 'remove_btn_not_found';
-    ...            removeBtn.click();
-    ...            return 'cleared';
-    ...        }
-    ...        var lc = findEl(document, 'lightning-combobox[data-id="defaultCatalog"]', 0);
-    ...        if (!lc) return 'combobox_not_found';
-    ...        var lbc = lc.shadowRoot && lc.shadowRoot.querySelector('lightning-base-combobox');
-    ...        if (!lbc) return 'lbc_not_found';
-    ...        var btn = lbc.shadowRoot && lbc.shadowRoot.querySelector('button[role="combobox"]');
-    ...        if (!btn) return 'btn_not_found';
-    ...        btn.click();
-    ...        return 'opened';
-    ...    })(arguments[0])
-    ...    ARGUMENTS    ${target_value}
+    # Step 1: check current state; clear wrong selection; open dropdown (retry on combobox_not_found)
+    ${open_result}=    Wait Until Keyword Succeeds    30s    3s
+    ...    _Open Default Catalog Combobox    ${target_value}
     IF    "${open_result}" == "already_set"
         Log    Default Catalog already set to "${target_value}". No change needed.
         RETURN
@@ -120,6 +104,38 @@ Set Default Catalog
     ...    msg=Option "${target_value}" not found in dropdown. ${select_result}
     Sleep    2s    reason=Allow selection to auto-save
     Log    Default Catalog set to "${target_value}".
+
+_Open Default Catalog Combobox
+    [Documentation]    Runs the state-check JS for Set Default Catalog.
+    ...    Returns 'opened' (combobox clicked open), 'already_set' (correct value present),
+    ...    'cleared' (wrong pill removed), or an error string. Fails with a retry-triggering
+    ...    message when 'combobox_not_found' — Salesforce background processing after
+    ...    reconfigure_pricing_discovery delays LWC render; Wait Until Keyword Succeeds retries.
+    [Arguments]    ${target_value}
+    ${result}=    Execute JavaScript
+    ...    ${_JS_FIND_EL}
+    ...    return (function(targetValue) {
+    ...        var selEl = findEl(document, '[data-id="selectedCatalog"]', 0);
+    ...        if (selEl && selEl.textContent.trim() === targetValue) return 'already_set';
+    ...        if (selEl) {
+    ...            var removeBtn = findEl(document, 'button.slds-pill__remove', 0);
+    ...            if (!removeBtn) return 'remove_btn_not_found';
+    ...            removeBtn.click();
+    ...            return 'cleared';
+    ...        }
+    ...        var lc = findEl(document, 'lightning-combobox[data-id="defaultCatalog"]', 0);
+    ...        if (!lc) return 'combobox_not_found';
+    ...        var lbc = lc.shadowRoot && lc.shadowRoot.querySelector('lightning-base-combobox');
+    ...        if (!lbc) return 'lbc_not_found';
+    ...        var btn = lbc.shadowRoot && lbc.shadowRoot.querySelector('button[role="combobox"]');
+    ...        if (!btn) return 'btn_not_found';
+    ...        btn.click();
+    ...        return 'opened';
+    ...    })(arguments[0])
+    ...    ARGUMENTS    ${target_value}
+    Should Not Be Equal    ${result}    combobox_not_found
+    ...    msg=Product Discovery combobox not yet rendered; retrying...
+    RETURN    ${result}
 
 Dismiss Toast If Present
     [Documentation]    Clicks the close button on any visible Salesforce toast messages.

--- a/robot/rlm-base/tests/setup/configure_product_discovery_settings.robot
+++ b/robot/rlm-base/tests/setup/configure_product_discovery_settings.robot
@@ -100,17 +100,19 @@ _Open Default Catalog Dropdown
     [Documentation]    Re-opens the Default Catalog combobox after a pill clear. Used by
     ...    Set Default Catalog when the cleared-path needs to wait for the LWC to re-render
     ...    the combobox button (pill removal is asynchronous and can take longer than the
-    ...    fixed sleep). Fails with a retry-triggering message on any lookup miss so
-    ...    Wait Until Keyword Succeeds can poll until the re-render settles.
+    ...    fixed sleep). Returns 'page_not_ready' for any transient render miss
+    ...    (combobox / lightning-base-combobox / button not yet present) so
+    ...    Wait Until Keyword Succeeds retries until the re-render settles —
+    ...    canonical pattern matching configure_core_pricing_setup.robot.
     ${result}=    Execute JavaScript
     ...    ${_JS_FIND_EL}
     ...    return (function() {
     ...        var lc = findEl(document, 'lightning-combobox[data-id="defaultCatalog"]', 0);
-    ...        if (!lc) return 'combobox_not_found';
+    ...        if (!lc) return 'page_not_ready';
     ...        var lbc = lc.shadowRoot && lc.shadowRoot.querySelector('lightning-base-combobox');
-    ...        if (!lbc) return 'lbc_not_found';
+    ...        if (!lbc) return 'page_not_ready';
     ...        var btn = lbc.shadowRoot && lbc.shadowRoot.querySelector('button[role="combobox"]');
-    ...        if (!btn) return 'btn_not_found';
+    ...        if (!btn) return 'page_not_ready';
     ...        btn.click();
     ...        return 'opened';
     ...    })()
@@ -121,9 +123,12 @@ _Open Default Catalog Dropdown
 _Open Default Catalog Combobox
     [Documentation]    Runs the state-check JS for Set Default Catalog.
     ...    Returns 'opened' (combobox clicked open), 'already_set' (correct value present),
-    ...    'cleared' (wrong pill removed), or an error string. Fails with a retry-triggering
-    ...    message when 'combobox_not_found' — Salesforce background processing after
-    ...    reconfigure_pricing_discovery delays LWC render; Wait Until Keyword Succeeds retries.
+    ...    'cleared' (wrong pill removed), 'remove_btn_not_found' (terminal — fails caller
+    ...    assertion), or 'page_not_ready' (any transient render miss — combobox /
+    ...    lightning-base-combobox / button not yet present). Salesforce background
+    ...    processing after reconfigure_pricing_discovery delays LWC render;
+    ...    Wait Until Keyword Succeeds retries on the page_not_ready sentinel —
+    ...    canonical pattern matching configure_core_pricing_setup.robot.
     [Arguments]    ${target_value}
     ${result}=    Execute JavaScript
     ...    ${_JS_FIND_EL}
@@ -137,17 +142,17 @@ _Open Default Catalog Combobox
     ...            return 'cleared';
     ...        }
     ...        var lc = findEl(document, 'lightning-combobox[data-id="defaultCatalog"]', 0);
-    ...        if (!lc) return 'combobox_not_found';
+    ...        if (!lc) return 'page_not_ready';
     ...        var lbc = lc.shadowRoot && lc.shadowRoot.querySelector('lightning-base-combobox');
-    ...        if (!lbc) return 'lbc_not_found';
+    ...        if (!lbc) return 'page_not_ready';
     ...        var btn = lbc.shadowRoot && lbc.shadowRoot.querySelector('button[role="combobox"]');
-    ...        if (!btn) return 'btn_not_found';
+    ...        if (!btn) return 'page_not_ready';
     ...        btn.click();
     ...        return 'opened';
     ...    })(arguments[0])
     ...    ARGUMENTS    ${target_value}
-    Should Not Be Equal    ${result}    combobox_not_found
-    ...    msg=Product Discovery combobox not yet rendered; retrying...
+    Should Not Be Equal    ${result}    page_not_ready
+    ...    msg=Product Discovery combobox or inner shadow elements not yet rendered; retrying...
     RETURN    ${result}
 
 Dismiss Toast If Present

--- a/robot/rlm-base/tests/setup/configure_product_discovery_settings.robot
+++ b/robot/rlm-base/tests/setup/configure_product_discovery_settings.robot
@@ -67,20 +67,11 @@ Set Default Catalog
         RETURN
     END
     # If a selection was cleared, wait for the combobox to reappear then re-open it
+    # with retry — the pill-removal re-render is asynchronous and may exceed the initial sleep.
     IF    "${open_result}" == "cleared"
-        Sleep    2s    reason=Allow pill removal to complete and combobox to reappear
-        ${open_result}=    Execute JavaScript
-        ...    ${_JS_FIND_EL}
-        ...    return (function() {
-        ...        var lc = findEl(document, 'lightning-combobox[data-id="defaultCatalog"]', 0);
-        ...        if (!lc) return 'combobox_not_found';
-        ...        var lbc = lc.shadowRoot && lc.shadowRoot.querySelector('lightning-base-combobox');
-        ...        if (!lbc) return 'lbc_not_found';
-        ...        var btn = lbc.shadowRoot && lbc.shadowRoot.querySelector('button[role="combobox"]');
-        ...        if (!btn) return 'btn_not_found';
-        ...        btn.click();
-        ...        return 'opened';
-        ...    })()
+        Sleep    2s    reason=Allow pill removal to start before polling for combobox
+        ${open_result}=    Wait Until Keyword Succeeds    30s    3s
+        ...    _Open Default Catalog Dropdown
     END
     Should Be Equal    ${open_result}    opened    msg=Could not prepare/open Default Catalog combobox: ${open_result}
     Sleep    1s    reason=Allow dropdown options to populate
@@ -104,6 +95,28 @@ Set Default Catalog
     ...    msg=Option "${target_value}" not found in dropdown. ${select_result}
     Sleep    2s    reason=Allow selection to auto-save
     Log    Default Catalog set to "${target_value}".
+
+_Open Default Catalog Dropdown
+    [Documentation]    Re-opens the Default Catalog combobox after a pill clear. Used by
+    ...    Set Default Catalog when the cleared-path needs to wait for the LWC to re-render
+    ...    the combobox button (pill removal is asynchronous and can take longer than the
+    ...    fixed sleep). Fails with a retry-triggering message on any lookup miss so
+    ...    Wait Until Keyword Succeeds can poll until the re-render settles.
+    ${result}=    Execute JavaScript
+    ...    ${_JS_FIND_EL}
+    ...    return (function() {
+    ...        var lc = findEl(document, 'lightning-combobox[data-id="defaultCatalog"]', 0);
+    ...        if (!lc) return 'combobox_not_found';
+    ...        var lbc = lc.shadowRoot && lc.shadowRoot.querySelector('lightning-base-combobox');
+    ...        if (!lbc) return 'lbc_not_found';
+    ...        var btn = lbc.shadowRoot && lbc.shadowRoot.querySelector('button[role="combobox"]');
+    ...        if (!btn) return 'btn_not_found';
+    ...        btn.click();
+    ...        return 'opened';
+    ...    })()
+    Should Be Equal    ${result}    opened
+    ...    msg=Default Catalog combobox not yet re-rendered after clear; retrying... (got: ${result})
+    RETURN    ${result}
 
 _Open Default Catalog Combobox
     [Documentation]    Runs the state-check JS for Set Default Catalog.

--- a/robot/rlm-base/tests/setup/enable_document_builder.robot
+++ b/robot/rlm-base/tests/setup/enable_document_builder.robot
@@ -36,14 +36,56 @@ Enable Document Templates Export On General Settings
     [Documentation]    Reload General Settings and enable Document Templates Export.
     ...    Requires Design Document Templates to be enabled first (see previous test case).
     ...    The page is reopened so Salesforce reflects the updated prerequisite state before the click.
-    ...    Note: this toggle is a plain input[type="checkbox"] (data-name="MetadataPreference") in
-    ...    light DOM — not a lightning-input — so _EnsureShadowDOMToggle falls back to plain inputs
-    ...    when no lightning-input exists at that DOM depth.
+    ...    Note: this toggle is a plain input[type="checkbox"] (data-name="MetadataPreference") inside
+    ...    an LWC shadow root (setup_industries_docgen-preference-toggle). Enable Toggle By Label
+    ...    cannot reach it because document.createTreeWalker and querySelectorAll do not pierce
+    ...    shadow roots. Instead, we use findEl (recursive shadow-DOM traversal) to click directly —
+    ...    the same approach used in configure_core_pricing_setup and configure_product_discovery.
+    ...    Sleep 5s ensures the save handler is wired before the click fires. After clicking,
+    ...    the page is reloaded to confirm server-side persistence before the suite exits.
     Open Setup Page    ${GENERAL_SETTINGS_PATH}
-    Enable Toggle By Label    ${DOC_TEMPLATES_EXPORT_LABEL}
-    Log    Document Templates Export toggle enabled.
+    Sleep    5s    reason=Allow setup_industries_docgen-preference-toggle LWC to fully wire save handler
+    ${click_result}=    Wait Until Keyword Succeeds    20s    3s
+    ...    _Click Document Templates Export Toggle
+    IF    "${click_result}" == "already_on"
+        Log    Document Templates Export already enabled. No change needed.
+    ELSE
+        Should Be Equal    ${click_result}    clicked
+        ...    msg=Document Templates Export could not be clicked (got: ${click_result})
+    END
+    Sleep    3s    reason=Allow toggle change to reach Salesforce server
+    # Reload and re-verify server-side persistence
+    Open Setup Page    ${GENERAL_SETTINGS_PATH}
+    ${verified}=    Execute JavaScript
+    ...    return (function() {
+    ...        function findEl(root, sel, d) { if (d > 6) return null; var el = root.querySelector(sel); if (el) return el; var all = root.querySelectorAll('*'); for (var i=0;i<all.length;i++){if(all[i].shadowRoot){var f=findEl(all[i].shadowRoot,sel,d+1);if(f)return f;}} return null; }
+    ...        var pi = findEl(document, 'input[data-name="MetadataPreference"]', 0);
+    ...        if (!pi) return 'not_found';
+    ...        return pi.checked ? 'on' : 'off';
+    ...    })()
+    Should Be Equal    ${verified}    on
+    ...    msg=Document Templates Export toggle not persisted after page reload (got: ${verified})
+    Log    Document Templates Export toggle enabled and confirmed.
 
 *** Keywords ***
+_Click Document Templates Export Toggle
+    [Documentation]    Directly clicks input[data-name="MetadataPreference"] inside
+    ...    setup_industries_docgen-preference-toggle's shadow root, bypassing Enable Toggle By Label
+    ...    which uses querySelectorAll / createTreeWalker (neither pierce shadow DOM). Returns
+    ...    'clicked', 'already_on', or fails with 'not_found' to trigger Wait Until Keyword Succeeds retry.
+    ${result}=    Execute JavaScript
+    ...    return (function() {
+    ...        function findEl(root, sel, d) { if (d > 6) return null; var el = root.querySelector(sel); if (el) return el; var all = root.querySelectorAll('*'); for (var i=0;i<all.length;i++){if(all[i].shadowRoot){var f=findEl(all[i].shadowRoot,sel,d+1);if(f)return f;}} return null; }
+    ...        var pi = findEl(document, 'input[data-name="MetadataPreference"]', 0);
+    ...        if (!pi) return 'not_found';
+    ...        if (pi.checked) return 'already_on';
+    ...        pi.click();
+    ...        return 'clicked';
+    ...    })()
+    Should Not Be Equal    ${result}    not_found
+    ...    msg=Document Templates Export input[data-name="MetadataPreference"] not yet rendered; retrying...
+    RETURN    ${result}
+
 Enable Prerequisite Then Document Builder
     [Documentation]    Enable the prerequisite toggle (e.g. Revenue Management) so Document Builder becomes enabled, then enable Document Builder.
     Enable Toggle By Label    ${DOCUMENT_BUILDER_PREREQUISITE_LABEL}

--- a/robot/rlm-base/tests/setup/enable_document_builder.robot
+++ b/robot/rlm-base/tests/setup/enable_document_builder.robot
@@ -1,5 +1,5 @@
 *** Settings ***
-Documentation     Enable Document Generation toggles: Document Builder on Revenue Settings, and Document Templates Export + Design Document Templates in Salesforce on General Settings. Required for prepare_docgen when the org does not have these enabled via metadata.
+Documentation     Enable Document Generation toggles: Document Builder on Revenue Settings, then Design Document Templates in Salesforce and Document Templates Export on General Settings (in that order — Design is a prerequisite for Export). Required for prepare_docgen when the org does not have these enabled via metadata.
 Resource          ../../resources/SetupToggles.robot
 Suite Setup       Open Browser For Setup
 Suite Teardown    Close Browser After Setup
@@ -24,16 +24,24 @@ Enable Document Builder Toggle On Revenue Settings
     Run Keyword If    """${DOCUMENT_BUILDER_PREREQUISITE_LABEL}""" == ""    Enable Toggle By Label    ${DOCUMENT_BUILDER_TOGGLE_LABEL}
     Log    Document Builder toggle enabled. You can now run prepare_docgen.
 
+Enable Design Document Templates On General Settings
+    [Documentation]    Navigate to General Settings (Document Generation) and enable Design Document Templates in Salesforce.
+    ...    This must run before Enable Document Templates Export — Salesforce renders the Document Templates Export
+    ...    toggle as disabled until Design Document Templates is enabled.
+    Open Setup Page    ${GENERAL_SETTINGS_PATH}
+    Enable Toggle By Label    ${DESIGN_DOC_TEMPLATES_LABEL}
+    Log    Design Document Templates in Salesforce toggle enabled.
+
 Enable Document Templates Export On General Settings
-    [Documentation]    Navigate to General Settings (Document Generation) and enable Document Templates Export.
+    [Documentation]    Reload General Settings and enable Document Templates Export.
+    ...    Requires Design Document Templates to be enabled first (see previous test case).
+    ...    The page is reopened so Salesforce reflects the updated prerequisite state before the click.
+    ...    Note: this toggle is a plain input[type="checkbox"] (data-name="MetadataPreference") in
+    ...    light DOM — not a lightning-input — so _EnsureShadowDOMToggle falls back to plain inputs
+    ...    when no lightning-input exists at that DOM depth.
     Open Setup Page    ${GENERAL_SETTINGS_PATH}
     Enable Toggle By Label    ${DOC_TEMPLATES_EXPORT_LABEL}
     Log    Document Templates Export toggle enabled.
-
-Enable Design Document Templates On General Settings
-    [Documentation]    Enable Design Document Templates in Salesforce on General Settings.
-    Enable Toggle By Label    ${DESIGN_DOC_TEMPLATES_LABEL}
-    Log    Design Document Templates in Salesforce toggle enabled.
 
 *** Keywords ***
 Enable Prerequisite Then Document Builder

--- a/robot/rlm-base/tests/setup/enable_document_builder.robot
+++ b/robot/rlm-base/tests/setup/enable_document_builder.robot
@@ -15,6 +15,9 @@ ${DOCUMENT_BUILDER_TOGGLE_LABEL}          Document Builder
 ${GENERAL_SETTINGS_PATH}                  /lightning/setup/GeneralSettings/home
 ${DOC_TEMPLATES_EXPORT_LABEL}             Document Templates Export
 ${DESIGN_DOC_TEMPLATES_LABEL}             Design Document Templates in Salesforce
+# Shared shadow-DOM traversal helper prepended to Execute JavaScript blocks that need findEl.
+# Same canonical pattern used in configure_core_pricing_setup.robot and configure_product_discovery_settings.robot.
+${_JS_FIND_EL}    function findEl(root, sel, d) { if (d > 6) return null; var el = root.querySelector(sel); if (el) return el; var all = root.querySelectorAll('*'); for (var i=0;i<all.length;i++){if(all[i].shadowRoot){var f=findEl(all[i].shadowRoot,sel,d+1);if(f)return f;}} return null; }
 
 *** Test Cases ***
 Enable Document Builder Toggle On Revenue Settings
@@ -57,8 +60,8 @@ Enable Document Templates Export On General Settings
     # Reload and re-verify server-side persistence
     Open Setup Page    ${GENERAL_SETTINGS_PATH}
     ${verified}=    Execute JavaScript
+    ...    ${_JS_FIND_EL}
     ...    return (function() {
-    ...        function findEl(root, sel, d) { if (d > 6) return null; var el = root.querySelector(sel); if (el) return el; var all = root.querySelectorAll('*'); for (var i=0;i<all.length;i++){if(all[i].shadowRoot){var f=findEl(all[i].shadowRoot,sel,d+1);if(f)return f;}} return null; }
     ...        var pi = findEl(document, 'input[data-name="MetadataPreference"]', 0);
     ...        if (!pi) return 'not_found';
     ...        return pi.checked ? 'on' : 'off';
@@ -77,8 +80,8 @@ _Click Document Templates Export Toggle
     ...    introduced in PR #139 for lightning-input toggles, where label clicks fire the LWC save
     ...    handler reliably and raw input clicks may not) and falls back to the input click otherwise.
     ${result}=    Execute JavaScript
+    ...    ${_JS_FIND_EL}
     ...    return (function() {
-    ...        function findEl(root, sel, d) { if (d > 6) return null; var el = root.querySelector(sel); if (el) return el; var all = root.querySelectorAll('*'); for (var i=0;i<all.length;i++){if(all[i].shadowRoot){var f=findEl(all[i].shadowRoot,sel,d+1);if(f)return f;}} return null; }
     ...        var pi = findEl(document, 'input[data-name="MetadataPreference"]', 0);
     ...        if (!pi) return 'not_found';
     ...        if (pi.checked) return 'already_on';

--- a/robot/rlm-base/tests/setup/enable_document_builder.robot
+++ b/robot/rlm-base/tests/setup/enable_document_builder.robot
@@ -73,13 +73,16 @@ _Click Document Templates Export Toggle
     ...    setup_industries_docgen-preference-toggle's shadow root, bypassing Enable Toggle By Label
     ...    which uses querySelectorAll / createTreeWalker (neither pierce shadow DOM). Returns
     ...    'clicked', 'already_on', or fails with 'not_found' to trigger Wait Until Keyword Succeeds retry.
+    ...    Targets the wrapping label when present (consistent with the SetupToggles.robot pattern
+    ...    introduced in PR #139 for lightning-input toggles, where label clicks fire the LWC save
+    ...    handler reliably and raw input clicks may not) and falls back to the input click otherwise.
     ${result}=    Execute JavaScript
     ...    return (function() {
     ...        function findEl(root, sel, d) { if (d > 6) return null; var el = root.querySelector(sel); if (el) return el; var all = root.querySelectorAll('*'); for (var i=0;i<all.length;i++){if(all[i].shadowRoot){var f=findEl(all[i].shadowRoot,sel,d+1);if(f)return f;}} return null; }
     ...        var pi = findEl(document, 'input[data-name="MetadataPreference"]', 0);
     ...        if (!pi) return 'not_found';
     ...        if (pi.checked) return 'already_on';
-    ...        pi.click();
+    ...        (pi.closest('label') || pi).click();
     ...        return 'clicked';
     ...    })()
     Should Not Be Equal    ${result}    not_found

--- a/tasks/rlm_configure_core_pricing_setup.py
+++ b/tasks/rlm_configure_core_pricing_setup.py
@@ -1,0 +1,110 @@
+"""Configure Salesforce Pricing Setup (CorePricingSetup) page via Robot Framework.
+
+Sets the default Pricing Procedure on the CorePricingSetup Lightning Setup page
+(/lightning/setup/CorePricingSetup/home). Uses the same anchored default procedure
+as configure_revenue_settings (RLM Revenue Management Default Pricing Procedure).
+
+Follows the same pattern as rlm_configure_revenue_settings.py.
+"""
+
+import subprocess
+import sys
+from pathlib import Path
+
+try:
+    from cumulusci.tasks.salesforce import BaseSalesforceTask
+    from cumulusci.core.exceptions import TaskOptionsError
+except ImportError:
+    BaseSalesforceTask = object  # type: ignore
+    TaskOptionsError = Exception  # type: ignore
+
+from tasks.robot_utils import check_urllib3_for_robot
+
+DEFAULT_SUITE = "robot/rlm-base/tests/setup/configure_core_pricing_setup.robot"
+DEFAULT_OUTPUT_DIR = "robot/rlm-base/results"
+
+
+class ConfigureCorePricingSetup(BaseSalesforceTask):
+    """Run the Robot test that configures the CorePricingSetup default Pricing Procedure.
+
+    Navigates to /lightning/setup/CorePricingSetup/home and sets the default
+    Pricing Procedure to the anchored RLM procedure. Required after the Pricing
+    Procedure expression set is deployed and activated.
+    """
+
+    task_options = {
+        "suite": {
+            "description": "Path to the Robot test suite.",
+            "required": False,
+        },
+        "outputdir": {
+            "description": "Directory for Robot output (log.html, report.html, output.xml).",
+            "required": False,
+        },
+        "pricing_procedure": {
+            "description": "Name of the default Pricing Procedure to set on CorePricingSetup.",
+            "required": False,
+        },
+    }
+
+    def _run_task(self):
+        check_urllib3_for_robot(task_name="ConfigureCorePricingSetup")
+        org_name = getattr(self.org_config, "username", None)
+        if not org_name:
+            org_name = getattr(self.org_config, "name", None) or getattr(
+                self.org_config, "alias", None
+            )
+        if not org_name:
+            raise TaskOptionsError(
+                "ConfigureCorePricingSetup requires an org (run as part of a flow "
+                "with --org, or set org_config)."
+            )
+
+        repo_root = Path(self.project_config.repo_root)
+        suite = self.options.get("suite") or DEFAULT_SUITE
+        suite_path = repo_root / suite
+        if not suite_path.exists():
+            raise FileNotFoundError(f"Robot suite not found: {suite_path}")
+
+        outputdir = self.options.get("outputdir") or DEFAULT_OUTPUT_DIR
+        out_path = repo_root / outputdir
+        out_path.mkdir(parents=True, exist_ok=True)
+
+        cmd = [
+            sys.executable,
+            "-m",
+            "robot",
+            "--variable",
+            f"ORG_ALIAS:{org_name}",
+        ]
+
+        if self.options.get("pricing_procedure"):
+            cmd.extend(["--variable", f"PRICING_PROCEDURE:{self.options['pricing_procedure']}"])
+
+        cmd.extend([
+            "--outputdir",
+            str(out_path),
+            str(suite_path),
+        ])
+
+        self.logger.info(
+            "Running configure core pricing setup test for org %s: %s",
+            org_name,
+            " ".join(cmd),
+        )
+        result = subprocess.run(
+            cmd,
+            cwd=str(repo_root),
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode != 0:
+            self.logger.error("Robot stdout: %s", result.stdout)
+            self.logger.error("Robot stderr: %s", result.stderr)
+            raise RuntimeError(
+                f"Configure core pricing setup test failed (exit code {result.returncode}). "
+                f"Check {out_path / 'log.html'} for details."
+            )
+        self.logger.info(
+            "CorePricingSetup configured: default Pricing Procedure set."
+        )

--- a/tasks/rlm_configure_product_discovery_settings.py
+++ b/tasks/rlm_configure_product_discovery_settings.py
@@ -1,0 +1,108 @@
+"""Configure Product Discovery Settings page via Robot Framework.
+
+Sets the Default Catalog to the specified catalog name (default: "QuantumBit Software").
+Must run after QB product catalog data has been loaded so the catalog record exists.
+
+Follows the same pattern as rlm_configure_revenue_settings.py.
+"""
+
+import subprocess
+import sys
+from pathlib import Path
+
+try:
+    from cumulusci.tasks.salesforce import BaseSalesforceTask
+    from cumulusci.core.exceptions import TaskOptionsError
+except ImportError:
+    BaseSalesforceTask = object  # type: ignore
+    TaskOptionsError = Exception  # type: ignore
+
+from tasks.robot_utils import check_urllib3_for_robot
+
+DEFAULT_SUITE = "robot/rlm-base/tests/setup/configure_product_discovery_settings.robot"
+DEFAULT_OUTPUT_DIR = "robot/rlm-base/results"
+DEFAULT_CATALOG = "QuantumBit Software"
+
+
+class ConfigureProductDiscoverySettings(BaseSalesforceTask):
+    """Run the Robot test that sets the Default Catalog on Product Discovery Settings.
+
+    Navigates to /lightning/setup/ProductDiscoverySettings/home and sets the
+    "Select Default Catalog" combobox to the configured catalog name. The page
+    auto-saves on selection (no explicit Save button needed).
+    """
+
+    task_options = {
+        "suite": {
+            "description": "Path to the Robot test suite.",
+            "required": False,
+        },
+        "outputdir": {
+            "description": "Directory for Robot output (log.html, report.html, output.xml).",
+            "required": False,
+        },
+        "default_catalog": {
+            "description": "Name of the Default Catalog to select in ProductDiscoverySettings.",
+            "required": False,
+        },
+    }
+
+    def _run_task(self):
+        check_urllib3_for_robot(task_name="ConfigureProductDiscoverySettings")
+        org_name = getattr(self.org_config, "username", None)
+        if not org_name:
+            org_name = getattr(self.org_config, "name", None) or getattr(
+                self.org_config, "alias", None
+            )
+        if not org_name:
+            raise TaskOptionsError(
+                "ConfigureProductDiscoverySettings requires an org (run as part of a flow "
+                "with --org, or set org_config)."
+            )
+
+        repo_root = Path(self.project_config.repo_root)
+        suite = self.options.get("suite") or DEFAULT_SUITE
+        suite_path = repo_root / suite
+        if not suite_path.exists():
+            raise FileNotFoundError(f"Robot suite not found: {suite_path}")
+
+        outputdir = self.options.get("outputdir") or DEFAULT_OUTPUT_DIR
+        out_path = repo_root / outputdir
+        out_path.mkdir(parents=True, exist_ok=True)
+
+        catalog = self.options.get("default_catalog") or DEFAULT_CATALOG
+
+        cmd = [
+            sys.executable,
+            "-m",
+            "robot",
+            "--variable",
+            f"ORG_ALIAS:{org_name}",
+            "--variable",
+            f"DEFAULT_CATALOG:{catalog}",
+            "--outputdir",
+            str(out_path),
+            str(suite_path),
+        ]
+
+        self.logger.info(
+            "Running configure product discovery settings test for org %s: %s",
+            org_name,
+            " ".join(cmd),
+        )
+        result = subprocess.run(
+            cmd,
+            cwd=str(repo_root),
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode != 0:
+            self.logger.error("Robot stdout: %s", result.stdout)
+            self.logger.error("Robot stderr: %s", result.stderr)
+            raise RuntimeError(
+                f"Configure product discovery settings test failed (exit code {result.returncode}). "
+                f"Check {out_path / 'log.html'} for details."
+            )
+        self.logger.info(
+            "Product Discovery Settings configured: Default Catalog set to '%s'.", catalog
+        )


### PR DESCRIPTION
## Summary

Forward-port of main PRs #131, #132, #133, #134, #135, #139, #152 onto the `262` branch. Five chronological cherry-picks, one conflict resolved (a stale `prepare_ux` docstring), generated CCI references re-emitted from the resolved `cumulusci.yml`.

| Cherry-pick | Main commit | Main PR |
|---|---|---|
| `338600f9` | `724c391f` | #133 — `fix: correctly enable DocGen General Settings toggles (closes #130)` |
| `6341f01c` | `c8fa3702` | #134 — `feat: configure Default Catalog in Product Discovery Settings (closes #131)` |
| `59ec2a83` | `b5a95262` | #135 — `fix: rewrite configure_core_pricing_setup robot with JS shadow DOM traversal (closes #132)` |
| `63cda26b` | `e5dfa8fa` | #139 — `fix: correct shadow DOM toggle clicks and add retry logic for setup robots (closes #133, #134)` |
| `978721bb` | `c0cec67c` | #152 — `refactor: replace dev_ed flag with automatic Developer Edition detection` |

## What's in it

**New CCI tasks (Python + Robot)**

- `tasks/rlm_configure_core_pricing_setup.py` + `robot/rlm-base/tests/setup/configure_core_pricing_setup.robot` — navigates to `/lightning/setup/CorePricingSetup/home`, sets the default Pricing Procedure (`RLM Revenue Management Default Pricing Procedure`) via JS-based shadow-DOM traversal (LWC combobox is 3 shadow levels deep).
- `tasks/rlm_configure_product_discovery_settings.py` + `robot/rlm-base/tests/setup/configure_product_discovery_settings.robot` — navigates to `/lightning/setup/ProductDiscoverySettings/home`, sets the Default Catalog to `QuantumBit Software` via the same JS shadow-DOM pattern.

**Flow wiring (`cumulusci.yml`)**

- `prepare_revenue_settings` gains **step 3** → `configure_core_pricing_setup` (runs unconditionally inside `prepare_rlm_org` after the Pricing Procedure expression set is activated).
- `prepare_pricing_discovery` gains **step 2** → `configure_product_discovery_settings`, gated by `when: project_config.project__custom__qb` so non-QB org builds skip it.

**Robot test fixes (already-present files updated)**

- `robot/rlm-base/tests/setup/enable_document_builder.robot` — corrected DocGen General Settings toggle handling (#133) + added retry-with-shadow-DOM logic for LWC post-reload rendering (#139).
- `robot/rlm-base/resources/SetupToggles.robot` — extracted dedicated verification keywords wrapped in `Wait Until Keyword Succeeds` (#139).

**`dev_ed` flag removed (#152)**

- `dev_ed: false` removed from `project.custom` in `cumulusci.yml` (38 → 37 flags).
- `assign_feature_permission_sets` flow step 3 guard switched:
  - Before: `when: project_config.project__custom__einstein and not (project_config.project__custom__dev_ed or org_config.name in [\"dev\", \"dev-sb0\", \"dev-r1\"])`
  - After: `when: project_config.project__custom__einstein and org_config.org_type != \"Developer Edition\"`
- `AGENTS.md` PR Review Focus Areas note updated to say Developer Edition detection is automatic.
- `Industries.settings-meta.xml` — minor settings tweak from #152.

**Regenerated**

- `.cursor/skills/cci-orchestration/{tasks-reference, flows-reference, feature-flags}.md` regenerated from the post-cherry-pick `cumulusci.yml`.

## Conflict resolution log

| File | Conflict | Resolution |
|---|---|---|
| `cumulusci.yml` | `prepare_ux` description: 262 says "step 29 ... personas at step 28"; #152 said "step 27" | Kept 262's text (current). The `dev_ed` removal applied cleanly above the conflicted block. |
| `.cursor/skills/cci-orchestration/{tasks,flows,feature-flags}-reference.md` | Auto-generated files; both sides differed | Regenerated from the resolved `cumulusci.yml`. |

## Validation done locally

- `cci task list` lists the two new tasks (`configure_core_pricing_setup`, `configure_product_discovery_settings`).
- `cci flow info prepare_revenue_settings` shows step 3 wires `configure_core_pricing_setup`.
- `cci flow info prepare_pricing_discovery` shows step 2 wires `configure_product_discovery_settings` with the `qb=true` guard.
- `cci flow info assign_feature_permission_sets` shows step 3 uses `org_config.org_type != \"Developer Edition\"` (no `dev_ed` flag).
- Repo-wide grep for `dev_ed`: no matches.

## Part of the 262 → main merge-readiness sweep

Sibling PRs:

- **#166** — `docs: skills + enablement catalog + Help snapshot tooling — 262` (split from #163 for reviewability)
- **#167** — `docs(salesforce/262/help): land 262 Help portal snapshot (840 articles)` (split from #163)
- **#164** — `chore(ci): bump Node.js from 22 to 24 (current LTS) — 262`

(#163 closed; replaced by #166 + #167.)

After these four PRs merge, `262` will be ahead of `main` only by 262-specific work. The remaining gap-closure is PR #142 (RLM_CreateOrdersFromQuote hardening), which needs careful merge resolution given 262's lineage already touched the same flow file differently — recommend handling that as a separate, scoped PR.

## Test plan

- [ ] CI green on this PR
- [ ] `cci task run configure_core_pricing_setup --org <test-org>` succeeds on a 262 scratch org with the Pricing Procedure deployed
- [ ] `cci task run configure_product_discovery_settings --org <test-org>` succeeds on a `qb=true` 262 scratch org with QB catalog loaded
- [ ] `cci flow run prepare_rlm_org --org <test-org>` reaches both setup tasks at the expected steps
- [ ] Spot-check `assign_feature_permission_sets` on a Developer Edition scratch (`pde=true`) and on an Enterprise Edition scratch — DE should skip `SalesCloudEinsteinAll`, EE should assign it