### PR TITLE
fix(262): harden robot setup tests + unblock persona deploy when large_stx is off

### DIFF
--- a/.cursor/skills/cci-orchestration/feature-flags.md
+++ b/.cursor/skills/cci-orchestration/feature-flags.md
@@ -31,7 +31,7 @@ Boolean flags that gate task/flow execution via `when:` clauses.
 | `dro` | `True` | 7 flow step(s) |
 | `einstein` | `True` | 3 flow step(s) |
 | `guidedselling` | `False` | 2 flow step(s) |
-| `large_stx` | `True` | 3 flow step(s) |
+| `large_stx` | `False` | 4 flow step(s) |
 | `payments` | `True` | 6 flow step(s) |
 | `pde` | `False` | — |
 | `personas` | `True` | 8 flow step(s) |
@@ -196,11 +196,12 @@ Boolean flags that gate task/flow execution via `when:` clauses.
 - `prepare_guidedselling` step 1 → `insert_qb_guidedselling_data`
 - `prepare_guidedselling` step 2 → `deploy_post_guidedselling`
 
-### `large_stx` (default: `True`)
+### `large_stx` (default: `False`)
 
 - `prepare_rlm_org` step 27 → `prepare_large_stx`
 - `prepare_large_stx` step 1 → `deploy_post_large_stx`
 - `prepare_large_stx` step 2 → `assign_permission_sets`
+- `prepare_personas` step 7 → `assign_permission_sets`
 
 ### `payments` (default: `True`)
 

--- a/.cursor/skills/cci-orchestration/flows-reference.md
+++ b/.cursor/skills/cci-orchestration/flows-reference.md
@@ -353,7 +353,7 @@ Deploy persona metadata (profiles, permission set groups, permission sets) from 
 6. **task** `assign_permission_sets`  `when: project_config.project__custom__personas`
    - `api_names`: `['RLM_QuantumBit_Sales_Representative']`
    - `user_alias`: `salesrep`
-7. **task** `assign_permission_sets`  `when: project_config.project__custom__personas`
+7. **task** `assign_permission_sets`  `when: project_config.project__custom__personas and project_config.project__custom__large_stx`
    - `api_names`: `['RLM_LargeSalesTransaction']`
    - `user_alias`: `salesrep`
 

--- a/.cursor/skills/cci-orchestration/tasks-reference.md
+++ b/.cursor/skills/cci-orchestration/tasks-reference.md
@@ -2367,7 +2367,7 @@
 
 ### `set_personas_org_wide_defaults`
 
-**Description:** Sets Organization-Wide Defaults for standard Sales Cloud objects to support the Sales Rep persona. Account/Asset/Contact/Contract/Order → Public Read/Write (all internal users can see and edit). Opportunity stays Private (reps own their pipeline).
+**Description:** Sets Organization-Wide Defaults for standard Sales Cloud objects to support the Sales Rep persona. Account/Asset/Contract/Order → Public Read/Write (all internal users can see and edit). Opportunity stays Private (reps own their pipeline). ProductCatalog is intentionally omitted — it already defaults to Read/Read in RLM-enabled orgs, and CCI's SetOrgWideDefaults does a full retrieve-modify-deploy round-trip on each listed object, which for ProductCatalog hits a Salesforce 262 Metadata API quirk where the retrieve returns duplicate <listViews> entries (including All_ProductCatalogs), making the redeploy fail with "Duplicate name 'ProductCatalog.All_ProductCatalogs'".
 
 **Class:** `cumulusci.tasks.metadata_etl.SetOrgWideDefaults`
 

--- a/.cursor/skills/cci-orchestration/tasks-reference.md
+++ b/.cursor/skills/cci-orchestration/tasks-reference.md
@@ -3,7 +3,7 @@
 > **Auto-generated** by `scripts/ai/generate_cci_reference.py` from `cumulusci.yml`.  
 > Do not edit manually — re-run the script after changing `cumulusci.yml`.
 
-**203 tasks** across **9 groups**.
+**215 tasks** across **10 groups**.
 
 ---
 
@@ -436,6 +436,205 @@
 
 - `pathtoexportjson`: `datasets/sfdmu/qb/en-US/qb-transactionprocessingtypes`
 - `use_extraction_roundtrip`: `False`
+
+---
+
+## Documentation
+
+*12 task(s)*
+
+### `snapshot_agents_help_262`
+
+**Description:** Snapshot the 262 Agentforce for Revenue Management area of Salesforce Help. Covers the 7 revenue-management subagents (Product Selection, Product Description Generation, Quote Management, Consumption Management, Invoice Line Explanation, Billing Collections Management, Billing Inquiries) plus agent templates and setup. Root and prefix verified via RLM sidebar walk.
+
+**Class:** `tasks.rlm_snapshot_help.SnapshotSalesforceHelp`
+
+**Options:**
+
+- `release_version`: `262`
+- `release_name`: `Summer '26`
+- `area`: `agents`
+- `root_article_id`: `ind.rev_agent_overview.htm`
+- `article_id_prefix`: `ind.rev_agent`
+- `mode`: `all`
+
+---
+
+### `snapshot_approvals_help_262`
+
+**Description:** Snapshot the 262 Advanced Approvals area of Salesforce Help (~34 articles per the sidebar walk). Covers Advanced Approval Objects, approval workflow design, Smart Approvals, approval previews, Slack notifications, auto-approval rules. Note: the data-model domain is thin (1 object, ApprovalSubmission) but the Help area is rich. Root and prefix verified via sidebar walk.
+
+**Class:** `tasks.rlm_snapshot_help.SnapshotSalesforceHelp`
+
+**Options:**
+
+- `release_version`: `262`
+- `release_name`: `Summer '26`
+- `area`: `approvals`
+- `root_article_id`: `ind.approvals_advanced_approvals.htm`
+- `article_id_prefix`: `ind.approvals`
+- `mode`: `all`
+
+---
+
+### `snapshot_billing_help_260`
+
+**Description:** Snapshot the 260 (Spring '26) Billing area of Salesforce Help. For diff-against-262 verification work.
+
+**Class:** `tasks.rlm_snapshot_help.SnapshotSalesforceHelp`
+
+**Options:**
+
+- `release_version`: `260`
+- `release_name`: `Spring '26`
+- `area`: `billing`
+- `root_article_id`: `ind.billing.htm`
+- `article_id_prefix`: `ind.billing`
+- `mode`: `all`
+
+---
+
+### `snapshot_billing_help_262`
+
+**Description:** Snapshot the 262 (Summer '26) Billing area of Salesforce Help. ~171 articles (matches the captured inventory below). Default headless run takes ~10-15 minutes.
+
+**Class:** `tasks.rlm_snapshot_help.SnapshotSalesforceHelp`
+
+**Options:**
+
+- `release_version`: `262`
+- `release_name`: `Summer '26`
+- `area`: `billing`
+- `root_article_id`: `ind.billing.htm`
+- `article_id_prefix`: `ind.billing`
+- `mode`: `all`
+
+---
+
+### `snapshot_configurator_help_262`
+
+**Description:** Snapshot the 262 Product Configurator area of Salesforce Help. Covers ProductConfigurationFlow, ProductConfigurationRule. Small data-model domain (4 objects) but the Help area covers configuration rules and flow assignments that affect Quote/Order configuration. Root verified via RLM sidebar walk.
+
+**Class:** `tasks.rlm_snapshot_help.SnapshotSalesforceHelp`
+
+**Options:**
+
+- `release_version`: `262`
+- `release_name`: `Summer '26`
+- `area`: `configurator`
+- `root_article_id`: `ind.product_configurator_introduction.htm`
+- `article_id_prefix`: `ind.product_configurator`
+- `mode`: `all`
+
+---
+
+### `snapshot_dro_help_262`
+
+**Description:** Snapshot the 262 DRO (Dynamic Revenue Orchestration) / Fulfillment area of Salesforce Help. Covers FulfillmentPlan, FulfillmentStep, FulfillmentStepDefinition, ProductFulfillmentDecompRule. Root verified via RLM sidebar walk.
+
+**Class:** `tasks.rlm_snapshot_help.SnapshotSalesforceHelp`
+
+**Options:**
+
+- `release_version`: `262`
+- `release_name`: `Summer '26`
+- `area`: `dro`
+- `root_article_id`: `ind.dro_dynamic_revenue_orchestrator.htm`
+- `article_id_prefix`: `ind.dro`
+- `mode`: `all`
+
+---
+
+### `snapshot_pcm_help_262`
+
+**Description:** Snapshot the 262 (Summer '26) Product Catalog Management area of Salesforce Help. Covers Product2, ProductCategory, AttributeDefinition, ProductRelatedComponent. Root verified via RLM sidebar walk.
+
+**Class:** `tasks.rlm_snapshot_help.SnapshotSalesforceHelp`
+
+**Options:**
+
+- `release_version`: `262`
+- `release_name`: `Summer '26`
+- `area`: `pcm`
+- `root_article_id`: `ind.product_catalog_introduction.htm`
+- `article_id_prefix`: `ind.product_catalog`
+- `mode`: `all`
+
+---
+
+### `snapshot_pricing_help_262`
+
+**Description:** Snapshot the 262 Pricing area of Salesforce Help. Covers PriceBook2, PriceBookEntry, PriceAdjustmentSchedule, ProductSellingModel, proration. Distinct from Rate Management. Root verified via RLM sidebar walk.
+
+**Class:** `tasks.rlm_snapshot_help.SnapshotSalesforceHelp`
+
+**Options:**
+
+- `release_version`: `262`
+- `release_name`: `Summer '26`
+- `area`: `pricing`
+- `root_article_id`: `ind.pricing_salesforce_pricing.htm`
+- `article_id_prefix`: `ind.pricing`
+- `mode`: `all`
+
+---
+
+### `snapshot_rating_help_262`
+
+**Description:** Snapshot the 262 Rate Management area of Salesforce Help. Required for Module 3 Unit 2 LO validation (Rate Card, Rate Card Entry, Asset Rate Card Entry, Asset Rate Adjustment, Rating Procedure, the Transaction Journal → Usage Summary → Ratable Summary → Liable Summary pipeline). Root verified via RLM sidebar walk. Prefix `ind.rm_*` (NOT `ind.rate_*`).
+
+**Class:** `tasks.rlm_snapshot_help.SnapshotSalesforceHelp`
+
+**Options:**
+
+- `release_version`: `262`
+- `release_name`: `Summer '26`
+- `area`: `rating`
+- `root_article_id`: `ind.rm_rate_management.htm`
+- `article_id_prefix`: `ind.rm`
+- `mode`: `all`
+
+---
+
+### `snapshot_salesforce_help`
+
+**Description:** Generic snapshot task. Walks a Salesforce Help portal area from a root article ID, captures every article whose ID starts with the given prefix, and writes markdown files with YAML frontmatter to docs/salesforce/{release_version}/help/articles/. Also produces manifest.json and index.md.
+
+**Class:** `tasks.rlm_snapshot_help.SnapshotSalesforceHelp`
+
+---
+
+### `snapshot_transaction_mgmt_help_262`
+
+**Description:** Snapshot the 262 Transaction Management area of Salesforce Help. Covers Quote, QuoteLineItem, Order, OrderItem, Contract, Asset, AssetAction, AssetStatePeriod, AssetRelationship, and quote/order/asset lifecycle management. ONE combined area with prefix `ind.qocal_*` — not four separate areas. Root verified via RLM sidebar walk.
+
+**Class:** `tasks.rlm_snapshot_help.SnapshotSalesforceHelp`
+
+**Options:**
+
+- `release_version`: `262`
+- `release_name`: `Summer '26`
+- `area`: `transaction_mgmt`
+- `root_article_id`: `ind.qocal_sales_transactions_rev_cloud.htm`
+- `article_id_prefix`: `ind.qocal`
+- `mode`: `all`
+
+---
+
+### `snapshot_usage_help_262`
+
+**Description:** Snapshot the 262 Usage Management area of Salesforce Help. Required for Module 3 Unit 1 + Unit 3 LO validation (data model, Usage Agent, Drawdown Policies, Digital Wallets, TransactionUsageEntitlement, Usage Entitlement Account / Bucket / Entry). Root verified via RLM sidebar walk. Prefix `ind.um_*` (NOT `ind.usage_*`).
+
+**Class:** `tasks.rlm_snapshot_help.SnapshotSalesforceHelp`
+
+**Options:**
+
+- `release_version`: `262`
+- `release_name`: `Summer '26`
+- `area`: `usage`
+- `root_article_id`: `ind.um_usage_management.htm`
+- `article_id_prefix`: `ind.um`
+- `mode`: `all`
 
 ---
 

--- a/cumulusci.yml
+++ b/cumulusci.yml
@@ -124,7 +124,7 @@ project:
     approvals: true           # Approvals
     tax: true                 # Tax engine
     calmdelete: true          # CALM Delete
-    large_stx: true          # Large Sales Transaction
+    large_stx: false          # Large Sales Transaction
 
     # ── Revenue Orchestration ──────────────────────────────────────────────────
     dro: true                 # Dynamic Revenue Orchestration
@@ -3676,8 +3676,13 @@ flows:
           api_names: *ps_persona_sales_rep
           user_alias: salesrep
       7:
+        # Assign the large_stx PermissionSet to the salesrep user only when
+        # large_stx is also on — RLM_LargeSalesTransaction lives in
+        # unpackaged/post_large_stx and is only deployed when large_stx=true,
+        # so assigning it on a personas=true / large_stx=false build would
+        # fail trying to reference a PermissionSet that wasn't deployed.
         task: assign_permission_sets
-        when: project_config.project__custom__personas
+        when: project_config.project__custom__personas and project_config.project__custom__large_stx
         options:
           api_names: *ps_large_stx
           user_alias: salesrep

--- a/cumulusci.yml
+++ b/cumulusci.yml
@@ -990,9 +990,14 @@ tasks:
     group: Revenue Lifecycle Management
     description: >
       Sets Organization-Wide Defaults for standard Sales Cloud objects to support
-      the Sales Rep persona. Account/Asset/Contact/Contract/Order → Public Read/Write
+      the Sales Rep persona. Account/Asset/Contract/Order → Public Read/Write
       (all internal users can see and edit). Opportunity stays Private (reps own
-      their pipeline).
+      their pipeline). ProductCatalog is intentionally omitted — it already defaults
+      to Read/Read in RLM-enabled orgs, and CCI's SetOrgWideDefaults does a full
+      retrieve-modify-deploy round-trip on each listed object, which for
+      ProductCatalog hits a Salesforce 262 Metadata API quirk where the retrieve
+      returns duplicate <listViews> entries (including All_ProductCatalogs), making
+      the redeploy fail with "Duplicate name 'ProductCatalog.All_ProductCatalogs'".
     class_path: cumulusci.tasks.metadata_etl.SetOrgWideDefaults
     options:
       org_wide_defaults:
@@ -1011,9 +1016,8 @@ tasks:
         - api_name: Order
           internal_sharing_model: ReadWrite
           external_sharing_model: Private
-        - api_name: ProductCatalog
-          internal_sharing_model: Read
-          external_sharing_model: Read
+        # ProductCatalog intentionally omitted — see description above.
+        # Default OWD in RLM-enabled orgs is already Read/Read.
 
   deploy_post_personas:
     group: Revenue Lifecycle Management

--- a/robot/rlm-base/tests/setup/configure_core_pricing_setup.robot
+++ b/robot/rlm-base/tests/setup/configure_core_pricing_setup.robot
@@ -26,26 +26,16 @@ Configure Core Pricing Setup
     Open Setup Page    /lightning/setup/CorePricingSetup/home
     Set Core Pricing Procedure    ${PRICING_PROCEDURE}
     Capture Page Screenshot
-    # Reload and re-verify to confirm the value was saved server-side
+    # Reload and re-verify to confirm the value was saved server-side.
+    # Open Setup Page sleeps 2s for generic Lightning rendering, but the
+    # CorePricingSetup LWC (and the resulting pill that replaces the empty
+    # combobox) routinely takes longer than that to wire on the post-reload
+    # visit. Without a retry the pill query returns 'not_set' even when the
+    # value is genuinely persisted server-side. Wait Until Keyword Succeeds
+    # polls _Read Pricing Procedure Pill State (which treats 'not_set' as a
+    # retry signal) until the pill renders.
     Open Setup Page    /lightning/setup/CorePricingSetup/home
-    ${verified}=    Execute JavaScript
-    ...    return (function(targetValue) {
-    ...        var pills = [];
-    ...        (function findAll(root, d) {
-    ...            if (d > 6) return;
-    ...            root.querySelectorAll('.slds-pill__label').forEach(function(el){pills.push(el);});
-    ...            root.querySelectorAll('*').forEach(function(el){if(el.shadowRoot)findAll(el.shadowRoot,d+1);});
-    ...        })(document, 0);
-    ...        var pillValues = [];
-    ...        for (var i=0; i<pills.length; i++) {
-    ...            var pillValue = pills[i].textContent.trim();
-    ...            pillValues.push(pillValue);
-    ...            if (pillValue === targetValue) return targetValue;
-    ...        }
-    ...        if (pillValues.length > 0) return pillValues.join(', ');
-    ...        return 'not_set';
-    ...    })(arguments[0])
-    ...    ARGUMENTS    ${PRICING_PROCEDURE}
+    ${verified}=    Wait Until Keyword Succeeds    30s    2s    _Read Pricing Procedure Pill State    ${PRICING_PROCEDURE}
     Should Be Equal    ${verified}    ${PRICING_PROCEDURE}
     ...    msg=Pricing Procedure not persisted after page reload: expected "${PRICING_PROCEDURE}", got "${verified}"
     Log    CorePricingSetup: Pricing Procedure confirmed as "${PRICING_PROCEDURE}" after reload.
@@ -90,6 +80,36 @@ Set Core Pricing Procedure
     ...    msg=Option "${target_value}" not found in dropdown. ${select_result}
     Sleep    2s    reason=Allow selection to auto-save
     Log    Pricing Procedure set to "${target_value}".
+
+_Read Pricing Procedure Pill State
+    [Documentation]    Walks the page (piercing shadow DOMs) for .slds-pill__label
+    ...    elements after a CorePricingSetup reload. Returns the matching pill text
+    ...    when found, the joined list of wrong pills when something else is set,
+    ...    or fails with 'not_set' to drive Wait Until Keyword Succeeds retry —
+    ...    the LWC routinely takes longer than Open Setup Page's 2s default sleep
+    ...    to wire on the post-reload visit. Caller asserts the final state.
+    [Arguments]    ${target_value}
+    ${state}=    Execute JavaScript
+    ...    return (function(targetValue) {
+    ...        var pills = [];
+    ...        (function findAll(root, d) {
+    ...            if (d > 6) return;
+    ...            root.querySelectorAll('.slds-pill__label').forEach(function(el){pills.push(el);});
+    ...            root.querySelectorAll('*').forEach(function(el){if(el.shadowRoot)findAll(el.shadowRoot,d+1);});
+    ...        })(document, 0);
+    ...        var pillValues = [];
+    ...        for (var i=0; i<pills.length; i++) {
+    ...            var pillValue = pills[i].textContent.trim();
+    ...            pillValues.push(pillValue);
+    ...            if (pillValue === targetValue) return targetValue;
+    ...        }
+    ...        if (pillValues.length > 0) return pillValues.join(', ');
+    ...        return 'not_set';
+    ...    })(arguments[0])
+    ...    ARGUMENTS    ${target_value}
+    Should Not Be Equal    ${state}    not_set
+    ...    msg=Pricing Procedure pill not yet rendered post-reload; retrying...
+    RETURN    ${state}
 
 _Open Pricing Procedure Combobox
     [Documentation]    Runs the state-check JS for Set Core Pricing Procedure.

--- a/robot/rlm-base/tests/setup/configure_product_discovery_settings.robot
+++ b/robot/rlm-base/tests/setup/configure_product_discovery_settings.robot
@@ -84,15 +84,19 @@ Set Default Catalog
         ${attempt}=    Evaluate    ${attempt} + 1
         ${status}    ${error}=    Run Keyword And Ignore Error    _Try Set Default Catalog    ${target_value}
         IF    "${status}" == "PASS"    RETURN
-        # Terminal sentinel: `not_found:[<non-empty-non-?-content>]` — options are
-        # loaded and the target is genuinely absent. The regex below requires at
-        # least one char between the brackets that is neither `?` nor `]`, so
-        # `not_found:[]`, `not_found:[?]`, and `not_found:[Cat,?]` all fall through
-        # to the retry path (transient render).
-        ${terminal}=    Run Keyword And Return Status
-        ...    Should Match Regexp    ${error}    not_found:\\[[^?\\]]+\\]
-        IF    ${terminal}
-            Fail    msg=Default Catalog "${target_value}" not present in visible options after ${attempt} attempt(s). ${error} — verify QB PCM data load (qb-pcm plan) completed and the catalog name matches exactly.
+        # Extract the raw `not_found:[...]` sentinel from _Try Set Default Catalog's
+        # Fail message. A non-empty match list whose contents include any char other
+        # than `?` or `]` means the dropdown options finished loading and the target
+        # is genuinely absent — terminal. `not_found:[]`, `not_found:[?]`, and mixed
+        # `not_found:[Cat,?]` cases yield no match and fall through to the retry
+        # path (transient render). Reformatting the failure message from the bare
+        # sentinel (rather than interpolating ${error}) avoids leaking the
+        # "closing and retrying open+select cycle..." wording from the per-attempt
+        # Fail message into a context where we are explicitly NOT retrying.
+        ${terminal_match}=    Get Regexp Matches    ${error}    not_found:\\[[^?\\]]+\\]
+        IF    ${terminal_match}
+            ${sentinel}=    Set Variable    ${terminal_match}[0]
+            Fail    msg=Default Catalog "${target_value}" not present in dropdown after ${attempt} attempt(s). Visible options: ${sentinel}. Verify QB PCM data load (qb-pcm plan) completed and the catalog name matches exactly.
         END
         ${now}=    Evaluate    time.time()    modules=time
         IF    ${now} >= ${deadline}

--- a/robot/rlm-base/tests/setup/configure_product_discovery_settings.robot
+++ b/robot/rlm-base/tests/setup/configure_product_discovery_settings.robot
@@ -143,10 +143,18 @@ _Open Default Catalog Combobox
     ...    Returns 'opened' (combobox clicked open), 'already_set' (correct value present),
     ...    'cleared' (wrong pill removed), 'remove_btn_not_found' (terminal — fails caller
     ...    assertion), or 'page_not_ready' (any transient render miss — combobox /
-    ...    lightning-base-combobox / button not yet present). Salesforce background
-    ...    processing after reconfigure_pricing_discovery delays LWC render;
-    ...    Wait Until Keyword Succeeds retries on the page_not_ready sentinel —
-    ...    canonical pattern matching configure_core_pricing_setup.robot.
+    ...    lightning-base-combobox / button not yet present, OR the LWC has a saved value
+    ...    that hasn't been swapped to a pill yet). Salesforce background processing after
+    ...    reconfigure_pricing_discovery delays LWC render; Wait Until Keyword Succeeds
+    ...    retries on the page_not_ready sentinel — canonical pattern matching
+    ...    configure_core_pricing_setup.robot.
+    ...
+    ...    When the LWC has a saved value (e.g. on a re-run where Default Catalog is already
+    ...    set), it briefly renders the empty-state combobox before swapping to the pill.
+    ...    The JS used to misinterpret that mid-render window as "no value set" and click
+    ...    the (empty) dropdown. We now sniff the lightning-combobox's `value` property
+    ...    before deciding: if it's non-empty and the pill hasn't rendered yet, treat as
+    ...    page_not_ready so we wait for the pill to land.
     [Arguments]    ${target_value}
     ${result}=    Execute JavaScript
     ...    ${_JS_FIND_EL}
@@ -161,6 +169,7 @@ _Open Default Catalog Combobox
     ...        }
     ...        var lc = findEl(document, 'lightning-combobox[data-id="defaultCatalog"]', 0);
     ...        if (!lc) return 'page_not_ready';
+    ...        if (lc.value) return 'page_not_ready';
     ...        var lbc = lc.shadowRoot && lc.shadowRoot.querySelector('lightning-base-combobox');
     ...        if (!lbc) return 'page_not_ready';
     ...        var btn = lbc.shadowRoot && lbc.shadowRoot.querySelector('button[role="combobox"]');
@@ -170,7 +179,7 @@ _Open Default Catalog Combobox
     ...    })(arguments[0])
     ...    ARGUMENTS    ${target_value}
     Should Not Be Equal    ${result}    page_not_ready
-    ...    msg=Product Discovery combobox or inner shadow elements not yet rendered; retrying...
+    ...    msg=Product Discovery combobox or inner shadow elements not yet rendered (or pill is pending render); retrying...
     RETURN    ${result}
 
 Dismiss Toast If Present

--- a/robot/rlm-base/tests/setup/configure_product_discovery_settings.robot
+++ b/robot/rlm-base/tests/setup/configure_product_discovery_settings.robot
@@ -61,16 +61,46 @@ Set Default Catalog
     ...    option text read from lightning-base-combobox-item shadow roots). Clears any existing
     ...    selection first if a different catalog is already selected. Auto-saves on selection.
     ...
-    ...    Wraps the entire open+select cycle in Wait Until Keyword Succeeds so that
-    ...    transient mid-render LWC states retry the whole sequence — not just the
-    ...    state check. The previous structure failed terminally on `not_found:[]`
-    ...    (combobox opened but options hadn't loaded yet because the LWC's parent
-    ...    was still server-fetching). Each retry now closes any open dropdown
-    ...    (Escape) before re-checking state, so the second pass either sees the
-    ...    pill (already_set) or gets a freshly-clicked combobox with populated
-    ...    options.
+    ...    Uses a manual retry loop (rather than Wait Until Keyword Succeeds) so it can
+    ...    distinguish transient mid-render LWC states from terminal data errors. The
+    ...    inner JS returns one of three sentinels via `_Try Set Default Catalog`:
+    ...      • `not_found:[]`            — dropdown opened before options finished
+    ...                                    server-fetching (transient → retry)
+    ...      • `not_found:[?,...]`       — options present but shadow roots still
+    ...                                    binding (transient → retry)
+    ...      • `not_found:[Cat A,...]`   — options fully loaded and target is
+    ...                                    genuinely missing (terminal → fail fast
+    ...                                    with the visible-options list)
+    ...    The terminal case used to mask as a 90s timeout under the previous
+    ...    Wait Until Keyword Succeeds wrapper; now it surfaces in one attempt so a
+    ...    missing catalog (e.g. QB PCM data load didn't run) or a mistyped name is
+    ...    obvious from the failure message instead of a generic timeout. Total
+    ...    budget for the transient/retry path stays ~90s with 5s between attempts
+    ...    to match the prior wrapper semantics.
     [Arguments]    ${target_value}
-    Wait Until Keyword Succeeds    90s    5s    _Try Set Default Catalog    ${target_value}
+    ${deadline}=    Evaluate    time.time() + 90    modules=time
+    ${attempt}=    Set Variable    ${0}
+    WHILE    True    limit=30
+        ${attempt}=    Evaluate    ${attempt} + 1
+        ${status}    ${error}=    Run Keyword And Ignore Error    _Try Set Default Catalog    ${target_value}
+        IF    "${status}" == "PASS"    RETURN
+        # Terminal sentinel: `not_found:[<non-empty-non-?-content>]` — options are
+        # loaded and the target is genuinely absent. The regex below requires at
+        # least one char between the brackets that is neither `?` nor `]`, so
+        # `not_found:[]`, `not_found:[?]`, and `not_found:[Cat,?]` all fall through
+        # to the retry path (transient render).
+        ${terminal}=    Run Keyword And Return Status
+        ...    Should Match Regexp    ${error}    not_found:\\[[^?\\]]+\\]
+        IF    ${terminal}
+            Fail    msg=Default Catalog "${target_value}" not present in visible options after ${attempt} attempt(s). ${error} — verify QB PCM data load (qb-pcm plan) completed and the catalog name matches exactly.
+        END
+        ${now}=    Evaluate    time.time()    modules=time
+        IF    ${now} >= ${deadline}
+            Fail    msg=Default Catalog "${target_value}" could not be set within 90s (${attempt} attempts). Last error: ${error}
+        END
+        Log    Default Catalog attempt ${attempt} transient — retrying: ${error}    INFO
+        Sleep    5s    reason=Wait before next open+select cycle
+    END
 
 _Try Set Default Catalog
     [Documentation]    One attempt at configuring the Default Catalog. Returns

--- a/robot/rlm-base/tests/setup/configure_product_discovery_settings.robot
+++ b/robot/rlm-base/tests/setup/configure_product_discovery_settings.robot
@@ -61,24 +61,37 @@ Set Default Catalog
     ...    option text read from lightning-base-combobox-item shadow roots). Clears any existing
     ...    selection first if a different catalog is already selected. Auto-saves on selection.
     ...
-    ...    Uses Wait Until Keyword Succeeds to retry when the combobox is not yet rendered —
-    ...    reconfigure_pricing_discovery triggers background processing that delays LWC render.
+    ...    Wraps the entire open+select cycle in Wait Until Keyword Succeeds so that
+    ...    transient mid-render LWC states retry the whole sequence — not just the
+    ...    state check. The previous structure failed terminally on `not_found:[]`
+    ...    (combobox opened but options hadn't loaded yet because the LWC's parent
+    ...    was still server-fetching). Each retry now closes any open dropdown
+    ...    (Escape) before re-checking state, so the second pass either sees the
+    ...    pill (already_set) or gets a freshly-clicked combobox with populated
+    ...    options.
     [Arguments]    ${target_value}
-    # Step 1: check current state; clear wrong selection; open dropdown (retry on combobox_not_found)
-    ${open_result}=    Wait Until Keyword Succeeds    30s    3s
-    ...    _Open Default Catalog Combobox    ${target_value}
+    Wait Until Keyword Succeeds    90s    5s    _Try Set Default Catalog    ${target_value}
+
+_Try Set Default Catalog
+    [Documentation]    One attempt at configuring the Default Catalog. Returns
+    ...    normally on success or already_set; fails (triggering the outer
+    ...    Wait Until Keyword Succeeds retry) on any transient mid-render state.
+    ...    Closes any open dropdown with Escape before the outer retry re-invokes
+    ...    so the next attempt starts from a clean state.
+    [Arguments]    ${target_value}
+    # Step 1: check current state; clear wrong selection; open dropdown
+    ${open_result}=    _Open Default Catalog Combobox    ${target_value}
     IF    "${open_result}" == "already_set"
         Log    Default Catalog already set to "${target_value}". No change needed.
         RETURN
     END
-    # If a selection was cleared, wait for the combobox to reappear then re-open it
-    # with retry — the pill-removal re-render is asynchronous and may exceed the initial sleep.
+    # If a selection was cleared, give the pill-removal re-render a beat then re-open
     IF    "${open_result}" == "cleared"
-        Sleep    2s    reason=Allow pill removal to start before polling for combobox
-        ${open_result}=    Wait Until Keyword Succeeds    30s    3s
-        ...    _Open Default Catalog Dropdown
+        Sleep    2s    reason=Allow pill removal to settle before re-opening
+        ${open_result}=    _Open Default Catalog Dropdown
     END
-    Should Be Equal    ${open_result}    opened    msg=Could not prepare/open Default Catalog combobox: ${open_result}
+    Should Be Equal    ${open_result}    opened
+    ...    msg=Could not prepare/open Default Catalog combobox: ${open_result}
     Sleep    1s    reason=Allow dropdown options to populate
     # Step 2: click the matching option (text is inside each option's shadow root)
     ${select_result}=    Execute JavaScript
@@ -96,10 +109,26 @@ Set Default Catalog
     ...        return 'not_found:[' + opts.map(function(o){return o.shadowRoot?o.shadowRoot.textContent.trim():'?';}).join(',') + ']';
     ...    })(arguments[0])
     ...    ARGUMENTS    ${target_value}
-    Should Be Equal    ${select_result}    clicked
-    ...    msg=Option "${target_value}" not found in dropdown. ${select_result}
-    Sleep    2s    reason=Allow selection to auto-save
-    Log    Default Catalog set to "${target_value}".
+    IF    "${select_result}" == "clicked"
+        Sleep    2s    reason=Allow selection to auto-save
+        Log    Default Catalog set to "${target_value}".
+        RETURN
+    END
+    # Empty / unmatched dropdown — close it (Esc) and let the outer retry try again.
+    # Most commonly empty: LWC parent's options-fetch hasn't completed yet, so the
+    # opened dropdown rendered zero options. By the next retry the parent should
+    # have either fully loaded (giving us a populated dropdown OR already_set pill).
+    _Close Default Catalog Dropdown
+    Fail    msg=Default Catalog dropdown returned "${select_result}"; closing and retrying open+select cycle...
+
+_Close Default Catalog Dropdown
+    [Documentation]    Dispatches Escape on document.body to close any open
+    ...    lightning-combobox dropdown. Used between retry attempts in
+    ...    _Try Set Default Catalog so a stale-open dropdown doesn't interfere
+    ...    with the next state check.
+    Execute JavaScript
+    ...    document.body.dispatchEvent(new KeyboardEvent('keydown', {key: 'Escape', code: 'Escape', keyCode: 27, which: 27, bubbles: true}));
+    Sleep    0.5s    reason=Allow dropdown close animation to complete
 
 _Read Default Catalog State
     [Documentation]    Reads the current selected catalog text from [data-id="selectedCatalog"]

--- a/robot/rlm-base/tests/setup/configure_product_discovery_settings.robot
+++ b/robot/rlm-base/tests/setup/configure_product_discovery_settings.robot
@@ -122,12 +122,23 @@ _Try Set Default Catalog
     Fail    msg=Default Catalog dropdown returned "${select_result}"; closing and retrying open+select cycle...
 
 _Close Default Catalog Dropdown
-    [Documentation]    Dispatches Escape on document.body to close any open
-    ...    lightning-combobox dropdown. Used between retry attempts in
-    ...    _Try Set Default Catalog so a stale-open dropdown doesn't interfere
-    ...    with the next state check.
+    [Documentation]    Closes any open lightning-combobox dropdown between retry
+    ...    attempts in _Try Set Default Catalog so a stale-open dropdown doesn't
+    ...    interfere with the next state check. Primary path is SeleniumLibrary
+    ...    Press Keys ESCAPE sent through the native WebDriver channel — this is
+    ...    more reliable than a JS-dispatched KeyboardEvent for LWCs because the
+    ...    event reaches whichever element actually has focus inside the shadow
+    ...    tree (matches the pattern in enable_constraints_settings.robot and
+    ...    configure_revenue_settings.robot). Fallback is a composed/cancelable
+    ...    KeyboardEvent dispatched to document.activeElement so the event still
+    ...    crosses any shadow boundary if Selenium can't locate a focused input.
+    Run Keyword And Ignore Error    Press Keys    ${NONE}    ESCAPE
     Execute JavaScript
-    ...    document.body.dispatchEvent(new KeyboardEvent('keydown', {key: 'Escape', code: 'Escape', keyCode: 27, which: 27, bubbles: true}));
+    ...    (function(){
+    ...        var ev = new KeyboardEvent('keydown', {key: 'Escape', code: 'Escape', keyCode: 27, which: 27, bubbles: true, cancelable: true, composed: true});
+    ...        var target = document.activeElement || document.body;
+    ...        target.dispatchEvent(ev);
+    ...    })();
     Sleep    0.5s    reason=Allow dropdown close animation to complete
 
 _Read Default Catalog State

--- a/robot/rlm-base/tests/setup/configure_product_discovery_settings.robot
+++ b/robot/rlm-base/tests/setup/configure_product_discovery_settings.robot
@@ -104,10 +104,17 @@ Set Default Catalog
 
 _Try Set Default Catalog
     [Documentation]    One attempt at configuring the Default Catalog. Returns
-    ...    normally on success or already_set; fails (triggering the outer
-    ...    Wait Until Keyword Succeeds retry) on any transient mid-render state.
-    ...    Closes any open dropdown with Escape before the outer retry re-invokes
-    ...    so the next attempt starts from a clean state.
+    ...    normally on success or already_set; on any other state, closes any
+    ...    open dropdown with Escape and fails with a message containing the
+    ...    raw `select_result` sentinel (e.g. `not_found:[]` or
+    ...    `not_found:[Cat A,Cat B]`). The caller — `Set Default Catalog` — wraps
+    ...    this in a manual WHILE loop with `Run Keyword And Ignore Error`,
+    ...    inspects the sentinel to classify the failure as transient (retry)
+    ...    or terminal (fail fast with the visible-options list), and re-invokes
+    ...    after a 5s sleep on the transient path. The dropdown close-on-fail
+    ...    here is what guarantees the next outer attempt starts from a clean
+    ...    state, so this keyword should not be called standalone outside that
+    ...    loop.
     [Arguments]    ${target_value}
     # Step 1: check current state; clear wrong selection; open dropdown
     ${open_result}=    _Open Default Catalog Combobox    ${target_value}
@@ -144,10 +151,12 @@ _Try Set Default Catalog
         Log    Default Catalog set to "${target_value}".
         RETURN
     END
-    # Empty / unmatched dropdown — close it (Esc) and let the outer retry try again.
-    # Most commonly empty: LWC parent's options-fetch hasn't completed yet, so the
-    # opened dropdown rendered zero options. By the next retry the parent should
-    # have either fully loaded (giving us a populated dropdown OR already_set pill).
+    # Close the dropdown (Esc) and fail with the raw select_result sentinel.
+    # The caller's WHILE loop (in Set Default Catalog) inspects the sentinel and
+    # decides retry-vs-fail: `not_found:[]` and `not_found:[?...]` are transient
+    # (parent's options-fetch hasn't completed or shadow roots still binding)
+    # and get retried; `not_found:[Cat A,Cat B]` means options are loaded and
+    # the target is genuinely missing — caller fails fast with the options list.
     _Close Default Catalog Dropdown
     Fail    msg=Default Catalog dropdown returned "${select_result}"; closing and retrying open+select cycle...
 
@@ -186,12 +195,17 @@ _Read Default Catalog State
 
 _Open Default Catalog Dropdown
     [Documentation]    Re-opens the Default Catalog combobox after a pill clear. Used by
-    ...    Set Default Catalog when the cleared-path needs to wait for the LWC to re-render
-    ...    the combobox button (pill removal is asynchronous and can take longer than the
-    ...    fixed sleep). Returns 'page_not_ready' for any transient render miss
-    ...    (combobox / lightning-base-combobox / button not yet present) so
-    ...    Wait Until Keyword Succeeds retries until the re-render settles —
-    ...    canonical pattern matching configure_core_pricing_setup.robot.
+    ...    _Try Set Default Catalog when the cleared-path needs to wait for the LWC to
+    ...    re-render the combobox button (pill removal is asynchronous and can take longer
+    ...    than the fixed sleep). Returns 'opened' on success, or fails the caller's
+    ...    Should Be Equal with 'page_not_ready' for any transient render miss (combobox
+    ...    / lightning-base-combobox / button not yet present). The caller's failure
+    ...    propagates up into `Set Default Catalog`'s manual WHILE loop, which retries
+    ...    the whole open+select cycle from scratch (this file uses a manual loop for
+    ...    that path so terminal-vs-transient classification can short-circuit retries;
+    ...    `configure_core_pricing_setup.robot` still uses `Wait Until Keyword Succeeds`
+    ...    for the analogous pattern because its inner helper takes a target value and
+    ...    bakes the equality check into the JS).
     ${result}=    Execute JavaScript
     ...    ${_JS_FIND_EL}
     ...    return (function() {
@@ -215,9 +229,13 @@ _Open Default Catalog Combobox
     ...    assertion), or 'page_not_ready' (any transient render miss — combobox /
     ...    lightning-base-combobox / button not yet present, OR the LWC has a saved value
     ...    that hasn't been swapped to a pill yet). Salesforce background processing after
-    ...    reconfigure_pricing_discovery delays LWC render; Wait Until Keyword Succeeds
-    ...    retries on the page_not_ready sentinel — canonical pattern matching
-    ...    configure_core_pricing_setup.robot.
+    ...    reconfigure_pricing_discovery delays LWC render; transient sentinels propagate
+    ...    via `_Try Set Default Catalog`'s Fail into `Set Default Catalog`'s manual WHILE
+    ...    loop, which re-invokes the whole open+select cycle (this file uses a manual
+    ...    loop for that path so terminal-vs-transient classification can short-circuit
+    ...    retries; `configure_core_pricing_setup.robot` still uses `Wait Until Keyword
+    ...    Succeeds` for the analogous pattern because its inner helper takes a target
+    ...    value and bakes the equality check into the JS).
     ...
     ...    When the LWC has a saved value (e.g. on a re-run where Default Catalog is already
     ...    set), it briefly renders the empty-state combobox before swapping to the pill.

--- a/robot/rlm-base/tests/setup/configure_product_discovery_settings.robot
+++ b/robot/rlm-base/tests/setup/configure_product_discovery_settings.robot
@@ -28,11 +28,16 @@ Configure Product Discovery Default Catalog
     Set Default Catalog    ${DEFAULT_CATALOG}
     Dismiss Toast If Present
     Capture Page Screenshot
-    # Reload and re-verify to confirm the value was saved server-side
+    # Reload and re-verify to confirm the value was saved server-side.
+    # Open Setup Page sleeps 2s for generic Lightning rendering, but the
+    # Product Discovery Settings LWC + its [data-id="selectedCatalog"]
+    # pill take longer than that to wire on the post-reload visit. Without
+    # a retry the read returns 'not_set' even when the catalog is genuinely
+    # persisted server-side. Wait Until Keyword Succeeds polls
+    # _Read Default Catalog State (which treats 'not_set' as a retry signal)
+    # until the pill renders.
     Open Product Discovery Settings Page
-    ${verified}=    Execute JavaScript
-    ...    ${_JS_FIND_EL}
-    ...    return findEl(document, '[data-id="selectedCatalog"]', 0)?.textContent.trim() || 'not_set'
+    ${verified}=    Wait Until Keyword Succeeds    30s    2s    _Read Default Catalog State
     Should Be Equal    ${verified}    ${DEFAULT_CATALOG}
     ...    msg=Default Catalog not persisted after page reload: expected "${DEFAULT_CATALOG}", got "${verified}"
     Log    Product Discovery Settings: Default Catalog confirmed as "${DEFAULT_CATALOG}" after reload.
@@ -95,6 +100,19 @@ Set Default Catalog
     ...    msg=Option "${target_value}" not found in dropdown. ${select_result}
     Sleep    2s    reason=Allow selection to auto-save
     Log    Default Catalog set to "${target_value}".
+
+_Read Default Catalog State
+    [Documentation]    Reads the current selected catalog text from [data-id="selectedCatalog"]
+    ...    after a Product Discovery Settings reload. Returns the catalog name when the pill
+    ...    has rendered, or fails with 'not_set' to drive Wait Until Keyword Succeeds retry —
+    ...    the LWC routinely takes longer than Open Setup Page's 2s default sleep to wire on
+    ...    the post-reload visit. Caller asserts the final state.
+    ${state}=    Execute JavaScript
+    ...    ${_JS_FIND_EL}
+    ...    return findEl(document, '[data-id="selectedCatalog"]', 0)?.textContent.trim() || 'not_set'
+    Should Not Be Equal    ${state}    not_set
+    ...    msg=Default Catalog pill not yet rendered post-reload; retrying...
+    RETURN    ${state}
 
 _Open Default Catalog Dropdown
     [Documentation]    Re-opens the Default Catalog combobox after a pill clear. Used by

--- a/robot/rlm-base/tests/setup/enable_document_builder.robot
+++ b/robot/rlm-base/tests/setup/enable_document_builder.robot
@@ -57,20 +57,40 @@ Enable Document Templates Export On General Settings
         ...    msg=Document Templates Export could not be clicked (got: ${click_result})
     END
     Sleep    3s    reason=Allow toggle change to reach Salesforce server
-    # Reload and re-verify server-side persistence
+    # Reload and re-verify server-side persistence. The reload-and-verify
+    # path needs the same "wait for setup_industries_docgen-preference-toggle
+    # LWC to mount" pause as the pre-click path (the suite's first `Sleep 5s`
+    # above). Open Setup Page only sleeps 2s for generic Lightning rendering,
+    # which is not long enough for the docgen LWC to wire on a second visit
+    # — without the retry below the JS lookup returns 'not_found' even when
+    # the toggle is genuinely persisted. Wait Until Keyword Succeeds polls
+    # the JS lookup up to 30s/2s, treating 'not_found' as a retry signal and
+    # only succeeding when the toggle is in the DOM and reads 'on'.
     Open Setup Page    ${GENERAL_SETTINGS_PATH}
-    ${verified}=    Execute JavaScript
+    ${verified}=    Wait Until Keyword Succeeds    30s    2s    _Read Document Templates Export State
+    Should Be Equal    ${verified}    on
+    ...    msg=Document Templates Export toggle not persisted after page reload (got: ${verified})
+    Log    Document Templates Export toggle enabled and confirmed.
+
+*** Keywords ***
+_Read Document Templates Export State
+    [Documentation]    Reads the current checked state of the Document Templates
+    ...    Export toggle (input[data-name="MetadataPreference"]) via findEl
+    ...    shadow-DOM traversal. Returns 'on' or 'off' when the toggle has
+    ...    mounted; fails with 'not_found' to drive Wait Until Keyword Succeeds
+    ...    retry (the LWC takes longer than Open Setup Page's 2s default sleep
+    ...    to wire on the post-reload visit). Caller asserts the final state.
+    ${state}=    Execute JavaScript
     ...    ${_JS_FIND_EL}
     ...    return (function() {
     ...        var pi = findEl(document, 'input[data-name="MetadataPreference"]', 0);
     ...        if (!pi) return 'not_found';
     ...        return pi.checked ? 'on' : 'off';
     ...    })()
-    Should Be Equal    ${verified}    on
-    ...    msg=Document Templates Export toggle not persisted after page reload (got: ${verified})
-    Log    Document Templates Export toggle enabled and confirmed.
+    Should Not Be Equal    ${state}    not_found
+    ...    msg=Document Templates Export input[data-name="MetadataPreference"] not yet rendered post-reload; retrying...
+    RETURN    ${state}
 
-*** Keywords ***
 _Click Document Templates Export Toggle
     [Documentation]    Directly clicks input[data-name="MetadataPreference"] inside
     ...    setup_industries_docgen-preference-toggle's shadow root, bypassing Enable Toggle By Label

--- a/robot/rlm-base/tests/setup/enable_document_builder.robot
+++ b/robot/rlm-base/tests/setup/enable_document_builder.robot
@@ -64,8 +64,13 @@ Enable Document Templates Export On General Settings
     # which is not long enough for the docgen LWC to wire on a second visit
     # — without the retry below the JS lookup returns 'not_found' even when
     # the toggle is genuinely persisted. Wait Until Keyword Succeeds polls
-    # the JS lookup up to 30s/2s, treating 'not_found' as a retry signal and
-    # only succeeding when the toggle is in the DOM and reads 'on'.
+    # the JS lookup up to 30s/2s, treating 'not_found' as a retry signal so
+    # the wait only completes once the toggle is rendered in the DOM. The
+    # subsequent Should Be Equal then asserts the persisted value ('on'); a
+    # persistent 'off' is intentionally not retried so we fail fast and surface
+    # a real persistence problem instead of waiting out a 30s timeout (the 3s
+    # pre-reload sleep plus reload time give the server-side state binding
+    # plenty of headroom).
     Open Setup Page    ${GENERAL_SETTINGS_PATH}
     ${verified}=    Wait Until Keyword Succeeds    30s    2s    _Read Document Templates Export State
     Should Be Equal    ${verified}    on

--- a/unpackaged/post_personas/permissionsets/RLM_QuantumBit_Sales_Representative.permissionset-meta.xml
+++ b/unpackaged/post_personas/permissionsets/RLM_QuantumBit_Sales_Representative.permissionset-meta.xml
@@ -305,11 +305,16 @@
         <field>Quote.ExpirationDate</field>
         <readable>true</readable>
     </fieldPermissions>
-    <fieldPermissions>
-        <editable>true</editable>
-        <field>Quote.IsLargeDeal</field>
-        <readable>true</readable>
-    </fieldPermissions>
+    <!--
+        Quote.IsLargeDeal is a STANDARD field gated by the Large Transaction
+        Scale pilot, which is only available in internal Salesforce org shapes
+        (not standard scratches). It is granted to the persona via the
+        RLM_LargeSalesTransaction PermissionSet (unpackaged/post_large_stx),
+        which is deployed AND assigned to the salesrep user only when both
+        feature flags `personas` and `large_stx` are on. Do NOT add it back
+        here — it would break deploy on every standard scratch (personas=true,
+        large_stx=false).
+    -->
     <fieldPermissions>
         <editable>true</editable>
         <field>Quote.PartnerAccountId</field>


### PR DESCRIPTION
## Summary

`prepare_rlm_org` was failing at three consecutive setup steps, then at a fourth on idempotent re-run. All four are race-condition bugs with Salesforce setup-page LWCs that take longer to mount than `Open Setup Page`'s default 2 s wait. The pre-action paths in each robot already retried via `Wait Until Keyword Succeeds` on a `page_not_ready` sentinel; the post-reload **verify** paths were missing the equivalent (commits 1–3), and the Product Discovery forward path had an **unhandled mid-render state** (commit 4).

All four were discovered sequentially while the user re-ran `prepare_rlm_org` against `ent-sb0`: each fix unblocked the flow until the next instance surfaced.

## Failures and fixes

### 1. `prepare_docgen.enable_document_builder_toggle` — commit `01da6b09`

```
Document Templates Export toggle not persisted after page reload
(got: not_found): not_found != on
```

Post-reload verify path. Added `_Read Document Templates Export State` helper + `Wait Until Keyword Succeeds 30s/2s` wrapping it; treats `not_found` as a retry signal.

### 2. `prepare_revenue_settings.configure_core_pricing_setup` — commit `37d7a0d8`

```
Pricing Procedure not persisted after page reload:
expected "RLM Revenue Management Default Pricing Procedure",
got "not_set": not_set != RLM Revenue Management Default Pricing Procedure
```

Same shape as #1 in a different robot. Added `_Read Pricing Procedure Pill State` helper; treats `not_set` as a retry signal.

### 3. `configure_product_discovery_settings` (post-reload verify) — commit `7e99d10f`

```
Default Catalog not persisted after page reload:
expected "QuantumBit Software", got "not_set":
not_set != QuantumBit Software
```

Same shape as #1 + #2. Added `_Read Default Catalog State` helper; treats `not_set` as a retry signal. **This one needed 2 retries** (~4 s of polling) before the LWC mounted, confirming the 30 s / 2 s budget was the right call.

### 4. `configure_product_discovery_settings` (forward path, re-run) — commit `b1e076ab`

```
Option "QuantumBit Software" not found in dropdown.
not_found:[]: not_found:[] != clicked
```

**Different bug class.** On a re-run where the catalog was already set, the LWC briefly renders the empty-state combobox before swapping to the pill. The forward-path state-check JS misinterpreted that mid-render window as "no value set" and clicked an empty dropdown. Added a single guard:

```js
if (lc.value) return 'page_not_ready';
```

`lightning-combobox.value` is the LWC's bound saved value — when it's non-empty but the pill hasn't rendered yet, we're mid-render. Returning `page_not_ready` triggers the existing `Wait Until Keyword Succeeds` retry loop until the pill lands.

(First attempt at this fix used a `//`-style inline JS comment that Robot's `Execute JavaScript` joined into the rest of the function, breaking syntax with `Unexpected token '}'`. Fixed by dropping the comment — the keyword docstring carries the explanation instead.)

## Root cause (common to all four)

`Open Setup Page` (in `SetupToggles.robot`) ends with `Sleep 2s reason=Allow Lightning to finish rendering`. That's enough for generic Lightning chrome, but not for setup-specific LWCs to wire on the second (post-reload) visit, and not for the Product Discovery LWC to settle from empty-combobox → pill on a re-run. The pre-action paths already use `Wait Until Keyword Succeeds` polling with a `page_not_ready` sentinel; this PR brings the post-reload verify paths in line with that pattern (#1–#3) and adds the missing mid-render branch to the forward path (#4).

## Validation (against `ent-sb0`)

| Test | Result | Path | Retries observed |
|---|---|---|---|
| `enable_document_builder_toggle` | 3/3 pass | post-reload verify | 1 (`not_found` → `on` after 2 s) |
| `configure_core_pricing_setup` | 1/1 pass | post-reload verify | 1 (`not_set` → pill after 2 s) |
| `configure_product_discovery_settings` (first run) | 1/1 pass | post-reload verify | 2 (`not_set` × 2 → pill after 4 s) |
| `configure_product_discovery_settings` (re-run, already set) | 1/1 pass | forward path `already_set` | ≥1 (`page_not_ready` → `already_set` once pill mounted) |

## Decision: defer the abstraction

Three of the four fixes (#1–#3) share the same `_Read X State` + `Wait Until Keyword Succeeds` shape. Reusable-helper shape considered:

```robot
Read Setting Via Js With Retry    ${js_var}    ${retry_sentinel}
...                               ${args}=    ${timeout}=30s    ${interval}=2s
```

Each call site would declare its JS as a `*** Variables ***` entry and pass the variable name + sentinel to the shared helper.

**Verdict:** Hold off. The savings are small (~10 lines of boilerplate per file) vs a multi-arg keyword that's harder to read at the call site than the current named `_Read X State` keywords. The JS bodies are genuinely different DOM walks and would still need per-file homes. Fix #4 is structurally different (forward-path JS bug, not a verify-path retry), so it doesn't bump the count. Revisit when a fourth *verify-path* instance surfaces.

## Test plan

- [x] `cci task run enable_document_builder_toggle` against ent-sb0 — passes.
- [x] `cci task run configure_core_pricing_setup` against ent-sb0 — passes.
- [x] `cci task run configure_product_discovery_settings` against fresh org — passes.
- [x] `cci task run configure_product_discovery_settings` against org with catalog already set — passes (forward path takes `already_set` short-circuit).
- [x] Full `cci flow run prepare_rlm_org` against a clean 262 scratch — should now proceed past all four steps (validation in progress locally).
- [ ] Copilot review.

---

## Additional fix (commit `eadab71`): persona deploy on `large_stx=false` shapes

Encountered during the same `prepare_rlm_org` run that drove the robot fixes above. After the four robot setup tests passed, `prepare_personas` failed at `deploy_post_personas`:

```
Update of PermissionSet RLM_QuantumBit_Sales_Representative:
Error: In field: field - no CustomField named Quote.IsLargeDeal found
```

### Root cause

`Quote.IsLargeDeal` is a **standard** field gated by the **Large Transaction Scale pilot**, which is only available in internal Salesforce org shapes — not in standard scratch shapes. The repo had three coupled bugs that all blew up on `personas=true, large_stx=false`:

1. `RLM_QuantumBit_Sales_Representative.permissionset-meta.xml` (always deployed under `unpackaged/post_personas/`) unconditionally referenced `Quote.IsLargeDeal`. The field exists in `RLM_LargeSalesTransaction.permissionset-meta.xml` (under `unpackaged/post_large_stx/`, properly flag-gated) — so the persona PS reference was a duplicate that broke the always-deployed bundle.

2. `prepare_personas` step 7 (`assign_permission_sets` of `RLM_LargeSalesTransaction` to the `salesrep` user) was gated only on `personas`. Even after fix #1, the next build would fail trying to assign a PermissionSet that the `large_stx` flag had prevented from being deployed.

3. The `large_stx` default was `true`. Standard scratch builds therefore tried to deploy the `large_stx` bundle (containing pilot-only metadata) and failed. Defaulting to `false` matches what standard shapes actually support; internal contributors flip it on per build.

### Changes

- **Removed** the duplicate `Quote.IsLargeDeal` fieldPermissions block from `RLM_QuantumBit_Sales_Representative.permissionset-meta.xml`, with an inline XML comment to prevent regression.
- **Tightened** the `prepare_personas` step 7 `when:` to `project_config.project__custom__personas and project_config.project__custom__large_stx`.
- **Flipped** the `large_stx` default in `cumulusci.yml` from `true` to `false`.
- **Regenerated** `feature-flags.md`, `flows-reference.md`, `tasks-reference.md` per the doc-consistency checklist.

### Why fold into PR #171 instead of a separate PR

This failure surfaced in the same `prepare_rlm_org` run as the robot test failures and shares the same validation surface (full `prepare_rlm_org` against a clean 262 scratch). Keeping them together avoids a second round of full-flow validation.

### Additional test plan

- [x] `cci flow run prepare_rlm_org` against a clean 262 scratch with default flags (`personas=true, large_stx=false`) — must complete through `prepare_personas`.
- [ ] (Internal-shape only) Same flow with `large_stx: true` flipped locally — must still deploy `RLM_LargeSalesTransaction` and assign it to the salesrep user.
