### PR TITLE
chore(262): forward-port layered dev environment from main (PR #161)

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,32 @@
+# Project env for rlm-base-dev. Activated by direnv on entry; deactivated on exit.
+# Requires: brew install direnv ; eval "$(direnv hook zsh)" in ~/.zshrc.
+
+# ── Python via pyenv ─────────────────────────────────────────────────────────
+# Pin to the 3.13 major.minor line; auto-resolve to the latest installed patch.
+# To install a new 3.13.x patch, run `scripts/bash/update-toolchain.sh` — it
+# resolves the latest patch in the line, installs it, and reinstalls the CCI
+# pipx venv under the new Python (the venv's python symlink breaks otherwise).
+# Manual equivalent: `pyenv install $(pyenv latest -k 3.13)`.
+if command -v pyenv >/dev/null 2>&1; then
+  _PY_RESOLVED="$(pyenv latest 3.13 2>/dev/null)"
+  if [ -n "$_PY_RESOLVED" ]; then
+    export PYENV_VERSION="$_PY_RESOLVED"
+    PATH_add "$(pyenv root)/shims"
+  else
+    echo ".envrc: no Python 3.13.x installed via pyenv. Run scripts/bash/update-toolchain.sh or 'pyenv install \$(pyenv latest -k 3.13)' to install the latest patch." >&2
+  fi
+  unset _PY_RESOLVED
+fi
+
+# ── Node via nvm ─────────────────────────────────────────────────────────────
+# `lts/*` tracks whichever line is currently the active LTS (today: Node 24).
+# When the next LTS lands, `nvm install --lts` + this line keeps you current.
+# nvm path is resolved via `brew --prefix nvm` to work on both Apple Silicon
+# (`/opt/homebrew`) and Intel macOS (`/usr/local`) — matches the README pattern.
+export NVM_DIR="$HOME/.nvm"
+_NVM_PREFIX="$(brew --prefix nvm 2>/dev/null || true)"
+if [ -n "$_NVM_PREFIX" ] && [ -s "$_NVM_PREFIX/nvm.sh" ]; then
+  . "$_NVM_PREFIX/nvm.sh" --no-use
+  nvm use --silent lts/\* >/dev/null 2>&1 || nvm use --silent default >/dev/null 2>&1
+fi
+unset _NVM_PREFIX

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -210,6 +210,7 @@ that topic.
 
 | I need to... | Skill File (relative to repo root) |
 |-------------|-------------------------------------|
+| Set up / replicate / update the local dev toolchain | `docs/guides/dev-environment-setup.md` |
 | Add new features, code placement | `.cursor/skills/repo-integration/SKILL.md` |
 | Work with CCI tasks, flows, CLI | `.cursor/skills/cci-orchestration/SKILL.md` |
 | Write a Python CCI task class | `.cursor/skills/cci-orchestration/custom-task-authoring.md` |

--- a/README.md
+++ b/README.md
@@ -31,6 +31,13 @@ The main branch targets Salesforce Release 260 (Spring '26, GA). Other branches 
 
 > **Cursor users:** Open this README in [Cursor](https://www.cursor.com/), press `Cmd+L` to open the AI chat, and paste: *"Walk me through the macOS Environment Setup section of this README, running each command in the terminal."* The agent can execute each step interactively. Run the steps in order — each one builds on the previous.
 
+> **For the layered/canonical view** (shell config architecture, per-project
+> `.envrc` activation via direnv, major-line pin strategy, and the
+> `scripts/bash/update-toolchain.sh` maintenance routine), see
+> [`docs/guides/dev-environment-setup.md`](docs/guides/dev-environment-setup.md).
+> Steps 1–11 below are the first-time bootstrap; the guide describes the
+> target architecture and ongoing maintenance you'll move to after that.
+
 This section walks through a full, clean environment setup on macOS using [Homebrew](https://brew.sh/) for package management, [pyenv](https://github.com/pyenv/pyenv) for Python version management, and [nvm](https://github.com/nvm-sh/nvm) for Node.js version management. Using version managers (pyenv + nvm) keeps your tool installations isolated from the macOS system Python and Node, avoiding conflicts when multiple projects need different versions. Skip any step for tools you already have installed.
 
 ### Step 1 — Install Homebrew
@@ -294,6 +301,19 @@ node --version && sf --version && cci version && python --version
 If any command returns "not found", check that `~/.zshenv` contains the nvm and pyenv init blocks (see Steps 3 and 4), then **restart Claude Code** so it picks up the updated PATH.
 
 **After any PATH change** (new nvm version, new pyenv version, new pipx install), restart Claude Code — it inherits the PATH from the shell that launched it and does not reload `~/.zshenv` mid-session.
+
+### Ongoing toolchain maintenance
+
+Once the bootstrap above is complete, ongoing updates (new Python patches,
+Node LTS refreshes, sf/CCI/SFDMU upgrades) are handled by a single script:
+
+```bash
+scripts/bash/update-toolchain.sh
+```
+
+It walks `brew update && brew upgrade` → latest patch in your pinned Python line → latest LTS Node → `sf update` → CCI reinstall/upgrade → `sf plugins update` → `cci task run validate_setup`. Major-line pins (e.g. Python 3.13, Node `lts/*`) are configured at the top of the script.
+
+For the full architecture — shell config responsibilities, the per-project `.envrc` pattern via [direnv](https://direnv.net/), troubleshooting, and instructions for replicating on a new workstation — see [`docs/guides/dev-environment-setup.md`](docs/guides/dev-environment-setup.md).
 
 **Validating the full setup from Claude Code:** Ask Claude to run `cci task run validate_setup`. This checks all required tools and — when the relevant auto-fix options are enabled — can auto-fix missing robot deps (default on) and update the SFDMU version (default on). urllib3 is upgraded as a side-effect of the robot dep fix, or independently with `auto_fix_urllib3=true`. No org connection needed. It is the fastest way to confirm your environment is ready before running flows.
 
@@ -1029,6 +1049,7 @@ For details on exporting new models, importing into target orgs, polymorphic ID 
 
 | Document | Description |
 |----------|-------------|
+| [Dev Environment Setup](docs/guides/dev-environment-setup.md) | Canonical local toolchain architecture — shell config layout, direnv `.envrc` per-project pinning, major-line update strategy, replication on new workstations |
 | [Constraints Utility Guide](datasets/constraints/README.md) | CML constraint model export, import, validate -- architecture, workflows, polymorphic resolution |
 | [Constraints Setup](docs/guides/constraints-setup.md) | `prepare_constraints` flow order, feature flags, deployment phases |
 | [Decision Table Examples](docs/references/decision-table-examples.md) | Comprehensive examples for Decision Table management tasks |

--- a/docs/guides/dev-environment-setup.md
+++ b/docs/guides/dev-environment-setup.md
@@ -1,0 +1,329 @@
+# Developer Environment Setup
+
+Canonical reference for setting up a local dev environment to work on
+**rlm-base-dev** (and similar Salesforce / CumulusCI projects) on macOS.
+
+This document captures **two layers**:
+
+1. **System layer** — versioned toolchain shared across all projects on the
+   workstation (Homebrew, nvm, pyenv, pipx, direnv).
+2. **Project layer** — per-project pins via `.envrc`, activated automatically
+   when you `cd` into the project directory.
+
+The goal is one inventory you can share with teammates so every workstation
+ends up with the same layered structure — not the same exact patch versions.
+
+> **Audience:** new contributors bootstrapping a workstation, or existing
+> contributors replicating the setup on a second machine. For the very first
+> install steps (Homebrew, git, nvm, pyenv), follow the README's
+> *macOS Environment Setup* (Steps 1–11). This doc describes the **target
+> architecture** and **ongoing maintenance** once those are in place.
+
+---
+
+## 1. Toolchain inventory
+
+| Tool | Installer | Purpose | Pin strategy |
+|------|-----------|---------|--------------|
+| **Homebrew** | macOS pkg installer (one-time) | Package manager for everything below | latest |
+| **direnv** | `brew install direnv` | Per-project env activation on `cd` | latest |
+| **nvm** | `brew install nvm` | Node version manager | latest |
+| **Node.js** | `nvm install --lts` | JavaScript runtime for `sf` CLI | major LTS line (`lts/*`) |
+| **pyenv** | `brew install pyenv` | Python version manager | latest |
+| **Python** | `pyenv install $(pyenv latest -k 3.13)` | Runtime for CumulusCI + scripts | major.minor line (`3.13`) |
+| **pipx** | `$(pyenv prefix)/bin/python3 -m pip install --user pipx` | Isolated CLI installs (CCI) | latest |
+| **CumulusCI** | `pipx install cumulusci --python "$(pyenv prefix)/bin/python3"` | Orchestration engine | latest; ensure `setuptools>=75.4` (snowfakery 4.x requirement) |
+| **Salesforce CLI (`sf`)** | `npm install -g @salesforce/cli` | Salesforce metadata + data | latest (built-in auto-updater) |
+| **SFDMU plugin** | `sf plugins install sfdmu` | Bulk data import/export | v5+ required (enforced by `cci task run validate_setup`) |
+| **gh, git, GCM** | `brew install gh git git-credential-manager` | Source control + PR workflow | latest |
+
+**Pin philosophy:**
+- **Major line, not minor.** Patch versions move forward automatically. Bumping
+  a major line (Python 3.13 → 3.14, Node 24 → 26) is a deliberate, tested
+  change tracked in `scripts/bash/update-toolchain.sh`.
+- **pyenv and nvm are version managers, not version pickers.** Let them
+  resolve the latest installed patch via `pyenv latest 3.13` and `nvm use 'lts/*'` (quote the glob so zsh doesn't expand it).
+
+---
+
+## 2. System layout
+
+```
+~/.zshenv                            All zsh shells (login, interactive, scripts, Claude Code Bash)
+~/.zprofile                          Login shells only
+~/.zshrc                             Interactive shells only
+
+/opt/homebrew/                       Homebrew prefix (Apple Silicon)
+~/.nvm/                              nvm dir; node versions under versions/node/
+~/.pyenv/                            pyenv dir; python versions under versions/
+~/.local/bin/                        pipx-installed CLIs (cci, etc.)
+
+<project>/.envrc                     direnv config — per-project pyenv + nvm pins
+```
+
+### Shell config responsibilities
+
+Each file does one job. No duplication.
+
+#### `~/.zshenv` — runs in **every** shell
+Must be **fast** (~70ms target). No interactive features.
+
+```sh
+# Homebrew — detect prefix on Apple Silicon (/opt/homebrew) and Intel (/usr/local).
+# Using `brew shellenv` here (rather than just adding bin to PATH) sets MANPATH,
+# INFOPATH, and HOMEBREW_* env vars too, so later `brew --prefix nvm` works
+# in non-login shells.
+if [ -x /opt/homebrew/bin/brew ]; then
+  eval "$(/opt/homebrew/bin/brew shellenv)"
+elif [ -x /usr/local/bin/brew ]; then
+  eval "$(/usr/local/bin/brew shellenv)"
+fi
+
+# pipx-installed CLIs
+export PATH="$HOME/.local/bin:$PATH"
+
+# NVM — function definitions + default node bin on PATH (no slow `nvm use`).
+# `brew --prefix nvm` resolves to /opt/homebrew/opt/nvm (Apple Silicon)
+# or /usr/local/opt/nvm (Intel) — works on both architectures.
+export NVM_DIR="$HOME/.nvm"
+_NVM_PREFIX="$(brew --prefix nvm 2>/dev/null || true)"
+if [ -n "$_NVM_PREFIX" ] && [ -s "$_NVM_PREFIX/nvm.sh" ]; then
+  . "$_NVM_PREFIX/nvm.sh" --no-use
+  if [ -s "$NVM_DIR/alias/default" ]; then
+    _NVM_DEF="$(cat "$NVM_DIR/alias/default")"
+    while [ -s "$NVM_DIR/alias/$_NVM_DEF" ]; do
+      _NVM_DEF="$(cat "$NVM_DIR/alias/$_NVM_DEF")"
+    done
+    _NVM_VER="v${_NVM_DEF#v}"
+    [ -d "$NVM_DIR/versions/node/$_NVM_VER/bin" ] && \
+      export PATH="$NVM_DIR/versions/node/$_NVM_VER/bin:$PATH"
+    unset _NVM_DEF _NVM_VER
+  fi
+fi
+unset _NVM_PREFIX
+
+# pyenv binary on PATH — but NO global init. Per-project init via direnv.
+export PYENV_ROOT="$HOME/.pyenv"
+[ -d "$PYENV_ROOT/bin" ] && export PATH="$PYENV_ROOT/bin:$PATH"
+
+# direnv export — activates project .envrc in non-interactive shells too
+command -v direnv >/dev/null 2>&1 && eval "$(direnv export zsh 2>/dev/null)"
+```
+
+#### `~/.zprofile` — runs in **login** shells only
+
+`.zshenv` already runs for every shell (including login), so it handles
+Homebrew setup. `.zprofile` is reserved for login-only extras.
+
+```sh
+# Login-only PATH additions (Homebrew + nvm + pyenv all live in .zshenv).
+export PATH="$PATH:$HOME/Library/Application Support/JetBrains/Toolbox/scripts"
+```
+
+#### `~/.zshrc` — runs in **interactive** shells only
+
+```sh
+# direnv hook: auto-reload .envrc on cd between dirs
+command -v direnv >/dev/null 2>&1 && eval "$(direnv hook zsh)"
+
+# nvm completions (interactive nicety)
+_NVM_PREFIX="$(brew --prefix nvm 2>/dev/null || true)"
+[ -n "$_NVM_PREFIX" ] && [ -s "$_NVM_PREFIX/etc/bash_completion.d/nvm" ] && \
+  . "$_NVM_PREFIX/etc/bash_completion.d/nvm"
+unset _NVM_PREFIX
+
+# Project / org env vars (Anthropic, Vertex, etc.) go here
+```
+
+### Why this layout
+
+- **`~/.zshenv` runs for everything** — including Claude Code's Bash tool,
+  IDE-spawned shells, and cron. Putting toolchain PATH here means `sf`,
+  `node`, `cci`, etc. are available even in non-interactive contexts.
+- **No global `pyenv init`** — that's the historical source of stale
+  `.pyenv-shim` lock files when multiple shells start concurrently. direnv
+  handles pyenv per-project, only where needed.
+- **direnv is sourced from both `.zshenv` and `.zshrc`.**
+  - `.zshenv` runs `direnv export zsh` — activates `.envrc` on shell startup
+    (the only path non-interactive shells get).
+  - `.zshrc` adds `direnv hook zsh` — adds a `precmd` for interactive
+    auto-reload when you `cd` between projects.
+
+---
+
+## 3. Per-project activation (direnv `.envrc`)
+
+Each project owns its `.envrc`. Commit it to git so teammates get the same
+pins. For **rlm-base-dev** it lives at the repo root:
+
+```sh
+# .envrc
+
+# Python via pyenv — major.minor line, auto-resolve latest patch
+if command -v pyenv >/dev/null 2>&1; then
+  _PY_RESOLVED="$(pyenv latest 3.13 2>/dev/null)"
+  if [ -n "$_PY_RESOLVED" ]; then
+    export PYENV_VERSION="$_PY_RESOLVED"
+    PATH_add "$(pyenv root)/shims"
+  else
+    echo ".envrc: no Python 3.13.x installed via pyenv. Run scripts/bash/update-toolchain.sh or 'pyenv install \$(pyenv latest -k 3.13)' to install the latest patch." >&2
+  fi
+  unset _PY_RESOLVED
+fi
+
+# Node via nvm — track active LTS line. brew --prefix nvm resolves to
+# /opt/homebrew/opt/nvm (Apple Silicon) or /usr/local/opt/nvm (Intel).
+export NVM_DIR="$HOME/.nvm"
+_NVM_PREFIX="$(brew --prefix nvm 2>/dev/null || true)"
+if [ -n "$_NVM_PREFIX" ] && [ -s "$_NVM_PREFIX/nvm.sh" ]; then
+  . "$_NVM_PREFIX/nvm.sh" --no-use
+  nvm use --silent lts/\* >/dev/null 2>&1 || nvm use --silent default >/dev/null 2>&1
+fi
+unset _NVM_PREFIX
+```
+
+### First-time activation
+
+```bash
+cd path/to/rlm-base-dev
+direnv allow              # one-time per workstation per .envrc revision
+```
+
+### Verify
+
+```bash
+python --version          # → Python 3.13.x  (whatever latest installed patch is)
+pyenv version             # → 3.13.x (set by PYENV_VERSION environment variable)
+node --version            # → v24.x (latest LTS)
+cci --version             # → CumulusCI 4.x
+sf --version              # → @salesforce/cli/2.x
+```
+
+### Adapting to another project
+
+Copy `.envrc`, edit the python/node lines (e.g. `pyenv latest 3.12` if the
+project still needs 3.12), `direnv allow`. The system layer doesn't change.
+
+---
+
+## 4. Maintaining the toolchain
+
+### Update routine
+
+```bash
+cd rlm-base-dev
+scripts/bash/update-toolchain.sh
+```
+
+The script handles:
+
+1. `brew update && brew upgrade`
+2. `pyenv install --skip-existing $(pyenv latest -k 3.13)` — installs newest
+   patch in the pinned major.minor line, **only if** there's a newer one
+3. `nvm install --lts --reinstall-packages-from=current --latest-npm` —
+   keeps `sf` and other npm globals carried forward
+4. `sf update` — uses the CLI's built-in updater
+5. `pipx install --force cumulusci` (if Python patch bumped) **or**
+   `pipx upgrade cumulusci` — required because patch upgrades break the
+   venv's python symlink
+6. `pipx inject --force cumulusci "setuptools>=75.4"` — snowfakery 4.x
+   requires modern setuptools. The historical `<71` pin (older docs)
+   is **incompatible**; see README's *Note on setuptools*. Note CI
+   adds `<77` as well (`.github/workflows/prepare-rlm-org.yml`) because
+   it's pinned to CCI 4.8.1; modern CCI 4.10+ works with setuptools
+   77+ so this guide doesn't enforce the upper bound.
+7. `sf plugins update`
+8. `cci task run validate_setup` — verifies all 12 checks still pass
+
+### Bumping a major line
+
+When Python 3.14 stabilizes for CCI, or Node 26 becomes LTS:
+
+1. Edit `PY_LINE` / `NODE_LINE` at the top of `scripts/bash/update-toolchain.sh`
+2. Edit the `pyenv latest <line>` call in `.envrc`
+3. Run the script. It installs the new line, reinstalls CCI under the new
+   Python, and verifies via `validate_setup`.
+4. Commit `.envrc` + the script changes.
+5. Optionally `pyenv uninstall <old.line>.x` and `nvm uninstall <old-node>`.
+
+---
+
+## 5. Replicating on a new workstation
+
+For a clean macOS workstation, in order:
+
+1. **System bootstrap** — follow `README.md` § *macOS Environment Setup*
+   Steps 1–11. That installs Homebrew, git, gh, GCM, nvm + Node LTS,
+   pyenv + Python 3.13.x, pipx, CumulusCI, sf CLI, and SFDMU.
+2. **Add direnv** — `brew install direnv`.
+3. **Restructure shell configs** — replace `~/.zshenv`, `~/.zprofile`,
+   `~/.zshrc` with the templates in §2 above. Save backups first
+   (`cp ~/.zshenv ~/.zshenv.bak.$(date +%Y%m%d)` etc.).
+4. **Clone and activate** —
+   ```bash
+   gh repo clone bgaldino/rlm-base-dev
+   cd rlm-base-dev
+   direnv allow
+   cci task run validate_setup
+   ```
+5. **Restart your terminal app** (and Claude Code, IDEs) so they regenerate
+   any cached shell snapshot from the new configs.
+
+---
+
+## 6. Troubleshooting
+
+### `pyenv: cannot rehash: couldn't acquire lock`
+Stale shim lock from a previous interrupted rehash. Usually caused by
+duplicated `eval "$(pyenv init -)"` in shell configs.
+
+```bash
+pkill -9 -f pyenv-rehash
+rm -f ~/.pyenv/shims/.pyenv-shim
+```
+
+Prevented by the layout above (no global `pyenv init`).
+
+### `cci` not found in Claude Code Bash tool
+Claude Code captures a shell snapshot at startup. If it was launched from
+Spotlight/Dock (minimal PATH), the snapshot misses your shell config. Fix:
+launch Claude Code from a terminal, **or** restart Claude Code after
+fixing `~/.zshenv`.
+
+### `pipx` venv broken after Python patch bump
+The CCI venv's python is a symlink to a specific pyenv patch dir
+(`~/.pyenv/versions/<old-patch>/bin/python3`). Installing a newer patch
+doesn't replace the old one, but if you uninstall the old patch the venv
+dies. The update script handles this; manually:
+
+```bash
+# Refresh pipx under the new patch (in case pipx's own shebang was tied
+# to the old patch), then reinstall CCI under it.
+"$(pyenv prefix "$(pyenv latest 3.13)")/bin/python3" -m pip install --user --upgrade pipx
+pipx install --force cumulusci --python "$(pyenv prefix "$(pyenv latest 3.13)")/bin/python3"
+pipx inject --force cumulusci "setuptools>=75.4"
+```
+
+### `python3` resolves to `/usr/bin/python3` instead of pyenv shim
+Cosmetic — `python` (no `3`) resolves correctly because the system doesn't
+ship one. CCI invokes `python`, so this won't break anything. If you need
+the pyenv `python3` specifically, use `pyenv exec python3`.
+
+### `direnv` doesn't activate when cd'ing in
+- Did you `direnv allow` in the project? (Run from inside the dir.)
+- Is the `direnv hook zsh` line in `~/.zshrc`?
+- Is your shell interactive? Non-interactive shells activate via the
+  `direnv export zsh` line in `~/.zshenv` at startup, not on cd.
+
+---
+
+## 7. Reference
+
+- Before editing shell configs, always save a dated backup:
+  `cp ~/.zshenv ~/.zshenv.bak.$(date +%Y%m%d)` (repeat for `~/.zshrc`, `~/.zprofile`)
+- Update script: `scripts/bash/update-toolchain.sh`
+- Project .envrc: `.envrc` at repo root
+- Validation: `cci task run validate_setup` (no org required)
+- direnv docs: https://direnv.net/
+- pyenv docs: https://github.com/pyenv/pyenv
+- nvm docs: https://github.com/nvm-sh/nvm

--- a/docs/guides/dev-environment-setup.md
+++ b/docs/guides/dev-environment-setup.md
@@ -85,20 +85,22 @@ export PATH="$HOME/.local/bin:$PATH"
 # NVM — function definitions + default node bin on PATH (no slow `nvm use`).
 # `brew --prefix nvm` resolves to /opt/homebrew/opt/nvm (Apple Silicon)
 # or /usr/local/opt/nvm (Intel) — works on both architectures.
+#
+# We skip the full `nvm use default` activation cycle (slow) and just resolve
+# `default` to a concrete vX.Y.Z via nvm's public API, then prepend that bin
+# dir. `nvm version default` handles any alias chain — including glob aliases
+# like `lts/*` (which `update-toolchain.sh` and `nvm install --lts` set) —
+# without depending on nvm's internal alias-cache file layout.
 export NVM_DIR="$HOME/.nvm"
 _NVM_PREFIX="$(brew --prefix nvm 2>/dev/null || true)"
 if [ -n "$_NVM_PREFIX" ] && [ -s "$_NVM_PREFIX/nvm.sh" ]; then
   . "$_NVM_PREFIX/nvm.sh" --no-use
-  if [ -s "$NVM_DIR/alias/default" ]; then
-    _NVM_DEF="$(cat "$NVM_DIR/alias/default")"
-    while [ -s "$NVM_DIR/alias/$_NVM_DEF" ]; do
-      _NVM_DEF="$(cat "$NVM_DIR/alias/$_NVM_DEF")"
-    done
-    _NVM_VER="v${_NVM_DEF#v}"
-    [ -d "$NVM_DIR/versions/node/$_NVM_VER/bin" ] && \
-      export PATH="$NVM_DIR/versions/node/$_NVM_VER/bin:$PATH"
-    unset _NVM_DEF _NVM_VER
+  _NVM_VER="$(nvm version default 2>/dev/null)"
+  if [ -n "$_NVM_VER" ] && [ "$_NVM_VER" != "N/A" ] && \
+     [ -d "$NVM_DIR/versions/node/$_NVM_VER/bin" ]; then
+    export PATH="$NVM_DIR/versions/node/$_NVM_VER/bin:$PATH"
   fi
+  unset _NVM_VER
 fi
 unset _NVM_PREFIX
 

--- a/scripts/bash/update-toolchain.sh
+++ b/scripts/bash/update-toolchain.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+# update-toolchain.sh — refresh the local dev toolchain for rlm-base-dev.
+#
+# Updates, in order:
+#   1. Homebrew packages (direnv, nvm, pyenv, pipx, etc.)
+#   2. Python — latest patch in the 3.13 line (via pyenv)
+#   3. Node — latest LTS (via nvm), carrying npm globals forward
+#   4. sf CLI — npm-installed under the active nvm Node
+#   5. CCI — pipx (reinstall is required after any Python patch bump)
+#   6. sf plugins (SFDMU, etc.)
+#   7. cci task run validate_setup
+#
+# Designed to be idempotent. Re-run after any tool emits a "new version" notice.
+# Major-line pins live in this script (PY_LINE, NODE_LINE) — edit them to bump.
+
+set -euo pipefail
+
+PY_LINE="3.13"
+NODE_LINE="lts/*"
+
+# Ensure pipx-managed bins (cci, snowfakery, etc.) are findable. pipx
+# ensurepath only updates shell rc files for future shells; we need PATH in
+# *this* shell so the final `cci task run validate_setup` works from a
+# minimal env. (Note: sf CLI lives under nvm's node bin, not here, and the
+# sfdmu plugin lives inside sf's plugin tree — neither passes through pipx.)
+export PATH="$HOME/.local/bin:$PATH"
+
+log()  { printf '\n\033[1;34m[update]\033[0m %s\n' "$*"; }
+warn() { printf '\n\033[1;33m[warn]\033[0m  %s\n' "$*" >&2; }
+die()  { printf '\n\033[1;31m[fail]\033[0m  %s\n' "$*" >&2; exit 1; }
+
+# ── 1. Homebrew ─────────────────────────────────────────────────────────────
+command -v brew >/dev/null || die "brew not found — install Homebrew from https://brew.sh first"
+log "Homebrew: update + upgrade"
+brew update
+brew upgrade
+
+# ── 2. Python (pyenv) ───────────────────────────────────────────────────────
+command -v pyenv >/dev/null || die "pyenv not found"
+
+LATEST_KNOWN="$(pyenv latest -k "$PY_LINE" 2>/dev/null || true)"
+LATEST_INSTALLED="$(pyenv latest "$PY_LINE" 2>/dev/null || true)"
+[ -n "$LATEST_KNOWN" ] || die "pyenv can't resolve latest Python $PY_LINE — run 'brew upgrade pyenv' to refresh python-build definitions"
+
+log "Python: latest known $PY_LINE = $LATEST_KNOWN ; installed = ${LATEST_INSTALLED:-none}"
+if [ "$LATEST_KNOWN" != "$LATEST_INSTALLED" ]; then
+  log "Installing Python $LATEST_KNOWN"
+  pyenv install --skip-existing "$LATEST_KNOWN"
+  PY_UPGRADED=1
+else
+  log "Python $LATEST_INSTALLED already latest"
+  PY_UPGRADED=0
+fi
+PY_TARGET="$(pyenv latest "$PY_LINE")"
+export PYENV_VERSION="$PY_TARGET"
+
+# ── 3. Node (nvm) ───────────────────────────────────────────────────────────
+export NVM_DIR="$HOME/.nvm"
+NVM_PREFIX="$(brew --prefix nvm 2>/dev/null || true)"
+[ -n "$NVM_PREFIX" ] && [ -s "$NVM_PREFIX/nvm.sh" ] || die "nvm.sh not found via 'brew --prefix nvm' — is nvm installed?"
+# shellcheck disable=SC1091
+. "$NVM_PREFIX/nvm.sh"
+
+OLD_NODE="$(nvm current 2>/dev/null || echo none)"
+log "Node: installing $NODE_LINE (current: $OLD_NODE)"
+# Drive install from NODE_LINE so changes at the top of this script take effect.
+# `lts/*` resolves to the active LTS line; explicit majors (e.g. `24`) also work.
+# --reinstall-packages-from=current carries `sf` and other globals forward.
+nvm install "$NODE_LINE" --reinstall-packages-from=current --latest-npm
+nvm alias default "$NODE_LINE" >/dev/null
+NEW_NODE="$(nvm current)"
+log "Node: now on $NEW_NODE"
+
+# ── 4. sf CLI ───────────────────────────────────────────────────────────────
+log "sf CLI: update channel"
+if command -v sf >/dev/null 2>&1; then
+  sf update || warn "sf update failed — try: npm install -g @salesforce/cli@latest"
+else
+  warn "sf not found on PATH for $NEW_NODE — installing"
+  npm install -g @salesforce/cli@latest
+fi
+
+# ── 5. CCI (pipx) ───────────────────────────────────────────────────────────
+# Re-bootstrap pipx under $PY_TARGET first. A Python patch bump can break the
+# existing pipx script's shebang (it pointed at the old patch's python3, which
+# may have been uninstalled). `command -v pipx` would still succeed in that
+# case but invocations would fail with a broken interpreter. Reinstalling pipx
+# under the current target Python (idempotent) repairs this proactively.
+PY_TARGET_BIN="$(pyenv prefix "$PY_TARGET")/bin/python3"
+[ -x "$PY_TARGET_BIN" ] || die "Target Python not found: $PY_TARGET_BIN"
+log "pipx: refresh under Python $PY_TARGET"
+"$PY_TARGET_BIN" -m pip install --user --upgrade pipx
+"$PY_TARGET_BIN" -m pipx ensurepath >/dev/null 2>&1 || true
+
+# Pin pipx invocation to the target Python so subsequent calls aren't subject
+# to PATH ordering surprises or shebang breakage from previous patch installs.
+# We never invoke bare `pipx` after this point, so no PATH check is needed —
+# this works even from a minimal env where ~/.local/bin isn't yet on PATH.
+PIPX=( "$PY_TARGET_BIN" -m pipx )
+
+cci_reinstall() {
+  log "CCI: reinstalling under Python $PY_TARGET"
+  "${PIPX[@]}" install --force cumulusci --python "$PY_TARGET_BIN"
+}
+
+if [ "$PY_UPGRADED" -eq 1 ] || ! "${PIPX[@]}" list --short 2>/dev/null | grep -q '^cumulusci'; then
+  cci_reinstall
+else
+  log "CCI: upgrade in place"
+  if ! "${PIPX[@]}" upgrade cumulusci; then
+    warn "pipx upgrade failed — reinstalling"
+    cci_reinstall
+  fi
+fi
+
+# Modern CCI 4.8+ with snowfakery 4.x requires setuptools>=75.4.
+# Historical `<71` pin (older docs) is incompatible — see README ~line 219.
+# Force-inject to repair any stale legacy install.
+# Note: CI (.github/workflows/prepare-rlm-org.yml) adds `<77` because it's
+# pinned to CCI 4.8.1; setuptools 77+ broke transitive deps on that version.
+# CCI 4.10+ (what this script installs) works with setuptools 77+, so we
+# don't enforce an upper bound here.
+log "CCI: ensuring setuptools>=75.4"
+"${PIPX[@]}" inject --force cumulusci "setuptools>=75.4"
+
+# ── 6. sf plugins ───────────────────────────────────────────────────────────
+log "sf plugins: update"
+sf plugins update || warn "sf plugins update failed"
+
+# ── 7. Verify ───────────────────────────────────────────────────────────────
+log "Running validate_setup"
+cci task run validate_setup
+
+log "Done."


### PR DESCRIPTION
## Summary

Forward-ports the layered dev-environment setup that's on `main` (PR #161, collapsing 12 fixup commits) to the `262` branch. Without these files, `cd`-ing into `262` leaves the dev-env unactivated: direnv has nothing to load, `PYENV_VERSION` stays unset, the pyenv shim PATH is never prepended, and `pyenv shell` itself fails (no global `pyenv init` by design — see the guide for why).

Brings 262 in line with the workflow already documented in `main`:
- `pyenv` binary on PATH only — **no** global `eval "$(pyenv init -)"`
- per-project `pyenv`/Node pins activated by direnv on `cd`
- one `scripts/bash/update-toolchain.sh` that walks `brew → pyenv-latest-patch → nvm-LTS → sf → CCI → sfdmu plugin → validate_setup` for ongoing maintenance

Also de-risks the upcoming **262 → main** promotion: if the promotion turns out to be anything other than a merge (e.g. a force-push or rebase reset), having `.envrc` on 262 first guarantees it can't be accidentally lost.

## Scope (purely additive — no edits to existing logic, metadata, or data plans)

| File | Lines | Notes |
|------|-------|-------|
| `.envrc` | +32 | direnv activation: `PYENV_VERSION=$(pyenv latest 3.13)`, `PATH_add $(pyenv root)/shims`, `nvm use lts/*` |
| `docs/guides/dev-environment-setup.md` | +329 | Canonical architecture guide — shell-config responsibilities, layered system/project pins, troubleshooting, replication |
| `scripts/bash/update-toolchain.sh` | +134 (`+x`) | Ongoing maintenance script |
| `README.md` | +21 | Three additive cross-refs to the guide (callout near "Cursor users", "Ongoing toolchain maintenance" subsection, Documentation Index row) |
| `AGENTS.md` | +1 | New row in the agent skill index pointing to the guide |

The README.md / AGENTS.md edits are **surgical** — only the dev-env cross-references from main. Unrelated 262-vs-main reorganization (constraint model removals on README, skill-table restructuring on AGENTS) is intentionally out of scope here.

## Test plan

- [x] `git diff --stat 262 HEAD` shows exactly the 5 files above, 517 insertions, 0 deletions
- [x] `scripts/bash/update-toolchain.sh` has executable bit (`-rwxr-xr-x`)
- [ ] After merge, in a fresh `cd` into the repo: `direnv allow .` activates, `echo $PYENV_VERSION` reports `3.13.x`, and `python3 --version` resolves to that patch
- [ ] `cci task run validate_setup` still passes (smoke test that the toolchain wiring is good)
- [ ] No regressions in any existing scripts/flows (no existing files modified)

## Source provenance (commits collapsed)

The 3 new files represent the final state of these 12 commits on `main`, collapsed into one clean addition (no historical fixup churn):

- `44904d42 chore: add layered dev environment setup (direnv + update script + guide)`
- `2f036864 fix(dev-env): address Copilot review feedback`
- `893c98da fix(dev-env): match CI's setuptools upper bound (<77)`
- `1446a8bc fix(dev-env): address second-round Copilot review`
- `5bc3f546 fix(dev-env): detect Homebrew prefix for Apple Silicon + Intel`
- `f2b683c1 fix(dev-env): address fourth-round Copilot review`
- `a0311a76 fix(dev-env): align SFDMU + python3 patterns with README`
- `63940664 fix(dev-env): replace 'pyenv install 3.13.x' placeholder with runnable commands`
- `80146225 fix(dev-env): loosen setuptools to >=75.4 (match README), drop 3.13.12 fallback`
- `09130229 fix(dev-env): repair pipx after Python patch bump; generalize troubleshooting`
- `cf6cd5d4 fix(dev-env): quote nvm lts glob; drop redundant pipx PATH check`
- `3c51f27b fix(dev-env): correct sfdmu/pipx confusion; align .envrc example with actual`

Closes the **Group B forward-port** item from earlier branch-cleanup discussion.

Made with [Cursor](https://cursor.com)