### PR TITLE
chore(262): refresh tfid + tfid-cdo-rlm org templates to current CDO snapshots

### DIFF
--- a/orgs/tfid-cdo-rlm.json
+++ b/orgs/tfid-cdo-rlm.json
@@ -1,6 +1,6 @@
 {
   "orgName": "Salesforce Agentforce Revenue Management",
   "country": "US",
-  "template": "0TTWt000000nwm1",
+  "template": "0TTWt000000oJCL",
   "instance": "USA796"
 }

--- a/orgs/tfid.json
+++ b/orgs/tfid.json
@@ -1,6 +1,6 @@
 {
   "orgName": "Salesforce Agentforce Revenue Management",
   "country": "US",
-  "template": "0TTWt000000g0mn",
-  "instance": "USA794"
+  "template": "0TTWs000001w7YP",
+  "instance": "USA796"
 }


### PR DESCRIPTION
## Summary

Routine refresh of two org-definition template IDs to track the latest Trailhead Forever CDO baseline snapshots. Same pattern as the org-template refresh portion of #176 — without it, `cci org info ... --json` returns stale template hashes and downstream scratch-org spins can drift from the intended starting state.

## Changes (all under `orgs/`)

- **`orgs/tfid-cdo-rlm.json`**
  - `template`: `0TTWt000000nwm1` → `0TTWt000000oJCL`
  - `instance`: unchanged (`USA796`)
  - Second refresh on this file in the 262 cycle; #176 refreshed `0TTWs000001kZS1` → `0TTWt000000nwm1`.

- **`orgs/tfid.json`**
  - `template`: `0TTWt000000g0mn` → `0TTWs000001w7YP`
  - `instance`: `USA794` → `USA796` (now co-located with `tfid-cdo-rlm.json`)

## Out of scope (intentionally not in this PR)

- No code, schema, data-plan, build-flow, or cumulusci.yml changes
- Unstaged local edits to `AGENTS.md` and the untracked `.agents/` directory are excluded; they belong to separate workstreams.

## Test plan

- [ ] Confirm `git diff main` (or `262...`) on this branch shows only the 2 files above
- [ ] `cci org info --json` on a fresh spin against either template returns the expected new template hash (validated whenever the next scratch-org spin happens — purely metadata change, no immediate verification required)

Made with [Cursor](https://cursor.com)