### PR TITLE
chore(gitignore): ignore intermediate orphan-cleanup batch reports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -128,6 +128,13 @@ datasets/bre/exports/**
 # (erd-data.json.batchN.bak, caught by *.bak above) and legacy variants
 # (.bak2, .bak.batchN) produced by earlier helper versions.
 docs/erds/erd-data.json.bak*
+# Intermediate orphan-cleanup batch reports — produced per run by
+# scripts/erd/orphan_batch_helper.py validate (orphan-candidates-after-batchN.md)
+# and the initial scan (orphan-candidates.md, orphan-candidates-dual-org.md,
+# orphan-candidates-after-cleanup.md). The cleanup's final outcome is already
+# baked into docs/erds/erd-data.json and docs/erds/validation-report.md, so
+# these intermediates are local-only artifacts.
+docs/erds/orphan-candidates*.md
 unpackaged/post_ux/drift_report.json
 tmp-metadata/
 .cursor/plans/**


### PR DESCRIPTION
## Summary

- Add `docs/erds/orphan-candidates*.md` to `.gitignore` so future runs of `scripts/erd/orphan_batch_helper.py validate` (and the initial-scan / cleanup variants) don't surface intermediate batch reports in `git status`.
- The matching `erd-data.json.bak*` backups are already ignored a few lines above (line 130); this is the missing belt-and-suspenders for the `.md` siblings.
- Pattern is narrowly scoped — verified `validation-report.md` does not match.

## Why now

Round 9 of the PR #179 Copilot review flagged `docs/erds/orphan-candidates-after-batch7.md` as a missing reference target in `.cursor/skills/revenue-cloud-data-model/SKILL.md`. The skill was fixed (Round 9 commit `049e6d80`) by removing the bullet and adding an "Internal-only (not committed)" subsection. This `.gitignore` change closes the loop so the same intermediate files can't reappear and surprise a future contributor.

## Test plan

- [x] `git ls-files docs/erds/ | rg -i 'orphan|candidate'` — confirmed zero tracked files would be excluded (none currently tracked).
- [x] Pattern smoke: `validation-report.md` does not match `orphan-candidates*.md`.
- [x] All 9 prior intermediate reports (`orphan-candidates.md`, `orphan-candidates-dual-org.md`, `orphan-candidates-after-cleanup.md`, `orphan-candidates-after-batch{2..7}.md`) were already removed from the local working tree in the post-merge cleanup; this `.gitignore` only governs future regenerations.

## Risk

Trivial — single `.gitignore` line + 6 lines of comment. No tracked files affected, no code paths touched.

Made with [Cursor](https://cursor.com)