### PR TITLE
ci: label-triggered prepare-rlm-org build (ci:prepare-org)

### DIFF
--- a/.github/workflows/prepare-rlm-org.yml
+++ b/.github/workflows/prepare-rlm-org.yml
@@ -23,6 +23,15 @@ permissions:
   contents: read
   pull-requests: write
 
+# Serialize runs that target the same scratch-org alias: per-PR for
+# label-triggered runs, per-ref for workflow_dispatch. Prevents two jobs from
+# concurrently creating/deleting the same org alias (flaky failures / leaked
+# scratch orgs). cancel-in-progress is false so an in-flight build finishes
+# (and tears down its org) before the next queued run starts.
+concurrency:
+  group: prepare-rlm-org-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: false
+
 jobs:
   prepare-rlm-org:
     # Run on manual dispatch, or when the trigger label is applied to a

--- a/.github/workflows/prepare-rlm-org.yml
+++ b/.github/workflows/prepare-rlm-org.yml
@@ -11,15 +11,44 @@ on:
         description: "Scratch org config name from orgs/ (e.g. dev, test-sb0)"
         required: false
         default: "dev"
+  # Label-triggered CI for same-repo PR branches: apply the "ci:prepare-org"
+  # label to a PR to kick off a full prepare_rlm_org build against the PR's
+  # merge ref. The label is auto-removed at the start of the run, so
+  # re-applying it re-triggers the build. (Fork PRs are skipped — they have
+  # no access to the SFDX_AUTH_URL secret.)
+  pull_request:
+    types: [labeled]
 
 permissions:
   contents: read
+  pull-requests: write
 
 jobs:
   prepare-rlm-org:
+    # Run on manual dispatch, or when the trigger label is applied to a
+    # same-repo PR.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'pull_request' &&
+       github.event.label.name == 'ci:prepare-org' &&
+       github.event.pull_request.head.repo.full_name == github.repository)
     runs-on: ubuntu-latest
     timeout-minutes: 120
+    env:
+      # Dispatch uses the provided inputs; label-triggered PR runs derive a
+      # per-PR alias and default to the `dev` scratch config.
+      ORG_ALIAS: ${{ inputs.org_alias || format('pr{0}-ci', github.event.pull_request.number) }}
+      SCRATCH_CONFIG: ${{ inputs.scratch_config || 'dev' }}
     steps:
+      - name: Remove trigger label (re-apply to re-run)
+        if: github.event_name == 'pull_request'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          gh pr edit "$PR_NUMBER" --repo "$REPO" --remove-label "ci:prepare-org" || true
+
       - name: Checkout repository
         uses: actions/checkout@v6
 
@@ -75,13 +104,13 @@ jobs:
 
       - name: Create scratch org
         run: |
-          cci org scratch ${{ inputs.scratch_config }} ${{ inputs.org_alias }} --default
+          cci org scratch "$SCRATCH_CONFIG" "$ORG_ALIAS" --default
 
       - name: Run prepare_rlm_org
         run: |
-          cci flow run prepare_rlm_org --org ${{ inputs.org_alias }}
+          cci flow run prepare_rlm_org --org "$ORG_ALIAS"
 
       - name: Delete scratch org
         if: always()
         run: |
-          cci org scratch_delete ${{ inputs.org_alias }} || true
+          cci org scratch_delete "$ORG_ALIAS" || true


### PR DESCRIPTION
## Summary

Adds a **label trigger** to the `Prepare RLM Org` workflow so CI can be run against a PR branch from the GitHub UI by simply applying a label — no need to find the Actions "Run workflow" dispatch form.

- Apply the **`ci:prepare-org`** label to a PR → runs `prepare_rlm_org` against the PR's merge ref.
- `workflow_dispatch` is retained for manual runs with explicit `org_alias` / `scratch_config` inputs.
- The label is **auto-removed** at the start of the run, so re-applying it re-triggers the build.
- Guarded to **same-repo PRs** (fork PRs can't access the `SFDX_AUTH_URL` secret).
- Label runs derive a per-PR org alias (`pr<N>-ci`) and default the scratch config to `dev`.
- `run:` steps use `env:` variables instead of inline `${{ }}` expressions (injection-safe; satisfies workflow-security lint).

## Why a separate PR

`pull_request` workflows execute from the **base branch's** copy of the workflow file. So this trigger only becomes active for PRs into `262` once it's merged here. Keeping it out of the guided-selling PR (#188) keeps that PR focused.

## Test plan

- [ ] Merge to `262`.
- [ ] Apply `ci:prepare-org` to an open PR into `262` and confirm a `Prepare RLM Org` run starts against the PR, the label is auto-removed, and the scratch org is created + torn down.
- [ ] Confirm `workflow_dispatch` still works with inputs.

> For #188 specifically (opened before this lands on 262), a build can be kicked off immediately via `workflow_dispatch --ref <pr-branch>`.

Made with [Cursor](https://cursor.com)