### PR TITLE
Add agent instruction stack docs and tool adapters

### DIFF
--- a/.agents/README.md
+++ b/.agents/README.md
@@ -17,7 +17,8 @@ content is intentionally reusable across agents.
 
 2. **`.cursor/skills/` — tool-neutral skill markdown**
    - Contains detailed task guides such as CCI orchestration, SFDMU data plans,
-     Robot testing, UX assembly, schema validation, and release enablement.
+     Robot testing, UX assembly (under `repo-integration`), schema validation,
+     and release enablement.
    - Despite the historical `.cursor` path, these are plain Markdown skills for
      any agent that can read repository files.
    - Use the Skill Index in `AGENTS.md` or `.cursor/skills/README.md` to choose
@@ -66,3 +67,16 @@ Short adapter notes live in `.agents/adapters/`:
 
 Each adapter explains how that tool should map its native instruction mechanism
 to the repository's existing files and which files are authoritative.
+
+## Other `.agents/` files
+
+The `.agents/` tree also holds supporting context for agents (added alongside
+this README):
+
+- `.agents/model-routing.md` — maps work types to model/execution modes and
+  defines escalation criteria.
+- `.agents/context/project-map.md` — human-readable map of the repository.
+- `.agents/context/project-memory.json` — machine-readable project memory,
+  validated against `.agents/schemas/project-memory.schema.json`.
+
+None of these override `AGENTS.md`; they are routing and context aids.

--- a/.agents/README.md
+++ b/.agents/README.md
@@ -1,0 +1,66 @@
+# Agent Instruction Stack
+
+This repository uses a layered instruction stack so every AI coding tool can
+start from the same project contract and then opt into more specific guidance.
+The path names reflect the tools that introduced each file, but most of the
+content is intentionally reusable across agents.
+
+## Canonical stack
+
+1. **`AGENTS.md` — root safety and project contract**
+   - Authoritative for repository-wide safety rules, project context, common
+     workflows, pre-merge checks, and the skill index.
+   - Every tool should read this file first and treat it as the top-level source
+     of truth unless a direct human instruction overrides it.
+
+2. **`.cursor/skills/` — tool-neutral skill markdown**
+   - Contains detailed task guides such as CCI orchestration, SFDMU data plans,
+     Robot testing, UX assembly, schema validation, and release enablement.
+   - Despite the historical `.cursor` path, these are plain Markdown skills for
+     any agent that can read repository files.
+   - Use the Skill Index in `AGENTS.md` or `.cursor/skills/README.md` to choose
+     the relevant entry point.
+
+3. **`.cursor/rules/` — Cursor-specific rule files with reusable guidance**
+   - Contains `.mdc` files that Cursor can auto-inject based on edited file
+     patterns.
+   - Non-Cursor tools can still read these files manually when working on the
+     same file types; the guidance is reusable, but the auto-injection mechanism
+     is Cursor-specific.
+
+4. **`.claude/skill-manifest.yml` — cross-repo skill manifest**
+   - Advertises Foundations skills, grounding artifacts, and cross-repo paths so
+     agents can resolve shared guidance between this repo and related repos such
+     as PMOS.
+   - Use it with `scripts/ai/skill_manifest.py` when cross-repo discovery or
+     validation is needed.
+
+5. **`.github/copilot-instructions.md` — Copilot pointer**
+   - Directs GitHub Copilot to `AGENTS.md` and summarizes the shared entry
+     points.
+   - It is an adapter for Copilot, not a replacement for the root contract.
+
+## Authority order
+
+1. Direct human/system instructions for the current task.
+2. `AGENTS.md` for repository-wide policy and safety.
+3. Relevant skill files under `.cursor/skills/` for task-specific workflows.
+4. Relevant `.cursor/rules/` files for file-pattern-specific guidance.
+5. Tool adapter files, including `.github/copilot-instructions.md` and the files
+   in `.agents/adapters/`, for mapping a tool to the shared instruction stack.
+
+If guidance appears to conflict, prefer the higher-authority source and document
+any important assumption in your response or PR notes.
+
+## Tool adapters
+
+Short adapter notes live in `.agents/adapters/`:
+
+- `codex.md`
+- `claude-code.md`
+- `cursor.md`
+- `copilot.md`
+- `agentforce-vibes.md`
+
+Each adapter explains how that tool should map its native instruction mechanism
+to the repository's existing files and which files are authoritative.

--- a/.agents/README.md
+++ b/.agents/README.md
@@ -12,6 +12,8 @@ content is intentionally reusable across agents.
      workflows, pre-merge checks, and the skill index.
    - Every tool should read this file first and treat it as the top-level source
      of truth unless a direct human instruction overrides it.
+   - Tool-specific entry points (`CLAUDE.md`, `.github/copilot-instructions.md`)
+     are symlinks or pointers to this file — edit `AGENTS.md` only.
 
 2. **`.cursor/skills/` — tool-neutral skill markdown**
    - Contains detailed task guides such as CCI orchestration, SFDMU data plans,
@@ -60,7 +62,7 @@ Short adapter notes live in `.agents/adapters/`:
 - `claude-code.md`
 - `cursor.md`
 - `copilot.md`
-- `agentforce-vibes.md`
+- `agentforce.md`
 
 Each adapter explains how that tool should map its native instruction mechanism
 to the repository's existing files and which files are authoritative.

--- a/.agents/adapters/agentforce-vibes.md
+++ b/.agents/adapters/agentforce-vibes.md
@@ -1,0 +1,28 @@
+# Agentforce Vibes Adapter
+
+Agentforce Vibes should use this repository's shared files as its source of
+instructions instead of introducing a parallel guidance stack.
+
+## Instruction mapping
+
+- **Primary instructions:** read repo-root `AGENTS.md` first and treat it as the
+  canonical safety and project contract.
+- **Task-specific skills:** use `AGENTS.md` to select relevant
+  `.cursor/skills/**` Markdown files. The skills are tool-neutral and are not
+  limited to Cursor.
+- **File-specific guidance:** read applicable `.cursor/rules/*.mdc` files for
+  reusable file-pattern guidance, while recognizing that Cursor-specific
+  auto-injection does not apply to Agentforce Vibes.
+- **Cross-repo discovery:** use `.claude/skill-manifest.yml` to understand which
+  skills and grounding artifacts are shared across repos.
+- **Copilot pointer:** `.github/copilot-instructions.md` is specific to GitHub
+  Copilot and should be treated as an adapter, not as a separate authority.
+
+## Authoritative files
+
+1. `AGENTS.md`
+2. Relevant `.cursor/skills/**` files
+3. Relevant `.cursor/rules/*.mdc` files
+4. `.claude/skill-manifest.yml` for cross-repo skill resolution
+
+This adapter is only a routing note; it does not override `AGENTS.md`.

--- a/.agents/adapters/agentforce.md
+++ b/.agents/adapters/agentforce.md
@@ -1,6 +1,6 @@
-# Agentforce Vibes Adapter
+# Agentforce Adapter
 
-Agentforce Vibes should use this repository's shared files as its source of
+Agentforce should use this repository's shared files as its source of
 instructions instead of introducing a parallel guidance stack.
 
 ## Instruction mapping
@@ -12,7 +12,7 @@ instructions instead of introducing a parallel guidance stack.
   limited to Cursor.
 - **File-specific guidance:** read applicable `.cursor/rules/*.mdc` files for
   reusable file-pattern guidance, while recognizing that Cursor-specific
-  auto-injection does not apply to Agentforce Vibes.
+  auto-injection does not apply to Agentforce.
 - **Cross-repo discovery:** use `.claude/skill-manifest.yml` to understand which
   skills and grounding artifacts are shared across repos.
 - **Copilot pointer:** `.github/copilot-instructions.md` is specific to GitHub

--- a/.agents/adapters/claude-code.md
+++ b/.agents/adapters/claude-code.md
@@ -5,8 +5,8 @@ separate Claude-only contract.
 
 ## Instruction mapping
 
-- **Primary instructions:** `CLAUDE.md` points to the same content as
-  `AGENTS.md`; `AGENTS.md` remains the authoritative root contract.
+- **Primary instructions:** `CLAUDE.md` is a symlink to `AGENTS.md`;
+  `AGENTS.md` is the authoritative root contract — edit only `AGENTS.md`.
 - **Task-specific skills:** read the applicable `.cursor/skills/**` Markdown
   files from the Skill Index in `AGENTS.md`. The skills are tool-neutral.
 - **File-specific guidance:** `.cursor/rules/*.mdc` files are Cursor auto-rules,
@@ -16,7 +16,7 @@ separate Claude-only contract.
 
 ## Authoritative files
 
-1. `AGENTS.md` / `CLAUDE.md` when it resolves to `AGENTS.md`
+1. `AGENTS.md` (authoritative); `CLAUDE.md` is the symlink entry point for Claude Code
 2. Relevant `.cursor/skills/**` files
 3. Relevant `.cursor/rules/*.mdc` files
 4. `.claude/skill-manifest.yml` for cross-repo skill resolution

--- a/.agents/adapters/claude-code.md
+++ b/.agents/adapters/claude-code.md
@@ -1,0 +1,24 @@
+# Claude Code Adapter
+
+Claude Code should use the repository's shared instruction stack rather than a
+separate Claude-only contract.
+
+## Instruction mapping
+
+- **Primary instructions:** `CLAUDE.md` points to the same content as
+  `AGENTS.md`; `AGENTS.md` remains the authoritative root contract.
+- **Task-specific skills:** read the applicable `.cursor/skills/**` Markdown
+  files from the Skill Index in `AGENTS.md`. The skills are tool-neutral.
+- **File-specific guidance:** `.cursor/rules/*.mdc` files are Cursor auto-rules,
+  but Claude Code can reuse their guidance manually for matching file types.
+- **Cross-repo discovery:** `.claude/skill-manifest.yml` is the manifest for
+  resolving shared skills and artifacts across Foundations and related repos.
+
+## Authoritative files
+
+1. `AGENTS.md` / `CLAUDE.md` when it resolves to `AGENTS.md`
+2. Relevant `.cursor/skills/**` files
+3. Relevant `.cursor/rules/*.mdc` files
+4. `.claude/skill-manifest.yml` for cross-repo skill resolution
+
+This adapter is only a routing note; it does not override `AGENTS.md`.

--- a/.agents/adapters/codex.md
+++ b/.agents/adapters/codex.md
@@ -1,0 +1,25 @@
+# Codex Adapter
+
+Codex should treat the repo-root `AGENTS.md` file as the canonical safety and
+project contract for every task in this repository.
+
+## Instruction mapping
+
+- **Primary instructions:** read and obey `AGENTS.md` first.
+- **Task-specific skills:** use the Skill Index in `AGENTS.md` to select and read
+  the relevant `.cursor/skills/**` Markdown files. These files are tool-neutral
+  despite the historical Cursor path.
+- **File-specific guidance:** when editing file types covered by
+  `.cursor/rules/*.mdc`, read the matching rule file as reusable guidance.
+- **Cross-repo discovery:** use `.claude/skill-manifest.yml` and
+  `scripts/ai/skill_manifest.py` when a task needs PMOS/Foundation skill or
+  artifact resolution.
+
+## Authoritative files
+
+1. `AGENTS.md`
+2. Relevant `.cursor/skills/**` files
+3. Relevant `.cursor/rules/*.mdc` files
+4. `.claude/skill-manifest.yml` for cross-repo skill resolution
+
+This adapter is only a routing note; it does not override `AGENTS.md`.

--- a/.agents/adapters/copilot.md
+++ b/.agents/adapters/copilot.md
@@ -1,0 +1,27 @@
+# GitHub Copilot Adapter
+
+GitHub Copilot should enter the shared instruction stack through the repository's
+Copilot instruction file.
+
+## Instruction mapping
+
+- **Copilot entry point:** `.github/copilot-instructions.md` points Copilot to
+  `AGENTS.md` and summarizes the common entry points.
+- **Primary instructions:** `AGENTS.md` is the canonical safety and project
+  contract.
+- **Task-specific skills:** use the Skill Index in `AGENTS.md` to read relevant
+  `.cursor/skills/**` Markdown files. These are tool-neutral.
+- **File-specific guidance:** `.cursor/rules/*.mdc` files are Cursor-specific for
+  injection, but Copilot can reuse their guidance manually.
+- **Cross-repo discovery:** `.claude/skill-manifest.yml` supports cross-repo
+  skill and artifact resolution.
+
+## Authoritative files
+
+1. `AGENTS.md`
+2. `.github/copilot-instructions.md` as Copilot's adapter pointer
+3. Relevant `.cursor/skills/**` files
+4. Relevant `.cursor/rules/*.mdc` files
+5. `.claude/skill-manifest.yml` for cross-repo skill resolution
+
+The Copilot instruction file is an entry point; it does not replace `AGENTS.md`.

--- a/.agents/adapters/cursor.md
+++ b/.agents/adapters/cursor.md
@@ -1,0 +1,27 @@
+# Cursor Adapter
+
+Cursor has native support for both the historical skill directory and
+file-pattern rule files in this repository.
+
+## Instruction mapping
+
+- **Primary instructions:** read and obey repo-root `AGENTS.md` as the canonical
+  safety and project contract.
+- **Task-specific skills:** use `.cursor/skills/**` as plain Markdown skill
+  files. They are reusable by all tools even though Cursor can navigate them
+  directly.
+- **File-specific guidance:** `.cursor/rules/*.mdc` files are Cursor-specific
+  auto-injection rules for matching file patterns.
+- **Cross-repo discovery:** use `.claude/skill-manifest.yml` and
+  `scripts/ai/skill_manifest.py` when resolving cross-repo skills or grounding
+  artifacts.
+
+## Authoritative files
+
+1. `AGENTS.md`
+2. Relevant `.cursor/skills/**` files
+3. Relevant `.cursor/rules/*.mdc` files
+4. `.claude/skill-manifest.yml` for cross-repo skill resolution
+
+Cursor rule auto-injection adds convenience, but it does not make `.cursor/rules/`
+more authoritative than `AGENTS.md`.


### PR DESCRIPTION
### Motivation

- Provide a clear, canonical instruction stack so every AI agent maps its native instruction mechanism to the same project contract and skill set.
- Clarify which files are authoritative for safety, cross-repo discovery, skill content, and Cursor-specific rules.

### Description

- Add `.agents/README.md` documenting the canonical instruction stack, authority order, and recommended resolution flow for agents.
- Add short per-tool adapter notes under `.agents/adapters/` for `codex`, `claude-code`, `cursor`, `copilot`, and `agentforce-vibes` that map each tool’s entry mechanism to the repository’s authoritative files.
- Authoritative files and entry points highlighted include `AGENTS.md`, `.cursor/skills/`, `.cursor/rules/`, `.claude/skill-manifest.yml`, and `.github/copilot-instructions.md`.
- All new files are plain Markdown and intended as routing/usage notes that do not override `AGENTS.md`.

### Testing

- Ran repository checks (`git diff --cached --check`) and they passed.
- Verified staged workspace status (`git status --short`) to confirm the new files were added.
- Confirmed the new Markdown files are readable and contain the expected adapter mappings by inspection.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a235d8f1254832a863b99b4c431e10a)