### PR TITLE
Add agent tooling optimization workflow and static analyzer

### DIFF
--- a/.github/workflows/agent-tooling-optimization.yml
+++ b/.github/workflows/agent-tooling-optimization.yml
@@ -1,0 +1,115 @@
+name: Agent Tooling Optimization
+
+on:
+  workflow_dispatch:
+    inputs:
+      deep_checks:
+        description: "Run optional deeper checks such as CCI reference generation and local schema/doc freshness checks"
+        required: false
+        default: false
+        type: boolean
+  schedule:
+    # Weekly on Sunday at 08:17 UTC.
+    - cron: "17 8 * * 0"
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: agent-tooling-optimization
+  cancel-in-progress: false
+
+jobs:
+  optimize-agent-tooling:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    env:
+      REPORT_DIR: ${{ runner.temp }}/agent-tooling-reports
+      DEEP_CHECKS: ${{ inputs.deep_checks || false }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          # Generated artifacts often need comparison against prior commits.
+          fetch-depth: 0
+
+      - name: Set up Python 3.13
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Prepare report directory
+        run: mkdir -p "$REPORT_DIR"
+
+      - name: Run static agent tooling analyzer
+        run: |
+          if [ ! -f scripts/ai/analyze_agent_tooling.py ]; then
+            echo "Expected scripts/ai/analyze_agent_tooling.py to exist." >&2
+            exit 1
+          fi
+          python scripts/ai/analyze_agent_tooling.py
+
+      - name: Run optional deeper checks
+        if: ${{ env.DEEP_CHECKS == 'true' }}
+        run: |
+          python scripts/ai/generate_cci_reference.py
+
+          # Keep these static/local by default: no Salesforce CLI, org auth, or
+          # external documentation access is required here. The analyzer can add
+          # report files under $REPORT_DIR when deeper check implementations grow.
+          if [ -f scripts/ai/skill_manifest.py ]; then
+            python scripts/ai/skill_manifest.py --check
+          fi
+
+          if [ -f scripts/erd/build_erds.py ]; then
+            python scripts/erd/build_erds.py
+          fi
+
+      - name: Collect generated report files
+        if: always()
+        run: |
+          mkdir -p "$REPORT_DIR"
+
+          # Preserve reports generated in common local locations without adding
+          # them to the eventual pull request branch.
+          for candidate in \
+            agent-tooling-report.md \
+            agent-tooling-report.json \
+            agent-tooling-report \
+            reports/agent-tooling \
+            reports/agent-tooling.md \
+            reports/agent-tooling.json \
+            reports/agent-tooling-optimization; do
+            if [ -e "$candidate" ]; then
+              cp -R "$candidate" "$REPORT_DIR"/
+            fi
+          done
+
+          find "$REPORT_DIR" -maxdepth 3 -type f -print | sort || true
+
+      - name: Upload agent tooling reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: agent-tooling-optimization-reports
+          path: ${{ env.REPORT_DIR }}
+          if-no-files-found: warn
+
+      - name: Open or update optimization pull request
+        uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ github.token }}
+          branch: automation/agent-tooling-optimization
+          delete-branch: true
+          title: "Optimize agent tooling artifacts"
+          commit-message: "chore: optimize agent tooling artifacts"
+          body: |
+            ## Summary
+            - Runs the agent tooling optimization workflow.
+            - Updates tracked generated artifacts when static or optional deeper checks produce changes.
+
+            ## Validation
+            - Static analyzer: `python scripts/ai/analyze_agent_tooling.py`
+            - Deeper checks enabled: `${{ env.DEEP_CHECKS }}`
+          labels: automation, agent-tooling

--- a/scripts/ai/analyze_agent_tooling.py
+++ b/scripts/ai/analyze_agent_tooling.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python3
+"""Static checks for repository agent-tooling guidance.
+
+The script intentionally uses only the Python standard library so scheduled
+workflows can run in static-only mode without installing Salesforce, CumulusCI,
+or other project dependencies.
+"""
+
+from __future__ import annotations
+
+import ast
+import json
+import os
+import re
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterable
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_REPORT_DIR = REPO_ROOT / "reports" / "agent-tooling-optimization"
+
+
+def rel(path: Path) -> str:
+    return path.relative_to(REPO_ROOT).as_posix()
+
+
+def status(ok: bool) -> str:
+    return "pass" if ok else "fail"
+
+
+def check_paths(paths: Iterable[str], category: str) -> list[dict[str, str | bool]]:
+    results: list[dict[str, str | bool]] = []
+    for raw_path in sorted(set(paths)):
+        path = REPO_ROOT / raw_path
+        results.append(
+            {
+                "category": category,
+                "check": f"{raw_path} exists",
+                "status": status(path.exists()),
+                "path": raw_path,
+            }
+        )
+    return results
+
+
+def extract_agent_references(agent_text: str) -> list[str]:
+    """Return path-like backtick references from AGENTS.md."""
+    references: list[str] = []
+    prefixes = (
+        ".cursor/",
+        ".github/",
+        "docs/",
+        "scripts/",
+        "tasks/",
+        "tests/",
+        "robot/",
+    )
+    for match in re.finditer(r"`([^`]+)`", agent_text):
+        token = match.group(1).strip()
+        if token.startswith(prefixes) and not any(ch.isspace() for ch in token):
+            references.append(token)
+    return references
+
+
+def check_python_syntax(paths: Iterable[Path]) -> list[dict[str, str | bool]]:
+    results: list[dict[str, str | bool]] = []
+    for path in sorted(paths):
+        try:
+            ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        except SyntaxError as exc:
+            results.append(
+                {
+                    "category": "python-syntax",
+                    "check": f"{rel(path)} parses",
+                    "status": "fail",
+                    "path": rel(path),
+                    "message": f"{exc.msg} at line {exc.lineno}",
+                }
+            )
+        else:
+            results.append(
+                {
+                    "category": "python-syntax",
+                    "check": f"{rel(path)} parses",
+                    "status": "pass",
+                    "path": rel(path),
+                }
+            )
+    return results
+
+
+def write_reports(report_dir: Path, results: list[dict[str, str | bool]]) -> None:
+    report_dir.mkdir(parents=True, exist_ok=True)
+    generated_at = datetime.now(timezone.utc).isoformat()
+    failures = [item for item in results if item["status"] != "pass"]
+
+    payload = {
+        "generated_at": generated_at,
+        "summary": {
+            "checks": len(results),
+            "failures": len(failures),
+        },
+        "results": results,
+    }
+    (report_dir / "agent-tooling-analysis.json").write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+    lines = [
+        "# Agent Tooling Analysis",
+        "",
+        f"Generated at: `{generated_at}`",
+        "",
+        "## Summary",
+        "",
+        f"- Checks: {len(results)}",
+        f"- Failures: {len(failures)}",
+        "",
+        "## Results",
+        "",
+        "| Status | Category | Check |",
+        "| --- | --- | --- |",
+    ]
+    for item in results:
+        icon = "✅" if item["status"] == "pass" else "❌"
+        lines.append(f"| {icon} | {item['category']} | {item['check']} |")
+    lines.append("")
+    (report_dir / "agent-tooling-analysis.md").write_text(
+        "\n".join(lines),
+        encoding="utf-8",
+    )
+
+
+def main() -> int:
+    report_dir = Path(os.environ.get("REPORT_DIR", DEFAULT_REPORT_DIR)).resolve()
+    agent_path = REPO_ROOT / "AGENTS.md"
+    results: list[dict[str, str | bool]] = [
+        {
+            "category": "entrypoint",
+            "check": "AGENTS.md exists",
+            "status": status(agent_path.exists()),
+            "path": "AGENTS.md",
+        },
+        {
+            "category": "entrypoint",
+            "check": ".github/copilot-instructions.md exists",
+            "status": status((REPO_ROOT / ".github/copilot-instructions.md").exists()),
+            "path": ".github/copilot-instructions.md",
+        },
+    ]
+
+    if agent_path.exists():
+        agent_text = agent_path.read_text(encoding="utf-8")
+        results.extend(check_paths(extract_agent_references(agent_text), "agent-reference"))
+
+    results.extend(check_python_syntax((REPO_ROOT / "scripts" / "ai").glob("*.py")))
+    write_reports(report_dir, results)
+
+    failures = [item for item in results if item["status"] != "pass"]
+    if failures:
+        print(f"Agent tooling analysis found {len(failures)} failure(s).", file=sys.stderr)
+        print(f"Reports written to {report_dir}", file=sys.stderr)
+        return 1
+
+    print(f"Agent tooling analysis passed with {len(results)} checks.")
+    print(f"Reports written to {report_dir}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
### Motivation

- Add a scheduled and manual GitHub Actions workflow to regularly validate and optimize AI/agent-related tooling artifacts and detect drift in generated files.
- Provide a static-only default mode to run safely in CI without installing Salesforce/CCI dependencies and an optional `deep_checks` input for more expensive local checks.

### Description

- Add `.github/workflows/agent-tooling-optimization.yml` with `workflow_dispatch` and weekly `schedule` triggers, full-history checkout (`fetch-depth: 0`), Python setup, artifact upload, and an automated PR creation step using `peter-evans/create-pull-request` that targets `automation/agent-tooling-optimization` when tracked files change.
- Workflow runs a dependency-free static analyzer by default via `python scripts/ai/analyze_agent_tooling.py` and supports optional deeper checks (`generate_cci_reference.py`, `skill_manifest.py --check`, `scripts/erd/build_erds.py`) when `deep_checks` is enabled.
- Add `scripts/ai/analyze_agent_tooling.py`, a stdlib-only analyzer that validates presence of key entrypoints (`AGENTS.md`, `.github/copilot-instructions.md`), extracts and checks path references from `AGENTS.md`, verifies Python syntax for `scripts/ai/*.py`, and writes both JSON and Markdown reports under `reports/agent-tooling-optimization`.
- Collect common report file locations into the workflow `REPORT_DIR` and upload them as GitHub Actions artifacts named `agent-tooling-optimization-reports`.

### Testing

- Ran the analyzer locally with `REPORT_DIR=/tmp/agent-tooling-test python scripts/ai/analyze_agent_tooling.py` and it completed successfully and wrote reports to the target directory.
- Verified Python source compiles with `python -m py_compile scripts/ai/analyze_agent_tooling.py` which succeeded.
- Validated the workflow YAML parses with a YAML loader (`ruby -e 'require "yaml"; YAML.load_file(".github/workflows/agent-tooling-optimization.yml")'`) which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a235df8b4a4832a9d5b6a70e8d0bb4b)