### PR TITLE
Add stdlib baseline checks and PyYAML-friendly fallbacks for AI tooling

### DIFF
--- a/scripts/ai/README.md
+++ b/scripts/ai/README.md
@@ -55,6 +55,36 @@ python scripts/ai/generate_cci_reference.py --dry-run       # preview without wr
 
 **Used by:** `.cursor/skills/cci-orchestration/SKILL.md`
 
+### `analyze_agent_tooling.py`
+
+Runs AI-agent tooling health checks. The default mode is intentionally a
+**baseline static check** suite that uses only the Python standard library, so
+it can run in a fresh clone before the CumulusCI/PyYAML environment is
+installed or activated. Baseline checks verify required files, Python syntax,
+manifest high-level keys, generated-reference file presence/markers, and the
+dependency guidance in existing utilities. They do **not** parse full YAML or
+regenerate CCI references.
+
+```bash
+python scripts/ai/analyze_agent_tooling.py
+```
+
+Use **full generated-reference checks** when you need to validate the generated
+CCI references against `cumulusci.yml`. This mode dry-runs
+`generate_cci_reference.py`, which requires full YAML parsing through the
+project CumulusCI/PyYAML environment. If that environment is missing, the tool
+prints activation/install guidance instead of failing with an import traceback.
+
+```bash
+python scripts/ai/analyze_agent_tooling.py --full-generated-reference-checks
+```
+
+**Data sources:** `AGENTS.md`, `.claude/skill-manifest.yml`,
+`scripts/ai/README.md`, `.cursor/skills/cci-orchestration/*-reference.md`,
+`cumulusci.yml` (full generated-reference mode only)
+**Used by:** AI agents before merge to distinguish always-available baseline
+validation from environment-dependent generated-reference validation.
+
 ---
 
 ## Dependencies
@@ -64,8 +94,13 @@ python scripts/ai/generate_cci_reference.py --dry-run       # preview without wr
   3.13 and the README recommends 3.12 for CumulusCI itself, so 3.10 is a
   safe lower bound and is what we test against in practice). The previous
   "3.8+" claim predated the schema-diff tooling.
-- **PyYAML** — used by `generate_cci_reference.py` and `skill_manifest.py`
-  (available in the CCI venv)
+- **PyYAML** — required by `generate_cci_reference.py` for full
+  `cumulusci.yml` parsing and used opportunistically by `skill_manifest.py`
+  when available. `skill_manifest.py` falls back to minimal baseline manifest
+  validation without PyYAML.
+- `analyze_agent_tooling.py` baseline static checks use only the Python standard
+  library. Its `--full-generated-reference-checks` mode requires the same
+  PyYAML/CCI environment as `generate_cci_reference.py`.
 - No other external dependencies
 
 ---

--- a/scripts/ai/analyze_agent_tooling.py
+++ b/scripts/ai/analyze_agent_tooling.py
@@ -1,0 +1,209 @@
+#!/usr/bin/env python3
+"""Baseline static checks for AI-agent tooling.
+
+The baseline mode intentionally uses only the Python standard library. It is
+meant to be safe in a fresh checkout before the CumulusCI/PyYAML environment is
+installed or activated. Use ``--full-generated-reference-checks`` when you want
+to exercise generators that require full YAML parsing.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import importlib.util
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable
+
+ROOT = Path(__file__).resolve().parent.parent.parent
+AI_DIR = ROOT / "scripts" / "ai"
+MANIFEST = ROOT / ".claude" / "skill-manifest.yml"
+CCI_REFERENCE_FILES = (
+    ROOT / ".cursor" / "skills" / "cci-orchestration" / "tasks-reference.md",
+    ROOT / ".cursor" / "skills" / "cci-orchestration" / "flows-reference.md",
+    ROOT / ".cursor" / "skills" / "cci-orchestration" / "feature-flags.md",
+)
+BASELINE_FILES = (
+    ROOT / "AGENTS.md",
+    AI_DIR / "README.md",
+    AI_DIR / "query_erd.py",
+    AI_DIR / "generate_cci_reference.py",
+    AI_DIR / "skill_manifest.py",
+    MANIFEST,
+    *CCI_REFERENCE_FILES,
+)
+
+FULL_CHECK_ENV_HELP = (
+    "Full generated-reference checks require PyYAML/CumulusCI. Activate the "
+    "project CCI environment, or install PyYAML with one of: "
+    "`pipx inject cumulusci PyYAML`, `python -m pip install PyYAML`, or "
+    "`python -m pip install cumulusci`."
+)
+
+
+@dataclass(frozen=True)
+class CheckResult:
+    name: str
+    ok: bool
+    detail: str
+
+
+def _display_path(path: Path) -> str:
+    try:
+        return str(path.relative_to(ROOT))
+    except ValueError:
+        return str(path)
+
+
+def _stdlib_module_names() -> set[str]:
+    names = set(getattr(sys, "stdlib_module_names", set()))
+    names.update(sys.builtin_module_names)
+    # Python packaging can expose platform-specific stdlib names; include the
+    # modules this script uses so the check remains stable on supported Python.
+    names.update({"argparse", "ast", "dataclasses", "pathlib", "subprocess", "typing"})
+    return names
+
+
+def _top_level_imports(path: Path) -> set[str]:
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    imports: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                imports.add(alias.name.split(".", 1)[0])
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            imports.add(node.module.split(".", 1)[0])
+    return imports
+
+
+def check_required_files() -> CheckResult:
+    missing = [_display_path(path) for path in BASELINE_FILES if not path.is_file()]
+    if missing:
+        return CheckResult("required files", False, "missing: " + ", ".join(missing))
+    return CheckResult("required files", True, f"found {len(BASELINE_FILES)} baseline files")
+
+
+def check_python_syntax() -> CheckResult:
+    failures: list[str] = []
+    for path in sorted(AI_DIR.glob("*.py")):
+        try:
+            ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        except SyntaxError as exc:
+            failures.append(f"{_display_path(path)}:{exc.lineno}: {exc.msg}")
+    if failures:
+        return CheckResult("python syntax", False, "; ".join(failures))
+    return CheckResult("python syntax", True, "all scripts/ai/*.py files parse with ast")
+
+
+def check_baseline_imports() -> CheckResult:
+    path = AI_DIR / "analyze_agent_tooling.py"
+    imports = _top_level_imports(path)
+    external = sorted(imports - _stdlib_module_names())
+    if external:
+        return CheckResult(
+            "baseline imports",
+            False,
+            f"{_display_path(path)} imports non-stdlib modules: {', '.join(external)}",
+        )
+    return CheckResult("baseline imports", True, "analyze_agent_tooling.py uses stdlib imports only")
+
+
+def check_optional_dependency_messages() -> CheckResult:
+    expected = {
+        AI_DIR / "generate_cci_reference.py": ["PyYAML", "pipx inject cumulusci PyYAML"],
+        AI_DIR / "skill_manifest.py": ["PyYAML", "minimal fallback"],
+    }
+    missing: list[str] = []
+    for path, needles in expected.items():
+        text = path.read_text(encoding="utf-8")
+        for needle in needles:
+            if needle not in text:
+                missing.append(f"{_display_path(path)} missing {needle!r}")
+    if missing:
+        return CheckResult("dependency guidance", False, "; ".join(missing))
+    return CheckResult("dependency guidance", True, "PyYAML/CCI activation guidance is present")
+
+
+def check_manifest_high_level_keys() -> CheckResult:
+    text = MANIFEST.read_text(encoding="utf-8")
+    required = ("manifest_version:", "foundations:", "pmos:", "skills:", "grounding:")
+    missing = [key for key in required if key not in text]
+    if missing:
+        return CheckResult("manifest baseline", False, "missing high-level keys: " + ", ".join(missing))
+    return CheckResult("manifest baseline", True, "manifest has required high-level keys")
+
+
+def check_generated_reference_presence() -> CheckResult:
+    failures: list[str] = []
+    for path in CCI_REFERENCE_FILES:
+        text = path.read_text(encoding="utf-8") if path.is_file() else ""
+        if "Auto-generated" not in text or "scripts/ai/generate_cci_reference.py" not in text:
+            failures.append(_display_path(path))
+    if failures:
+        return CheckResult("generated reference markers", False, "missing generator marker: " + ", ".join(failures))
+    return CheckResult("generated reference markers", True, "CCI reference files identify their generator")
+
+
+def check_readme_explains_check_modes() -> CheckResult:
+    text = (AI_DIR / "README.md").read_text(encoding="utf-8")
+    required = ("baseline static checks", "full generated-reference checks")
+    missing = [phrase for phrase in required if phrase not in text.lower()]
+    if missing:
+        return CheckResult("README check modes", False, "missing phrases: " + ", ".join(missing))
+    return CheckResult("README check modes", True, "README documents baseline vs full check modes")
+
+
+def run_baseline_checks() -> list[CheckResult]:
+    return [
+        check_required_files(),
+        check_python_syntax(),
+        check_baseline_imports(),
+        check_optional_dependency_messages(),
+        check_manifest_high_level_keys(),
+        check_generated_reference_presence(),
+        check_readme_explains_check_modes(),
+    ]
+
+
+def run_full_generated_reference_check() -> CheckResult:
+    if importlib.util.find_spec("yaml") is None:
+        return CheckResult("full generated-reference dry run", False, FULL_CHECK_ENV_HELP)
+    cmd = [sys.executable, str(AI_DIR / "generate_cci_reference.py"), "--dry-run"]
+    proc = subprocess.run(cmd, cwd=ROOT, text=True, capture_output=True, check=False)
+    if proc.returncode != 0:
+        detail = (proc.stderr or proc.stdout or "generator returned non-zero exit").strip()
+        return CheckResult("full generated-reference dry run", False, detail)
+    return CheckResult("full generated-reference dry run", True, "generate_cci_reference.py --dry-run completed")
+
+
+def print_results(results: Iterable[CheckResult]) -> int:
+    overall_ok = True
+    for result in results:
+        marker = "PASS" if result.ok else "FAIL"
+        print(f"[{marker}] {result.name}: {result.detail}")
+        overall_ok = overall_ok and result.ok
+    return 0 if overall_ok else 1
+
+
+def main(argv: Iterable[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Run AI-agent tooling checks. Baseline mode uses only Python stdlib."
+    )
+    parser.add_argument(
+        "--full-generated-reference-checks",
+        action="store_true",
+        help="also dry-run CCI reference generation (requires PyYAML/CumulusCI)",
+    )
+    args = parser.parse_args(list(argv) if argv is not None else None)
+
+    results = run_baseline_checks()
+    if args.full_generated_reference_checks:
+        results.append(run_full_generated_reference_check())
+    return print_results(results)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())

--- a/scripts/ai/generate_cci_reference.py
+++ b/scripts/ai/generate_cci_reference.py
@@ -18,12 +18,16 @@ Usage:
 No external dependencies beyond PyYAML.
 """
 import argparse
+import importlib
+import importlib.util
 import re
 import sys
 from collections import defaultdict
 from pathlib import Path
 
-import yaml
+yaml = None
+if importlib.util.find_spec("yaml") is not None:
+    yaml = importlib.import_module("yaml")
 
 ROOT = Path(__file__).resolve().parent.parent.parent
 CCI_YML = ROOT / "cumulusci.yml"
@@ -40,7 +44,19 @@ HEADER_NOTE = (
 # YAML loading
 # ---------------------------------------------------------------------------
 
+def _pyyaml_error() -> str:
+    return (
+        "generate_cci_reference.py requires PyYAML for full cumulusci.yml parsing.\n"
+        "Activate the project CumulusCI environment, or install PyYAML with one of:\n"
+        "  - pipx inject cumulusci PyYAML\n"
+        "  - python -m pip install PyYAML\n"
+        "  - python -m pip install cumulusci\n"
+    )
+
+
 def load_cci() -> dict:
+    if yaml is None:
+        raise SystemExit(_pyyaml_error())
     with open(CCI_YML, "r") as f:
         return yaml.safe_load(f)
 
@@ -375,8 +391,8 @@ def main():
         print(f"ERROR: {CCI_YML} not found", file=sys.stderr)
         sys.exit(1)
 
-    print(f"Parsing {CCI_YML.relative_to(ROOT)} ...")
     data = load_cci()
+    print(f"Parsed {CCI_YML.relative_to(ROOT)}.")
 
     generate_all = not (args.tasks_only or args.flows_only or args.flags_only)
 

--- a/scripts/ai/skill_manifest.py
+++ b/scripts/ai/skill_manifest.py
@@ -34,24 +34,203 @@ CLI usage (for diagnostics):
 from __future__ import annotations
 
 import argparse
+import importlib
+import importlib.util
 import os
 import sys
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Iterable
 
-try:
-    import yaml
-except ImportError:  # pragma: no cover
-    sys.stderr.write(
-        "skill_manifest.py requires PyYAML. Install via "
-        "`pipx inject cumulusci PyYAML` (CCI venv) or `pip install pyyaml`.\n"
-    )
-    sys.exit(2)
+yaml = None
+if importlib.util.find_spec("yaml") is not None:
+    yaml = importlib.import_module("yaml")
 
 
 MANIFEST_FILENAME = ".claude/skill-manifest.yml"
 
+PY_YAML_HELP = (
+    "PyYAML is not installed, so skill_manifest.py is using its minimal fallback. "
+    "The fallback supports baseline diagnostics only: file presence, high-level "
+    "manifest keys, repo discovery, and simple skill path listing. For full YAML "
+    "support, activate the project CumulusCI environment or install PyYAML with "
+    "`pipx inject cumulusci PyYAML`, `python -m pip install PyYAML`, or "
+    "`python -m pip install cumulusci`."
+)
+
+
+def _strip_inline_comment(value: str) -> str:
+    """Remove simple YAML comments outside quoted values for fallback parsing."""
+    in_single = False
+    in_double = False
+    for idx, char in enumerate(value):
+        if char == "'" and not in_double:
+            in_single = not in_single
+        elif char == '"' and not in_single:
+            in_double = not in_double
+        elif char == "#" and not in_single and not in_double:
+            return value[:idx].rstrip()
+    return value.strip()
+
+
+def _parse_scalar(value: str) -> Any:
+    """Parse a tiny subset of YAML scalars used by baseline diagnostics."""
+    value = _strip_inline_comment(value.strip())
+    if value in ("", "null", "Null", "NULL", "~"):
+        return None
+    if value in ("true", "True", "TRUE"):
+        return True
+    if value in ("false", "False", "FALSE"):
+        return False
+    if value == "[]":
+        return []
+    if value.startswith("[") and value.endswith("]"):
+        inner = value[1:-1].strip()
+        if not inner:
+            return []
+        return [_parse_scalar(part.strip()) for part in inner.split(",")]
+    if (value.startswith('"') and value.endswith('"')) or (
+        value.startswith("'") and value.endswith("'")
+    ):
+        return value[1:-1]
+    try:
+        return int(value)
+    except ValueError:
+        return value
+
+
+def _load_manifest_minimal(manifest_path: Path) -> dict[str, Any]:
+    """Load enough manifest structure for baseline checks without PyYAML.
+
+    This fallback intentionally does not try to be a general YAML parser. It
+    recognizes the manifest's top-level metadata, repo sections, local path
+    hints, simple grounding/context_files path entries, and skill ``id`` /
+    ``path`` / ``purpose`` fields so diagnostics can still run in a fresh
+    checkout. Complex nested YAML remains a PyYAML-only feature.
+    """
+    data: dict[str, Any] = {"_minimal_fallback": True}
+    current_repo: str | None = None
+    current_list: str | None = None
+    current_skill: dict[str, Any] | None = None
+    current_mapping: str | None = None
+    current_mapping_key: str | None = None
+
+    for raw_line in manifest_path.read_text(encoding="utf-8").splitlines():
+        if not raw_line.strip() or raw_line.lstrip().startswith("#"):
+            continue
+        indent = len(raw_line) - len(raw_line.lstrip(" "))
+        line = raw_line.strip()
+
+        if indent == 0 and line.endswith(":"):
+            key = line[:-1]
+            if key in ("foundations", "pmos"):
+                current_repo = key
+                data.setdefault(key, {})
+            else:
+                data.setdefault(key, {})
+                current_repo = None
+            current_list = None
+            current_skill = None
+            current_mapping = None
+            current_mapping_key = None
+            continue
+
+        if indent == 0 and ":" in line:
+            key, value = line.split(":", 1)
+            data[key] = _parse_scalar(value)
+            current_repo = None
+            current_list = None
+            current_mapping = None
+            current_mapping_key = None
+            continue
+
+        if current_repo is None:
+            continue
+        section = data.setdefault(current_repo, {})
+
+        if indent == 2 and line.endswith(":"):
+            key = line[:-1]
+            if key in ("local_path_hints", "skills"):
+                section.setdefault(key, [])
+                current_list = key
+                current_mapping = None
+            elif key in ("grounding", "context_files"):
+                section.setdefault(key, {})
+                current_mapping = key
+                current_list = None
+            else:
+                section.setdefault(key, {})
+                current_list = None
+                current_mapping = None
+            current_skill = None
+            current_mapping_key = None
+            continue
+
+        if indent == 2 and ":" in line:
+            key, value = line.split(":", 1)
+            section[key] = _parse_scalar(value)
+            current_list = None
+            current_skill = None
+            current_mapping = None
+            current_mapping_key = None
+            continue
+
+        if (
+            current_list == "local_path_hints"
+            and indent == 4
+            and line.startswith("- ")
+        ):
+            section.setdefault("local_path_hints", []).append(_parse_scalar(line[2:]))
+            continue
+
+        if current_list == "skills" and indent == 4 and line.startswith("- "):
+            current_skill = {}
+            section.setdefault("skills", []).append(current_skill)
+            item = line[2:]
+            if ":" in item:
+                key, value = item.split(":", 1)
+                current_skill[key] = _parse_scalar(value)
+            continue
+
+        if (
+            current_list == "skills"
+            and current_skill is not None
+            and indent == 6
+            and ":" in line
+        ):
+            key, value = line.split(":", 1)
+            # Baseline diagnostics only need simple scalar skill metadata.
+            if key in ("id", "path", "purpose"):
+                current_skill[key] = _parse_scalar(value)
+            continue
+
+        if (
+            current_mapping in ("grounding", "context_files")
+            and indent == 4
+            and ":" in line
+        ):
+            key, value = line.split(":", 1)
+            mapping = section.setdefault(current_mapping, {})
+            parsed_value = _parse_scalar(value)
+            mapping[key] = {} if parsed_value is None else parsed_value
+            current_mapping_key = key
+            continue
+
+        if (
+            current_mapping in ("grounding", "context_files")
+            and current_mapping_key
+            and indent == 6
+            and ":" in line
+        ):
+            key, value = line.split(":", 1)
+            entry = section.setdefault(current_mapping, {}).setdefault(
+                current_mapping_key, {}
+            )
+            if isinstance(entry, dict) and key == "path":
+                entry[key] = _parse_scalar(value)
+            continue
+
+    return data
 
 # ─── Repo discovery ─────────────────────────────────────────────────────────
 
@@ -160,8 +339,12 @@ def find_manifest(start: Path | None = None) -> Path:
 def load_manifest(path: Path | None = None) -> dict[str, Any]:
     """Load and lightly normalize the manifest. Discovers repo locations."""
     manifest_path = path or find_manifest()
-    with manifest_path.open("r") as f:
-        data: dict[str, Any] = yaml.safe_load(f) or {}
+    if yaml is None:
+        print(PY_YAML_HELP, file=sys.stderr)
+        data = _load_manifest_minimal(manifest_path)
+    else:
+        with manifest_path.open("r") as f:
+            data: dict[str, Any] = yaml.safe_load(f) or {}
 
     # Stash where we found it so callers can debug
     data["_manifest_path"] = str(manifest_path)


### PR DESCRIPTION
### Motivation
- Provide an always-available, safe baseline validation for AI-agent tooling that runs in a fresh checkout using only the Python standard library. 
- Preserve existing full-featured behaviors that rely on PyYAML/CCI while failing gracefully with clear activation/install guidance when the environment is not present. 
- Allow `skill_manifest.py` to still provide useful baseline diagnostics when PyYAML is absent by implementing a minimal manifest fallback. 

### Description
- Add `scripts/ai/analyze_agent_tooling.py`, a standard-library-only baseline checker that verifies required files, Python syntax, dependency guidance messages, manifest high-level keys, generated-reference markers, and README coverage, and that can optionally dry-run generator checks. 
- Update `scripts/ai/generate_cci_reference.py` to detect PyYAML at runtime and print a clear activation/install message instead of raising an import traceback if PyYAML is missing. 
- Update `scripts/ai/skill_manifest.py` to detect PyYAML optionally and add a minimal, purpose-built `_load_manifest_minimal` fallback parser that extracts high-level keys, repo sections, local path hints, grounding paths, and simple skill metadata for baseline diagnostics. 
- Document the distinction between “baseline static checks” and “full generated-reference checks” in `scripts/ai/README.md` and note dependency expectations for each mode. 

### Testing
- Ran `python scripts/ai/analyze_agent_tooling.py` (baseline mode) and all baseline checks passed. 
- Ran `python scripts/ai/skill_manifest.py --check` and it produced a manifest discovery report using the minimal fallback (printed PyYAML guidance) and exited successfully. 
- Ran `python -m py_compile scripts/ai/analyze_agent_tooling.py scripts/ai/generate_cci_reference.py scripts/ai/skill_manifest.py` and compilation succeeded. 
- Ran `python scripts/ai/analyze_agent_tooling.py --full-generated-reference-checks` and `python scripts/ai/generate_cci_reference.py --dry-run` which both reported the expected PyYAML/CCI activation guidance in the current environment (failures are expected when PyYAML/CCI is not installed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a235e611044832a93301499f93c6ae5)