### PR TITLE
Consolidate agent-tooling analyzer (supersedes #196/#197/#200/#201)

### DIFF
--- a/.agents/context/rule-skill-coverage.md
+++ b/.agents/context/rule-skill-coverage.md
@@ -14,12 +14,12 @@
 
 | Rule file path | Glob pattern | Equivalent skill path | Has DO NOT section | Appears in AGENTS.md | Listed in skill README | Recommended owner/domain |
 |---|---|---|---|---|---|---|
-| `.cursor/rules/apex-classes.mdc` | `unpackaged/**/*.cls`<br>`force-app/**/*.cls` | `repo-integration/SKILL.md` | Yes | Yes | No | Apex |
+| `.cursor/rules/apex-classes.mdc` | `unpackaged/**/*.cls`<br>`force-app/**/*.cls` | (stand-alone) | Yes | Yes | No | Apex |
 | `.cursor/rules/apex-scripts.mdc` | `scripts/apex/**/*.apex` | `troubleshooting/SKILL.md` | Yes | Yes | Yes | Apex |
 | `.cursor/rules/cci-python-tasks.mdc` | `tasks/**/*.py` | `cci-orchestration/custom-task-authoring.md` | Yes | Yes | Yes | CCI Orchestration |
 | `.cursor/rules/cci-task-definitions.mdc` | `cumulusci.yml` | `cci-orchestration/SKILL.md` | Yes | Yes | Yes | CCI Orchestration |
 | `.cursor/rules/doc-review.mdc` | `cumulusci.yml`<br>`tasks/**/*.py`<br>`datasets/sfdmu/**/export.json`<br>`datasets/sfdmu/**/*.csv`<br>`robot/**/*.robot`<br>`.cursor/skills/**/*.md` | `doc-consistency/SKILL.md` | No | Yes | Yes | Doc Consistency |
-| `.cursor/rules/lwc-components.mdc` | `unpackaged/**/lwc/**/*.html`<br>`unpackaged/**/lwc/**/*.js`<br>`force-app/**/lwc/**/*.html`<br>`force-app/**/lwc/**/*.js` | `repo-integration/SKILL.md` | Yes | Yes | No | Lightning Web Components |
+| `.cursor/rules/lwc-components.mdc` | `unpackaged/**/lwc/**/*.html`<br>`unpackaged/**/lwc/**/*.js`<br>`force-app/**/lwc/**/*.html`<br>`force-app/**/lwc/**/*.js` | (stand-alone) | Yes | Yes | No | Lightning Web Components |
 | `.cursor/rules/robot-tests.mdc` | `robot/**/*.robot`<br>`robot/**/*.py` | `robot-testing/SKILL.md` | Yes | Yes | Yes | Robot Testing |
 | `.cursor/rules/sfdmu-csv-data.mdc` | `datasets/sfdmu/**/*.csv` | `sfdmu-data-plans/SKILL.md` | Yes | Yes | Yes | SFDMU Data Plans |
 | `.cursor/rules/sfdmu-export-json.mdc` | `**/export.json` | `sfdmu-data-plans/SKILL.md` | Yes | Yes | Yes | SFDMU Data Plans |

--- a/.agents/context/rule-skill-coverage.md
+++ b/.agents/context/rule-skill-coverage.md
@@ -1,0 +1,59 @@
+# Rule / Skill Coverage Matrix
+
+> **Auto-generated** by `scripts/ai/analyze_agent_tooling.py coverage`.
+> Do not edit manually — re-run the analyzer after changing `AGENTS.md`, `.cursor/rules/`, or `.cursor/skills/README.md`.
+
+## Summary
+
+- Cursor rule files found: **10**
+- Rules not listed in `.cursor/skills/README.md`: **2**
+- Recommended skill rules still missing: **6**
+- High-risk AGENTS.md paths lacking both a rule and analyzer check: **4**
+
+## Rule Matrix
+
+| Rule file path | Glob pattern | Equivalent skill path | Has DO NOT section | Appears in AGENTS.md | Listed in skill README | Recommended owner/domain |
+|---|---|---|---|---|---|---|
+| `.cursor/rules/apex-classes.mdc` | `unpackaged/**/*.cls`<br>`force-app/**/*.cls` | `repo-integration/SKILL.md` | Yes | Yes | No | Apex |
+| `.cursor/rules/apex-scripts.mdc` | `scripts/apex/**/*.apex` | `troubleshooting/SKILL.md` | Yes | Yes | Yes | Apex |
+| `.cursor/rules/cci-python-tasks.mdc` | `tasks/**/*.py` | `cci-orchestration/custom-task-authoring.md` | Yes | Yes | Yes | CCI Orchestration |
+| `.cursor/rules/cci-task-definitions.mdc` | `cumulusci.yml` | `cci-orchestration/SKILL.md` | Yes | Yes | Yes | CCI Orchestration |
+| `.cursor/rules/doc-review.mdc` | `cumulusci.yml`<br>`tasks/**/*.py`<br>`datasets/sfdmu/**/export.json`<br>`datasets/sfdmu/**/*.csv`<br>`robot/**/*.robot`<br>`.cursor/skills/**/*.md` | `doc-consistency/SKILL.md` | No | Yes | Yes | Doc Consistency |
+| `.cursor/rules/lwc-components.mdc` | `unpackaged/**/lwc/**/*.html`<br>`unpackaged/**/lwc/**/*.js`<br>`force-app/**/lwc/**/*.html`<br>`force-app/**/lwc/**/*.js` | `repo-integration/SKILL.md` | Yes | Yes | No | Lightning Web Components |
+| `.cursor/rules/robot-tests.mdc` | `robot/**/*.robot`<br>`robot/**/*.py` | `robot-testing/SKILL.md` | Yes | Yes | Yes | Robot Testing |
+| `.cursor/rules/sfdmu-csv-data.mdc` | `datasets/sfdmu/**/*.csv` | `sfdmu-data-plans/SKILL.md` | Yes | Yes | Yes | SFDMU Data Plans |
+| `.cursor/rules/sfdmu-export-json.mdc` | `**/export.json` | `sfdmu-data-plans/SKILL.md` | Yes | Yes | Yes | SFDMU Data Plans |
+| `.cursor/rules/ux-templates.mdc` | `templates/**` | `repo-integration/SKILL.md` | Yes | Yes | Yes | UX Assembly |
+
+## Flags
+
+### 1. Rules not listed in the skill README
+
+- `.cursor/rules/apex-classes.mdc` — owner/domain: **Apex**; add it to `.cursor/skills/README.md` or document why it is intentionally omitted.
+- `.cursor/rules/lwc-components.mdc` — owner/domain: **Lightning Web Components**; add it to `.cursor/skills/README.md` or document why it is intentionally omitted.
+
+### 2. Skills with no corresponding rule where file-specific auto-injection would reduce risk
+
+| Skill path | Suggested rule | Suggested glob(s) | Owner/domain | Reason |
+|---|---|---|---|---|
+| `schema-validation/SKILL.md` | `schema-validation.mdc` | `docs/erds/**`<br>`scripts/erd/**/*.py` | Schema Validation | ERD/schema files are safety-critical and the skill has no file-triggered rule today. |
+| `release-enablement/SKILL.md` | `release-enablement.mdc` | `docs/enablement/**`<br>`docs/salesforce/**` | Release Enablement | Enablement docs have release-specific source/extract conventions that are easy to miss. |
+| `rlm-business-apis/SKILL.md` | `rlm-business-apis.mdc` | `postman/**`<br>`scripts/soql/**` | Business APIs | API collections and SOQL files benefit from endpoint/auth/query guardrails at edit time. |
+| `pmos-integration/SKILL.md` | `pmos-integration.mdc` | `.claude/skill-manifest.yml` | PMOS Integration | The cross-repo skill manifest is a single integration point with no auto-injected rule. |
+| `revenue-cloud-docs/SKILL.md` | `revenue-cloud-docs.mdc` | `docs/salesforce/**`<br>`docs/enablement/**` | Revenue Cloud Docs | Grounding product claims against Salesforce Help is high-risk but not file-triggered. |
+| `repo-integration/ux-assembly-retrieve.md` | `post-ux-generated-output.mdc` | `unpackaged/post_ux/**` | UX Assembly | `unpackaged/post_ux/` is generated output and should warn on any direct edit. |
+
+### 3. High-risk paths from AGENTS.md that lack a rule or explicit analyzer check
+
+| Path | Owner/domain | AGENTS.md source | Expected rule | Explicit analyzer check | Reason |
+|---|---|---|---|---|---|
+| `unpackaged/post_ux/**` | UX Assembly | AGENTS.md DO NOT #1 and Repository Layout | `post-ux-generated-output.mdc` | — | Generated UX output must not be edited directly. |
+| `force-app/**/profiles/*.profile-meta.xml` | UX Assembly / Profiles | AGENTS.md DO NOT #2 | `force-app-profile-safety.mdc` | — | Force-app profiles should stay classAccesses-only; layout/application visibility belongs in templates. |
+| `force-app/**/*.object-meta.xml` | UX Assembly / Objects | AGENTS.md DO NOT #3 | `force-app-object-safety.mdc` | — | Object actionOverrides/compact layout assignment belong in templates, not force-app objects. |
+| `**/rlm.network-meta.xml` | PRM Network | AGENTS.md DO NOT #7 | `network-email-safety.mdc` | — | Network metadata must keep placeholder emails; deploy tasks patch/revert real values. |
+
+## Notes
+
+- `Appears in AGENTS.md` is true when the rule filename is present in the root `AGENTS.md` file-specific rule table.
+- `Listed in skill README` is true when the rule filename is present in `.cursor/skills/README.md`.
+- High-risk path coverage is satisfied by either a matching `.cursor/rules/*.mdc` glob or an explicit analyzer/validator script listed in this report.

--- a/.agents/context/tooling-scorecard.json
+++ b/.agents/context/tooling-scorecard.json
@@ -59,20 +59,14 @@
     "generated_at": "2026-05-23T00:00:00Z",
     "last_verified": "2026-05-23",
     "manifest_version": "2",
-    "parser": "line-oriented fallback",
     "present": true,
     "salesforce_release_active": "262",
-    "skill_count": 21,
+    "skill_count": 14,
     "skill_ids": [
       "cci-orchestration",
-      "check_pmos_prd",
       "doc-consistency",
-      "mfg/en-US",
       "pmos-integration",
-      "q3/en-US",
       "qb-demo-script",
-      "qb/en-US",
-      "qb/ja",
       "release-enablement",
       "repo-integration",
       "revenue-cloud-data-model",
@@ -82,9 +76,7 @@
       "schema-validation",
       "sfdmu-data-plans",
       "skill-authoring",
-      "snapshot_salesforce_help",
-      "troubleshooting",
-      "validate_setup"
+      "troubleshooting"
     ],
     "skill_paths": [
       ".cursor/skills/cci-orchestration/SKILL.md",

--- a/.agents/context/tooling-scorecard.json
+++ b/.agents/context/tooling-scorecard.json
@@ -1,0 +1,220 @@
+{
+  "agents_skill_references": {
+    "checked": [
+      ".cursor/skills/cci-orchestration/SKILL.md",
+      ".cursor/skills/cci-orchestration/custom-task-authoring.md",
+      ".cursor/skills/cci-orchestration/feature-flags.md",
+      ".cursor/skills/cci-orchestration/flows-reference.md",
+      ".cursor/skills/cci-orchestration/tasks-reference.md",
+      ".cursor/skills/doc-consistency/SKILL.md",
+      ".cursor/skills/pmos-integration/SKILL.md",
+      ".cursor/skills/qb-demo-script/SKILL.md",
+      ".cursor/skills/release-enablement/SKILL.md",
+      ".cursor/skills/release-enablement/authoring-patterns.md",
+      ".cursor/skills/release-enablement/resume-enablement-work.md",
+      ".cursor/skills/repo-integration/SKILL.md",
+      ".cursor/skills/repo-integration/dependency-ordering.md",
+      ".cursor/skills/repo-integration/new-feature-guide.md",
+      ".cursor/skills/repo-integration/ux-assembly-retrieve.md",
+      ".cursor/skills/revenue-cloud-data-model/SKILL.md",
+      ".cursor/skills/revenue-cloud-data-model/cross-domain-relationships.md",
+      ".cursor/skills/revenue-cloud-docs/SKILL.md",
+      ".cursor/skills/rlm-business-apis/SKILL.md",
+      ".cursor/skills/robot-testing/SKILL.md",
+      ".cursor/skills/robot-testing/patterns.md",
+      ".cursor/skills/robot-testing/setup-ui-shadow-dom.md",
+      ".cursor/skills/schema-validation/SKILL.md",
+      ".cursor/skills/sfdmu-data-plans/SKILL.md",
+      ".cursor/skills/sfdmu-data-plans/object-plan-mapping.md",
+      ".cursor/skills/sfdmu-data-plans/plan-dependency-graph.md",
+      ".cursor/skills/skill-authoring/SKILL.md",
+      ".cursor/skills/troubleshooting/SKILL.md"
+    ],
+    "missing": []
+  },
+  "counts": {
+    "agents_skill_references": 28,
+    "cursor_rules": 10,
+    "errors": 0,
+    "generated_cci_reference_files_present": 3,
+    "generated_cci_reference_files_total": 3,
+    "missing_agents_skill_references": 0,
+    "required_files_present": 6,
+    "required_files_total": 6,
+    "skills_markdown_files": 38,
+    "warnings": 0
+  },
+  "errors": [],
+  "generated_cci_reference_files": {
+    ".cursor/skills/cci-orchestration/feature-flags.md": true,
+    ".cursor/skills/cci-orchestration/flows-reference.md": true,
+    ".cursor/skills/cci-orchestration/tasks-reference.md": true
+  },
+  "manifest": {
+    "auto_generated_subfiles": [
+      ".cursor/skills/cci-orchestration/feature-flags.md",
+      ".cursor/skills/cci-orchestration/flows-reference.md",
+      ".cursor/skills/cci-orchestration/tasks-reference.md"
+    ],
+    "generated_at": "2026-05-23T00:00:00Z",
+    "last_verified": "2026-05-23",
+    "manifest_version": "2",
+    "parser": "line-oriented fallback",
+    "present": true,
+    "salesforce_release_active": "262",
+    "skill_count": 21,
+    "skill_ids": [
+      "cci-orchestration",
+      "check_pmos_prd",
+      "doc-consistency",
+      "mfg/en-US",
+      "pmos-integration",
+      "q3/en-US",
+      "qb-demo-script",
+      "qb/en-US",
+      "qb/ja",
+      "release-enablement",
+      "repo-integration",
+      "revenue-cloud-data-model",
+      "revenue-cloud-docs",
+      "rlm-business-apis",
+      "robot-testing",
+      "schema-validation",
+      "sfdmu-data-plans",
+      "skill-authoring",
+      "snapshot_salesforce_help",
+      "troubleshooting",
+      "validate_setup"
+    ],
+    "skill_paths": [
+      ".cursor/skills/cci-orchestration/SKILL.md",
+      ".cursor/skills/doc-consistency/SKILL.md",
+      ".cursor/skills/pmos-integration/SKILL.md",
+      ".cursor/skills/qb-demo-script/SKILL.md",
+      ".cursor/skills/release-enablement/SKILL.md",
+      ".cursor/skills/repo-integration/SKILL.md",
+      ".cursor/skills/revenue-cloud-data-model/SKILL.md",
+      ".cursor/skills/revenue-cloud-docs/SKILL.md",
+      ".cursor/skills/rlm-business-apis/SKILL.md",
+      ".cursor/skills/robot-testing/SKILL.md",
+      ".cursor/skills/schema-validation/SKILL.md",
+      ".cursor/skills/sfdmu-data-plans/SKILL.md",
+      ".cursor/skills/skill-authoring/SKILL.md",
+      ".cursor/skills/troubleshooting/SKILL.md"
+    ]
+  },
+  "required_files": {
+    ".claude/skill-manifest.yml": true,
+    ".cursor/skills/README.md": true,
+    ".github/copilot-instructions.md": true,
+    "AGENTS.md": true,
+    "CLAUDE.md": true,
+    "scripts/ai/README.md": true
+  },
+  "rule_mappings": [
+    {
+      "rule": "apex-classes.mdc",
+      "status": "standalone",
+      "target": "*(stand-alone \u2014 sharing keywords, `Id.valueOf` validation, SOQL safety, test patterns; complements `repo-integration/SKILL.md` for placement)*"
+    },
+    {
+      "rule": "apex-scripts.mdc",
+      "status": "skill",
+      "target": ".cursor/skills/troubleshooting/SKILL.md"
+    },
+    {
+      "rule": "cci-python-tasks.mdc",
+      "status": "skill",
+      "target": ".cursor/skills/cci-orchestration/custom-task-authoring.md"
+    },
+    {
+      "rule": "cci-task-definitions.mdc",
+      "status": "skill",
+      "target": ".cursor/skills/cci-orchestration/SKILL.md"
+    },
+    {
+      "rule": "doc-review.mdc",
+      "status": "skill",
+      "target": ".cursor/skills/doc-consistency/SKILL.md"
+    },
+    {
+      "rule": "lwc-components.mdc",
+      "status": "standalone",
+      "target": "*(stand-alone \u2014 template syntax, ARIA/accessibility, performance, error messages; complements `repo-integration/SKILL.md` for placement)*"
+    },
+    {
+      "rule": "robot-tests.mdc",
+      "status": "skill",
+      "target": ".cursor/skills/robot-testing/SKILL.md"
+    },
+    {
+      "rule": "sfdmu-csv-data.mdc",
+      "status": "skill",
+      "target": ".cursor/skills/sfdmu-data-plans/SKILL.md"
+    },
+    {
+      "rule": "sfdmu-export-json.mdc",
+      "status": "skill",
+      "target": ".cursor/skills/sfdmu-data-plans/SKILL.md"
+    },
+    {
+      "rule": "ux-templates.mdc",
+      "status": "skill",
+      "target": ".cursor/skills/repo-integration/SKILL.md"
+    }
+  ],
+  "rules": [
+    ".cursor/rules/apex-classes.mdc",
+    ".cursor/rules/apex-scripts.mdc",
+    ".cursor/rules/cci-python-tasks.mdc",
+    ".cursor/rules/cci-task-definitions.mdc",
+    ".cursor/rules/doc-review.mdc",
+    ".cursor/rules/lwc-components.mdc",
+    ".cursor/rules/robot-tests.mdc",
+    ".cursor/rules/sfdmu-csv-data.mdc",
+    ".cursor/rules/sfdmu-export-json.mdc",
+    ".cursor/rules/ux-templates.mdc"
+  ],
+  "skills": [
+    ".cursor/skills/README.md",
+    ".cursor/skills/cci-orchestration/SKILL.md",
+    ".cursor/skills/cci-orchestration/custom-task-authoring.md",
+    ".cursor/skills/cci-orchestration/feature-flags.md",
+    ".cursor/skills/cci-orchestration/flows-reference.md",
+    ".cursor/skills/cci-orchestration/tasks-reference.md",
+    ".cursor/skills/doc-consistency/SKILL.md",
+    ".cursor/skills/pmos-integration/SKILL.md",
+    ".cursor/skills/qb-demo-script/SKILL.md",
+    ".cursor/skills/release-enablement/SKILL.md",
+    ".cursor/skills/release-enablement/authoring-patterns.md",
+    ".cursor/skills/release-enablement/resume-enablement-work.md",
+    ".cursor/skills/repo-integration/SKILL.md",
+    ".cursor/skills/repo-integration/dependency-ordering.md",
+    ".cursor/skills/repo-integration/new-feature-guide.md",
+    ".cursor/skills/repo-integration/ux-assembly-retrieve.md",
+    ".cursor/skills/revenue-cloud-data-model/SKILL.md",
+    ".cursor/skills/revenue-cloud-data-model/cross-domain-relationships.md",
+    ".cursor/skills/revenue-cloud-data-model/domains/approvals.md",
+    ".cursor/skills/revenue-cloud-data-model/domains/billing.md",
+    ".cursor/skills/revenue-cloud-data-model/domains/configurator.md",
+    ".cursor/skills/revenue-cloud-data-model/domains/dro.md",
+    ".cursor/skills/revenue-cloud-data-model/domains/pcm.md",
+    ".cursor/skills/revenue-cloud-data-model/domains/pricing.md",
+    ".cursor/skills/revenue-cloud-data-model/domains/rates.md",
+    ".cursor/skills/revenue-cloud-data-model/domains/transactions.md",
+    ".cursor/skills/revenue-cloud-data-model/domains/usage.md",
+    ".cursor/skills/revenue-cloud-docs/SKILL.md",
+    ".cursor/skills/rlm-business-apis/SKILL.md",
+    ".cursor/skills/robot-testing/SKILL.md",
+    ".cursor/skills/robot-testing/patterns.md",
+    ".cursor/skills/robot-testing/setup-ui-shadow-dom.md",
+    ".cursor/skills/schema-validation/SKILL.md",
+    ".cursor/skills/sfdmu-data-plans/SKILL.md",
+    ".cursor/skills/sfdmu-data-plans/object-plan-mapping.md",
+    ".cursor/skills/sfdmu-data-plans/plan-dependency-graph.md",
+    ".cursor/skills/skill-authoring/SKILL.md",
+    ".cursor/skills/troubleshooting/SKILL.md"
+  ],
+  "status": "pass",
+  "warnings": []
+}

--- a/.github/workflows/agent-tooling-optimization.yml
+++ b/.github/workflows/agent-tooling-optimization.yml
@@ -22,56 +22,79 @@ on:
       - "scripts/ai/**"
       - ".github/workflows/agent-tooling-optimization.yml"
 
+# Least-privilege default: the workflow floor is read-only, so any job that
+# does not declare its own permissions can never pick up write access. The
+# deep-checks job elevates only the scopes it needs.
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 concurrency:
   group: agent-tooling-optimization-${{ github.ref }}
   cancel-in-progress: false
 
 jobs:
-  analyze-agent-tooling:
+  # Stdlib-only baseline gate. Runs on every event (pull_request, schedule,
+  # workflow_dispatch) as a read-only check — no writes, no PR creation — so it
+  # is safe to run against untrusted pull_request content.
+  baseline:
+    name: Baseline static checks (stdlib only)
     runs-on: ubuntu-latest
-    timeout-minutes: 30
-    env:
-      # Deep checks (regenerate artifacts + open a drift PR) run on the weekly
-      # schedule and on manual dispatch with deep_checks=true. pull_request runs
-      # the stdlib-only baseline gate only.
-      # Use github.event.inputs (always a valid context; null on non-dispatch
-      # events) rather than the dispatch-only `inputs` context. It is a string,
-      # so compare against 'true' — a non-empty string is otherwise truthy.
-      DEEP_CHECKS: ${{ github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && github.event.inputs.deep_checks == 'true') || false }}
+    timeout-minutes: 20
+    permissions:
+      contents: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
-          fetch-depth: 0
+          # Read-only gate never pushes, so do not leave the token in .git/config.
+          persist-credentials: false
 
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
           python-version: "3.13"
 
-      # The baseline gate is stdlib-only by design: run it before installing
-      # anything so a regression in the stdlib-only invariant is caught here.
       - name: Baseline static checks (stdlib only)
         run: python scripts/ai/analyze_agent_tooling.py check
 
-      - name: Install PyYAML for deep checks
-        if: ${{ env.DEEP_CHECKS == 'true' }}
+  # Deep checks: regenerate the committed artifacts and open a drift PR. Gated
+  # at the JOB level to trusted events only (weekly schedule, or manual dispatch
+  # with deep_checks=true) — pull_request can never satisfy the `if:`, so the
+  # write-scoped token is never exposed to PR (incl. fork) content. Runs only
+  # after the read-only baseline gate passes.
+  deep-checks:
+    name: Deep checks and drift PR
+    needs: baseline
+    if: ${{ github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && github.event.inputs.deep_checks == 'true') }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          # create-pull-request supplies its own token via `token:`, so the
+          # persisted credential is unnecessary here too.
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Install PyYAML
         run: python -m pip install --upgrade PyYAML
 
       - name: Full generated-reference checks
-        if: ${{ env.DEEP_CHECKS == 'true' }}
         run: python scripts/ai/analyze_agent_tooling.py check --full-generated-reference-checks
 
       - name: Regenerate report, scorecard, and coverage artifacts
-        if: ${{ env.DEEP_CHECKS == 'true' }}
         run: python scripts/ai/analyze_agent_tooling.py all
 
       - name: Upload tooling artifacts
-        if: ${{ env.DEEP_CHECKS == 'true' }}
         uses: actions/upload-artifact@v4
         with:
           name: agent-tooling-artifacts
@@ -82,8 +105,9 @@ jobs:
           if-no-files-found: warn
 
       - name: Open or update optimization pull request
-        if: ${{ env.DEEP_CHECKS == 'true' }}
-        uses: peter-evans/create-pull-request@v7
+        # Third-party, write-scoped action — pinned to a full commit SHA (not the
+        # mutable v7 tag) to limit supply-chain blast radius. Bump via Dependabot.
+        uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676  # v7.0.11
         with:
           token: ${{ github.token }}
           branch: automation/agent-tooling-optimization

--- a/.github/workflows/agent-tooling-optimization.yml
+++ b/.github/workflows/agent-tooling-optimization.yml
@@ -1,0 +1,99 @@
+name: Agent Tooling Optimization
+
+on:
+  workflow_dispatch:
+    inputs:
+      deep_checks:
+        description: "Regenerate report/scorecard/coverage artifacts (installs PyYAML) and open an update PR if they drift"
+        required: false
+        default: false
+        type: boolean
+  schedule:
+    # Weekly on Sunday at 08:17 UTC.
+    - cron: "17 8 * * 0"
+  pull_request:
+    paths:
+      - "AGENTS.md"
+      - ".github/copilot-instructions.md"
+      - ".claude/skill-manifest.yml"
+      - ".cursor/skills/**"
+      - ".cursor/rules/**"
+      - ".agents/**"
+      - "scripts/ai/**"
+      - ".github/workflows/agent-tooling-optimization.yml"
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: agent-tooling-optimization-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  analyze-agent-tooling:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      # workflow_dispatch passes a real boolean input; schedule/pull_request
+      # leave it unset, so default to false.
+      DEEP_CHECKS: ${{ github.event_name == 'workflow_dispatch' && inputs.deep_checks || false }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      # The baseline gate is stdlib-only by design: run it before installing
+      # anything so a regression in the stdlib-only invariant is caught here.
+      - name: Baseline static checks (stdlib only)
+        run: python scripts/ai/analyze_agent_tooling.py check
+
+      - name: Install PyYAML for deep checks
+        if: ${{ env.DEEP_CHECKS == 'true' }}
+        run: python -m pip install --upgrade PyYAML
+
+      - name: Full generated-reference checks
+        if: ${{ env.DEEP_CHECKS == 'true' }}
+        run: python scripts/ai/analyze_agent_tooling.py check --full-generated-reference-checks
+
+      - name: Regenerate report, scorecard, and coverage artifacts
+        if: ${{ env.DEEP_CHECKS == 'true' }}
+        run: python scripts/ai/analyze_agent_tooling.py all
+
+      - name: Upload tooling artifacts
+        if: ${{ env.DEEP_CHECKS == 'true' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: agent-tooling-artifacts
+          path: |
+            docs/analysis/tooling-optimization-report.md
+            .agents/context/tooling-scorecard.json
+            .agents/context/rule-skill-coverage.md
+          if-no-files-found: warn
+
+      - name: Open or update optimization pull request
+        if: ${{ env.DEEP_CHECKS == 'true' }}
+        uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ github.token }}
+          branch: automation/agent-tooling-optimization
+          delete-branch: true
+          title: "chore: refresh agent tooling artifacts"
+          commit-message: "chore: refresh agent tooling artifacts"
+          body: |
+            ## Summary
+            - Regenerated the agent tooling report, scorecard, and rule/skill
+              coverage matrix via `analyze_agent_tooling.py all`.
+            - Opened automatically because the committed artifacts drifted from
+              the current repository state.
+
+            ## Validation
+            - Baseline gate: `python scripts/ai/analyze_agent_tooling.py check`
+            - Deep checks: `python scripts/ai/analyze_agent_tooling.py check --full-generated-reference-checks`
+          labels: automation, agent-tooling

--- a/.github/workflows/agent-tooling-optimization.yml
+++ b/.github/workflows/agent-tooling-optimization.yml
@@ -38,7 +38,10 @@ jobs:
       # Deep checks (regenerate artifacts + open a drift PR) run on the weekly
       # schedule and on manual dispatch with deep_checks=true. pull_request runs
       # the stdlib-only baseline gate only.
-      DEEP_CHECKS: ${{ github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.deep_checks) || false }}
+      # Use github.event.inputs (always a valid context; null on non-dispatch
+      # events) rather than the dispatch-only `inputs` context. It is a string,
+      # so compare against 'true' — a non-empty string is otherwise truthy.
+      DEEP_CHECKS: ${{ github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && github.event.inputs.deep_checks == 'true') || false }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/agent-tooling-optimization.yml
+++ b/.github/workflows/agent-tooling-optimization.yml
@@ -35,9 +35,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     env:
-      # workflow_dispatch passes a real boolean input; schedule/pull_request
-      # leave it unset, so default to false.
-      DEEP_CHECKS: ${{ github.event_name == 'workflow_dispatch' && inputs.deep_checks || false }}
+      # Deep checks (regenerate artifacts + open a drift PR) run on the weekly
+      # schedule and on manual dispatch with deep_checks=true. pull_request runs
+      # the stdlib-only baseline gate only.
+      DEEP_CHECKS: ${{ github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.deep_checks) || false }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/docs/analysis/tooling-optimization-report.md
+++ b/docs/analysis/tooling-optimization-report.md
@@ -133,20 +133,14 @@ Each `.cursor/rules/*.mdc` is checked against the AGENTS.md File-Specific Rules 
 ## Skill Manifest Snapshot
 
 - Present: **True**
-- Parser: `line-oriented fallback`
 - Manifest version: `2`
 - Last verified: `2026-05-23`
 - Active Salesforce release: `262`
-- Manifest skill count: **21**
+- Manifest skill count: **14**
   - `cci-orchestration`
-  - `check_pmos_prd`
   - `doc-consistency`
-  - `mfg/en-US`
   - `pmos-integration`
-  - `q3/en-US`
   - `qb-demo-script`
-  - `qb/en-US`
-  - `qb/ja`
   - `release-enablement`
   - `repo-integration`
   - `revenue-cloud-data-model`
@@ -156,9 +150,7 @@ Each `.cursor/rules/*.mdc` is checked against the AGENTS.md File-Specific Rules 
   - `schema-validation`
   - `sfdmu-data-plans`
   - `skill-authoring`
-  - `snapshot_salesforce_help`
   - `troubleshooting`
-  - `validate_setup`
 
 ## Findings
 

--- a/docs/analysis/tooling-optimization-report.md
+++ b/docs/analysis/tooling-optimization-report.md
@@ -1,0 +1,170 @@
+# Agent Tooling Optimization Report
+
+> **Auto-generated** by `scripts/ai/analyze_agent_tooling.py report`.
+> Do not edit manually — re-run the analyzer after changing agent docs,
+> skills, rules, or the skill manifest.
+
+## Summary
+
+- Overall status: **PASS**
+- Required files: **6/6** present
+- Skills inventoried: **38** Markdown files under `.cursor/skills/`
+- Cursor rules inventoried: **10** `.mdc` files under `.cursor/rules/`
+- AGENTS.md skill references: **28** checked, **0** missing
+- Generated CCI references: **3/3** present
+- Errors: **0**
+- Warnings: **0**
+
+## Required Agent Entry Points
+
+- ✅ `AGENTS.md` — Found AGENTS.md
+- ✅ `CLAUDE.md` — Found CLAUDE.md
+- ✅ `.github/copilot-instructions.md` — Found .github/copilot-instructions.md
+- ✅ `.claude/skill-manifest.yml` — Found .claude/skill-manifest.yml
+- ✅ `.cursor/skills/README.md` — Found .cursor/skills/README.md
+- ✅ `scripts/ai/README.md` — Found scripts/ai/README.md
+
+## Skill Inventory
+
+- `.cursor/skills/README.md`
+- `.cursor/skills/cci-orchestration/SKILL.md`
+- `.cursor/skills/cci-orchestration/custom-task-authoring.md`
+- `.cursor/skills/cci-orchestration/feature-flags.md`
+- `.cursor/skills/cci-orchestration/flows-reference.md`
+- `.cursor/skills/cci-orchestration/tasks-reference.md`
+- `.cursor/skills/doc-consistency/SKILL.md`
+- `.cursor/skills/pmos-integration/SKILL.md`
+- `.cursor/skills/qb-demo-script/SKILL.md`
+- `.cursor/skills/release-enablement/SKILL.md`
+- `.cursor/skills/release-enablement/authoring-patterns.md`
+- `.cursor/skills/release-enablement/resume-enablement-work.md`
+- `.cursor/skills/repo-integration/SKILL.md`
+- `.cursor/skills/repo-integration/dependency-ordering.md`
+- `.cursor/skills/repo-integration/new-feature-guide.md`
+- `.cursor/skills/repo-integration/ux-assembly-retrieve.md`
+- `.cursor/skills/revenue-cloud-data-model/SKILL.md`
+- `.cursor/skills/revenue-cloud-data-model/cross-domain-relationships.md`
+- `.cursor/skills/revenue-cloud-data-model/domains/approvals.md`
+- `.cursor/skills/revenue-cloud-data-model/domains/billing.md`
+- `.cursor/skills/revenue-cloud-data-model/domains/configurator.md`
+- `.cursor/skills/revenue-cloud-data-model/domains/dro.md`
+- `.cursor/skills/revenue-cloud-data-model/domains/pcm.md`
+- `.cursor/skills/revenue-cloud-data-model/domains/pricing.md`
+- `.cursor/skills/revenue-cloud-data-model/domains/rates.md`
+- `.cursor/skills/revenue-cloud-data-model/domains/transactions.md`
+- `.cursor/skills/revenue-cloud-data-model/domains/usage.md`
+- `.cursor/skills/revenue-cloud-docs/SKILL.md`
+- `.cursor/skills/rlm-business-apis/SKILL.md`
+- `.cursor/skills/robot-testing/SKILL.md`
+- `.cursor/skills/robot-testing/patterns.md`
+- `.cursor/skills/robot-testing/setup-ui-shadow-dom.md`
+- `.cursor/skills/schema-validation/SKILL.md`
+- `.cursor/skills/sfdmu-data-plans/SKILL.md`
+- `.cursor/skills/sfdmu-data-plans/object-plan-mapping.md`
+- `.cursor/skills/sfdmu-data-plans/plan-dependency-graph.md`
+- `.cursor/skills/skill-authoring/SKILL.md`
+- `.cursor/skills/troubleshooting/SKILL.md`
+
+## Cursor Rule Inventory
+
+- `.cursor/rules/apex-classes.mdc`
+- `.cursor/rules/apex-scripts.mdc`
+- `.cursor/rules/cci-python-tasks.mdc`
+- `.cursor/rules/cci-task-definitions.mdc`
+- `.cursor/rules/doc-review.mdc`
+- `.cursor/rules/lwc-components.mdc`
+- `.cursor/rules/robot-tests.mdc`
+- `.cursor/rules/sfdmu-csv-data.mdc`
+- `.cursor/rules/sfdmu-export-json.mdc`
+- `.cursor/rules/ux-templates.mdc`
+
+## AGENTS.md Skill Reference Check
+
+- ✅ `.cursor/skills/cci-orchestration/SKILL.md`
+- ✅ `.cursor/skills/cci-orchestration/custom-task-authoring.md`
+- ✅ `.cursor/skills/cci-orchestration/feature-flags.md`
+- ✅ `.cursor/skills/cci-orchestration/flows-reference.md`
+- ✅ `.cursor/skills/cci-orchestration/tasks-reference.md`
+- ✅ `.cursor/skills/doc-consistency/SKILL.md`
+- ✅ `.cursor/skills/pmos-integration/SKILL.md`
+- ✅ `.cursor/skills/qb-demo-script/SKILL.md`
+- ✅ `.cursor/skills/release-enablement/SKILL.md`
+- ✅ `.cursor/skills/release-enablement/authoring-patterns.md`
+- ✅ `.cursor/skills/release-enablement/resume-enablement-work.md`
+- ✅ `.cursor/skills/repo-integration/SKILL.md`
+- ✅ `.cursor/skills/repo-integration/dependency-ordering.md`
+- ✅ `.cursor/skills/repo-integration/new-feature-guide.md`
+- ✅ `.cursor/skills/repo-integration/ux-assembly-retrieve.md`
+- ✅ `.cursor/skills/revenue-cloud-data-model/SKILL.md`
+- ✅ `.cursor/skills/revenue-cloud-data-model/cross-domain-relationships.md`
+- ✅ `.cursor/skills/revenue-cloud-docs/SKILL.md`
+- ✅ `.cursor/skills/rlm-business-apis/SKILL.md`
+- ✅ `.cursor/skills/robot-testing/SKILL.md`
+- ✅ `.cursor/skills/robot-testing/patterns.md`
+- ✅ `.cursor/skills/robot-testing/setup-ui-shadow-dom.md`
+- ✅ `.cursor/skills/schema-validation/SKILL.md`
+- ✅ `.cursor/skills/sfdmu-data-plans/SKILL.md`
+- ✅ `.cursor/skills/sfdmu-data-plans/object-plan-mapping.md`
+- ✅ `.cursor/skills/sfdmu-data-plans/plan-dependency-graph.md`
+- ✅ `.cursor/skills/skill-authoring/SKILL.md`
+- ✅ `.cursor/skills/troubleshooting/SKILL.md`
+
+## Cursor Rule Coverage
+
+Each `.cursor/rules/*.mdc` is checked against the AGENTS.md File-Specific Rules table for an equivalent skill or an explicit stand-alone note. See `.agents/context/rule-skill-coverage.md` for the full coverage matrix and recommendations.
+
+- ✅ `apex-classes.mdc` — explicit stand-alone note
+- ✅ `apex-scripts.mdc` — mapped to `.cursor/skills/troubleshooting/SKILL.md`
+- ✅ `cci-python-tasks.mdc` — mapped to `.cursor/skills/cci-orchestration/custom-task-authoring.md`
+- ✅ `cci-task-definitions.mdc` — mapped to `.cursor/skills/cci-orchestration/SKILL.md`
+- ✅ `doc-review.mdc` — mapped to `.cursor/skills/doc-consistency/SKILL.md`
+- ✅ `lwc-components.mdc` — explicit stand-alone note
+- ✅ `robot-tests.mdc` — mapped to `.cursor/skills/robot-testing/SKILL.md`
+- ✅ `sfdmu-csv-data.mdc` — mapped to `.cursor/skills/sfdmu-data-plans/SKILL.md`
+- ✅ `sfdmu-export-json.mdc` — mapped to `.cursor/skills/sfdmu-data-plans/SKILL.md`
+- ✅ `ux-templates.mdc` — mapped to `.cursor/skills/repo-integration/SKILL.md`
+
+## Generated CCI Reference Files
+
+- ✅ `.cursor/skills/cci-orchestration/tasks-reference.md` — Found .cursor/skills/cci-orchestration/tasks-reference.md
+- ✅ `.cursor/skills/cci-orchestration/flows-reference.md` — Found .cursor/skills/cci-orchestration/flows-reference.md
+- ✅ `.cursor/skills/cci-orchestration/feature-flags.md` — Found .cursor/skills/cci-orchestration/feature-flags.md
+
+## Skill Manifest Snapshot
+
+- Present: **True**
+- Parser: `line-oriented fallback`
+- Manifest version: `2`
+- Last verified: `2026-05-23`
+- Active Salesforce release: `262`
+- Manifest skill count: **21**
+  - `cci-orchestration`
+  - `check_pmos_prd`
+  - `doc-consistency`
+  - `mfg/en-US`
+  - `pmos-integration`
+  - `q3/en-US`
+  - `qb-demo-script`
+  - `qb/en-US`
+  - `qb/ja`
+  - `release-enablement`
+  - `repo-integration`
+  - `revenue-cloud-data-model`
+  - `revenue-cloud-docs`
+  - `rlm-business-apis`
+  - `robot-testing`
+  - `schema-validation`
+  - `sfdmu-data-plans`
+  - `skill-authoring`
+  - `snapshot_salesforce_help`
+  - `troubleshooting`
+  - `validate_setup`
+
+## Findings
+
+- ✅ No blocking errors found.
+
+## Notes
+
+- Generated by `scripts/ai/analyze_agent_tooling.py report`.
+- The analyzer needs no third-party dependencies. With PyYAML installed, manifest reporting is richer; otherwise a line-oriented fallback is used.

--- a/scripts/ai/README.md
+++ b/scripts/ai/README.md
@@ -55,6 +55,60 @@ python scripts/ai/generate_cci_reference.py --dry-run       # preview without wr
 
 **Used by:** `.cursor/skills/cci-orchestration/SKILL.md`
 
+### `skill_manifest.py`
+
+Resolves and validates the cross-repo skill manifest (`.claude/skill-manifest.yml`)
+that links Foundations and PMOS. Uses PyYAML when available; otherwise it falls
+back to a **minimal fallback** parser that supports baseline diagnostics only
+(file presence, high-level manifest keys, repo discovery, and skill/grounding
+path listing).
+
+```bash
+python scripts/ai/skill_manifest.py --check              # validate the manifest resolves
+python scripts/ai/skill_manifest.py --list-skills foundations
+```
+
+**Data source:** `.claude/skill-manifest.yml`
+**Used by:** `.cursor/skills/pmos-integration/SKILL.md`
+
+### `analyze_agent_tooling.py`
+
+The single, tool-agnostic analyzer for the repository's AI-agent layer. It uses
+positional subcommands (like `query_erd.py`) and imports only the Python
+standard library at import time, so the gate runs in a fresh checkout before
+CumulusCI/PyYAML are installed.
+
+```bash
+python scripts/ai/analyze_agent_tooling.py            # 'check' (default)
+python scripts/ai/analyze_agent_tooling.py check       # baseline static checks (stdlib-only gate)
+python scripts/ai/analyze_agent_tooling.py report      # write Markdown report + JSON scorecard
+python scripts/ai/analyze_agent_tooling.py coverage    # write rule/skill coverage matrix
+python scripts/ai/analyze_agent_tooling.py all         # check, then report, then coverage
+```
+
+Two check modes:
+
+- **Baseline static checks** (`check`) — stdlib-only, no third-party
+  dependencies. Verifies required agent entry points, `scripts/ai/*.py`
+  syntax, the stdlib-only import invariant, dependency-guidance messages,
+  manifest high-level keys, generated-reference markers, and that this README
+  documents the check modes. Exits non-zero on any failure, so it is safe to
+  run as a CI/scheduled gate.
+- **Full generated-reference checks** (`check --full-generated-reference-checks`)
+  — additionally dry-runs `generate_cci_reference.py`, which requires
+  PyYAML/CumulusCI. Skipped with clear guidance when PyYAML is absent.
+
+PyYAML, when installed, enriches the `report` and `coverage` subcommands;
+without it they degrade gracefully to a line-oriented fallback.
+
+**Outputs:**
+- `docs/analysis/tooling-optimization-report.md` — report (`report`)
+- `.agents/context/tooling-scorecard.json` — machine-readable scorecard (`report`)
+- `.agents/context/rule-skill-coverage.md` — rule/skill coverage matrix (`coverage`)
+
+**Used by:** `.github/workflows/agent-tooling-optimization.yml`, the `.agents/`
+tool-agnostic layer.
+
 ---
 
 ## Dependencies
@@ -64,8 +118,11 @@ python scripts/ai/generate_cci_reference.py --dry-run       # preview without wr
   3.13 and the README recommends 3.12 for CumulusCI itself, so 3.10 is a
   safe lower bound and is what we test against in practice). The previous
   "3.8+" claim predated the schema-diff tooling.
-- **PyYAML** — used by `generate_cci_reference.py` and `skill_manifest.py`
-  (available in the CCI venv)
+- **PyYAML** — required by `generate_cci_reference.py` (a YAML generator) and
+  used to enrich `skill_manifest.py` and `analyze_agent_tooling.py`
+  (available in the CCI venv). `skill_manifest.py` and
+  `analyze_agent_tooling.py` degrade to a stdlib-only fallback when it is
+  absent; `analyze_agent_tooling.py check` never needs it.
 - No other external dependencies
 
 ---

--- a/scripts/ai/analyze_agent_tooling.py
+++ b/scripts/ai/analyze_agent_tooling.py
@@ -84,7 +84,8 @@ BACKTICK_MD_RE = re.compile(r"`([^`]+\.md)`")
 FENCE_RE = re.compile(r"^\s*```")
 
 FULL_CHECK_ENV_HELP = (
-    "Full generated-reference checks require PyYAML/CumulusCI. Activate the "
+    "Full generated-reference checks need PyYAML/CumulusCI, which is not "
+    "available (not installed, or failed to import). Activate the "
     "project CCI environment, or install PyYAML with one of: "
     "`pipx inject cumulusci PyYAML`, `python -m pip install PyYAML`, or "
     "`python -m pip install cumulusci`."

--- a/scripts/ai/analyze_agent_tooling.py
+++ b/scripts/ai/analyze_agent_tooling.py
@@ -181,15 +181,19 @@ def load_yaml_optional(path: Path) -> tuple[dict[str, Any] | None, str]:
     """Load YAML with PyYAML when importable; otherwise return ``(None, label)``.
 
     ``find_spec`` can report a module that still fails to import (broken or
-    partial install), so the actual import is guarded.
+    partial install), so the actual import is guarded against any import-time
+    failure (not only ImportError) and degrades to the line fallback.
     """
-    if importlib.util.find_spec("yaml") is None:
-        return None, "line-oriented fallback"
     try:
+        if importlib.util.find_spec("yaml") is None:
+            return None, "line-oriented fallback"
         yaml = importlib.import_module("yaml")
-    except ImportError:
+        data = yaml.safe_load(read_text(path)) or {}
+    except Exception:
+        # Any import-time OR parse failure (incl. malformed YAML) degrades to
+        # the line fallback, which produces the same environment-independent
+        # summary, so report/coverage still write their artifacts.
         return None, "line-oriented fallback"
-    data = yaml.safe_load(read_text(path)) or {}
     if not isinstance(data, dict):
         return {}, "PyYAML"
     return data, "PyYAML"
@@ -493,7 +497,11 @@ def run_baseline_checks(root: Path) -> list[CheckResult]:
 
 
 def run_full_generated_reference_check(root: Path) -> CheckResult:
-    if importlib.util.find_spec("yaml") is None:
+    try:
+        yaml_present = importlib.util.find_spec("yaml") is not None
+    except Exception:
+        yaml_present = False
+    if not yaml_present:
         # Skip (do not fail) when PyYAML is absent — this opt-in deeper check
         # requires it, and the README documents it as skipped with guidance.
         return CheckResult("full generated-reference dry run", True, FULL_CHECK_ENV_HELP, skipped=True)
@@ -934,11 +942,11 @@ OWNER_KEYWORDS: tuple[tuple[str, str], ...] = (
 
 
 def extract_frontmatter(text: str) -> str:
-    if not text.lstrip("﻿").startswith("---"):
+    # Strip a leading UTF-8 BOM and tolerate CRLF / an optional trailing newline
+    # after the closing fence, so a rule file's globs are not silently dropped.
+    text = text.lstrip("﻿").replace("\r\n", "\n").replace("\r", "\n")
+    if not text.startswith("---"):
         return ""
-    # Tolerate CRLF line endings and an optional trailing newline after the
-    # closing fence so a rule file's globs are not silently dropped.
-    text = text.replace("\r\n", "\n").replace("\r", "\n")
     match = re.match(r"^---\n(.*?)\n---\s*(?:\n|$)", text, flags=re.DOTALL)
     return match.group(1) if match else ""
 
@@ -1054,8 +1062,9 @@ def glob_covers(rules: list[RuleInfo], candidate: str) -> bool:
             if pattern == candidate:
                 return True
             for sample in samples:
-                # fnmatch(name, pattern): the candidate is the name to match.
-                if fnmatch.fnmatch(sample, pattern):
+                # fnmatchcase (not fnmatch) skips os.path.normcase, so coverage
+                # matching is case-sensitive and identical on every platform.
+                if fnmatch.fnmatchcase(sample, pattern):
                     return True
     return False
 

--- a/scripts/ai/analyze_agent_tooling.py
+++ b/scripts/ai/analyze_agent_tooling.py
@@ -205,14 +205,29 @@ def stdlib_module_names() -> set[str]:
 
 
 def top_level_imports(path: Path) -> set[str]:
+    """Module-level (import-time) imports only.
+
+    Does NOT descend into function or class bodies, so a lazy in-function
+    third-party import (e.g. an ``import yaml`` inside a report/coverage helper)
+    is not counted against the stdlib-only-at-import-time contract. Imports in
+    module-level ``if``/``try``/``with`` blocks still execute at import time and
+    are included.
+    """
     tree = ast.parse(read_text(path), filename=str(path))
     imports: set[str] = set()
-    for node in ast.walk(tree):
-        if isinstance(node, ast.Import):
-            for alias in node.names:
-                imports.add(alias.name.split(".", 1)[0])
-        elif isinstance(node, ast.ImportFrom) and node.module and node.level == 0:
-            imports.add(node.module.split(".", 1)[0])
+    scopes = (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)
+
+    def visit(node: ast.AST) -> None:
+        for child in ast.iter_child_nodes(node):
+            if isinstance(child, ast.Import):
+                for alias in child.names:
+                    imports.add(alias.name.split(".", 1)[0])
+            elif isinstance(child, ast.ImportFrom) and child.module and child.level == 0:
+                imports.add(child.module.split(".", 1)[0])
+            elif not isinstance(child, scopes):
+                visit(child)
+
+    visit(tree)
     return imports
 
 
@@ -335,6 +350,7 @@ class CheckResult:
     name: str
     ok: bool
     detail: str
+    skipped: bool = False
 
 
 def check_required_files(root: Path) -> CheckResult:
@@ -460,7 +476,9 @@ def run_baseline_checks(root: Path) -> list[CheckResult]:
 
 def run_full_generated_reference_check(root: Path) -> CheckResult:
     if importlib.util.find_spec("yaml") is None:
-        return CheckResult("full generated-reference dry run", False, FULL_CHECK_ENV_HELP)
+        # Skip (do not fail) when PyYAML is absent — this opt-in deeper check
+        # requires it, and the README documents it as skipped with guidance.
+        return CheckResult("full generated-reference dry run", True, FULL_CHECK_ENV_HELP, skipped=True)
     script = root / "scripts" / "ai" / "generate_cci_reference.py"
     cmd = [sys.executable, str(script), "--dry-run"]
     try:
@@ -480,12 +498,19 @@ def cmd_check(root: Path, full_generated_reference_checks: bool) -> int:
     if full_generated_reference_checks:
         results.append(run_full_generated_reference_check(root))
     overall_ok = True
+    skipped = 0
     for result in results:
-        marker = "PASS" if result.ok else "FAIL"
+        if result.skipped:
+            marker = "SKIP"
+            skipped += 1
+        else:
+            marker = "PASS" if result.ok else "FAIL"
         print(f"[{marker}] {result.name}: {result.detail}")
         overall_ok = overall_ok and result.ok
+    failing = sum(1 for r in results if not r.ok)
+    suffix = f", {skipped} skipped" if skipped else ""
     print(f"Status: {'PASS' if overall_ok else 'FAIL'} "
-          f"({sum(1 for r in results if not r.ok)} failing of {len(results)} checks)")
+          f"({failing} failing of {len(results)} checks{suffix})")
     return 0 if overall_ok else 1
 
 

--- a/scripts/ai/analyze_agent_tooling.py
+++ b/scripts/ai/analyze_agent_tooling.py
@@ -1,0 +1,1207 @@
+#!/usr/bin/env python3
+"""Analyze the repository's AI-agent tooling surface.
+
+This is the single, tool-agnostic analyzer for the repo's AI-agent layer. It
+exposes positional subcommands (mirroring ``scripts/ai/query_erd.py``):
+
+  check     stdlib-only pass/fail gate (default). Safe in a fresh checkout
+            before CumulusCI/PyYAML are installed; exits non-zero on failure.
+  report    rich Markdown report + JSON scorecard of the tooling surface.
+  coverage  Cursor rule / skill coverage matrix and gap analysis.
+  all       run check, then report, then coverage.
+
+Design contract:
+  * The module imports ONLY the Python standard library at import time, so the
+    ``check`` gate runs with no third-party dependencies. The ``check`` gate
+    self-verifies this invariant.
+  * PyYAML, when installed, is loaded lazily (via importlib, guarded against
+    import failure) to enrich ``report``/``coverage``. Without it, a
+    conservative line-oriented fallback is used.
+  * Written artifacts are deterministic (no embedded wall-clock timestamps) so
+    scheduled regeneration only produces a diff on a real change.
+
+Outputs:
+  report   -> docs/analysis/tooling-optimization-report.md
+              .agents/context/tooling-scorecard.json
+  coverage -> .agents/context/rule-skill-coverage.md
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import fnmatch
+import importlib
+import importlib.util
+import json
+import os
+import re
+import subprocess
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Iterable
+
+# ---------------------------------------------------------------------------
+# Repo-relative path constants (resolved against a repo root computed at runtime)
+# ---------------------------------------------------------------------------
+
+REQUIRED_FILES = [
+    "AGENTS.md",
+    "CLAUDE.md",
+    ".github/copilot-instructions.md",
+    ".claude/skill-manifest.yml",
+    ".cursor/skills/README.md",
+    "scripts/ai/README.md",
+]
+
+GENERATED_CCI_REFERENCE_FILES = [
+    ".cursor/skills/cci-orchestration/tasks-reference.md",
+    ".cursor/skills/cci-orchestration/flows-reference.md",
+    ".cursor/skills/cci-orchestration/feature-flags.md",
+]
+
+# Files whose presence the baseline gate asserts, beyond REQUIRED_FILES.
+BASELINE_EXTRA_FILES = [
+    "scripts/ai/query_erd.py",
+    "scripts/ai/generate_cci_reference.py",
+    "scripts/ai/skill_manifest.py",
+]
+
+MANIFEST_PATH = ".claude/skill-manifest.yml"
+AGENTS_PATH = "AGENTS.md"
+SKILLS_ROOT = ".cursor/skills"
+RULES_ROOT = ".cursor/rules"
+SKILLS_README = ".cursor/skills/README.md"
+AI_README = "scripts/ai/README.md"
+
+REPORT_PATH = "docs/analysis/tooling-optimization-report.md"
+SCORECARD_PATH = ".agents/context/tooling-scorecard.json"
+COVERAGE_PATH = ".agents/context/rule-skill-coverage.md"
+
+# A backtick-wrapped token that points at a Markdown file, e.g. `foo/bar.md`.
+BACKTICK_MD_RE = re.compile(r"`([^`]+\.md)`")
+FENCE_RE = re.compile(r"^\s*```")
+
+FULL_CHECK_ENV_HELP = (
+    "Full generated-reference checks require PyYAML/CumulusCI. Activate the "
+    "project CCI environment, or install PyYAML with one of: "
+    "`pipx inject cumulusci PyYAML`, `python -m pip install PyYAML`, or "
+    "`python -m pip install cumulusci`."
+)
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+
+def find_repo_root(start: Path | None = None) -> Path:
+    """Return the repo root.
+
+    Prefer walking up to a directory that has both AGENTS.md and .git; fall
+    back to the script's grandparent (scripts/ai/<file> -> repo root).
+    """
+    if start is None:
+        start = Path(__file__).resolve().parent
+    start = start.resolve()
+    for candidate in [start, *start.parents]:
+        if (candidate / "AGENTS.md").is_file() and (candidate / ".git").exists():
+            return candidate
+    # Fallback: this file lives at <root>/scripts/ai/analyze_agent_tooling.py.
+    here = Path(__file__).resolve()
+    if len(here.parents) >= 3:
+        return here.parents[2]
+    return start
+
+
+def read_text(path: Path, default: str = "") -> str:
+    """Read UTF-8 text, returning ``default`` for missing/unreadable files."""
+    try:
+        return path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return default
+
+
+def posix(path: Path) -> str:
+    return path.as_posix()
+
+
+def rel(path: Path, root: Path) -> str:
+    """Repo-relative POSIX path when possible, else the absolute POSIX path."""
+    try:
+        return posix(path.relative_to(root))
+    except ValueError:
+        return posix(path)
+
+
+def repo_relative(root: Path, reference: str) -> Path:
+    """Resolve a repo-relative reference, neutralizing a stray leading slash.
+
+    ``root / "/abs"`` would discard ``root`` under pathlib semantics, so a
+    leading slash is treated as repo-relative rather than filesystem-absolute.
+    """
+    return root / reference.lstrip("/")
+
+
+def path_reference_exists(root: Path, reference: str) -> bool:
+    if any(ch in reference for ch in "*{}"):
+        # Glob/template tokens are matched against the filesystem, not stat'd.
+        return bool(list(root.glob(reference.lstrip("/"))))
+    return repo_relative(root, reference).is_file()
+
+
+def strip_fenced_code(text: str) -> str:
+    """Remove fenced code blocks so their contents are not parsed as prose."""
+    kept: list[str] = []
+    in_fence = False
+    for line in text.splitlines():
+        if FENCE_RE.match(line):
+            in_fence = not in_fence
+            continue
+        if not in_fence:
+            kept.append(line)
+    return "\n".join(kept)
+
+
+def looks_like_concrete_path(token: str) -> bool:
+    """True for a token that is a plausible concrete file path.
+
+    Excludes glob/template tokens (``*``, ``**``, ``{version}``) and any token
+    containing whitespace.
+    """
+    if any(ch in token for ch in "*{}"):
+        return False
+    if any(ch.isspace() for ch in token):
+        return False
+    return True
+
+
+def load_yaml_optional(path: Path) -> tuple[dict[str, Any] | None, str]:
+    """Load YAML with PyYAML when importable; otherwise return ``(None, label)``.
+
+    ``find_spec`` can report a module that still fails to import (broken or
+    partial install), so the actual import is guarded.
+    """
+    if importlib.util.find_spec("yaml") is None:
+        return None, "line-oriented fallback"
+    try:
+        yaml = importlib.import_module("yaml")
+    except ImportError:
+        return None, "line-oriented fallback"
+    data = yaml.safe_load(read_text(path)) or {}
+    if not isinstance(data, dict):
+        return {}, "PyYAML"
+    return data, "PyYAML"
+
+
+def stdlib_module_names() -> set[str]:
+    """Best-effort set of standard-library top-level module names (3.10+)."""
+    names = set(getattr(sys, "stdlib_module_names", set()))
+    names.update(sys.builtin_module_names)
+    # __future__ is stdlib but is sometimes excluded from stdlib_module_names.
+    names.add("__future__")
+    return names
+
+
+def top_level_imports(path: Path) -> set[str]:
+    tree = ast.parse(read_text(path), filename=str(path))
+    imports: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                imports.add(alias.name.split(".", 1)[0])
+        elif isinstance(node, ast.ImportFrom) and node.module and node.level == 0:
+            imports.add(node.module.split(".", 1)[0])
+    return imports
+
+
+def sorted_relative_files(root: Path, sub: str, pattern: str) -> list[str]:
+    base = root / sub
+    if not base.exists():
+        return []
+    return sorted(
+        rel(p, root) for p in base.glob(pattern) if p.is_file()
+    )
+
+
+def first_level_skill_dirs(root: Path) -> set[str]:
+    base = root / SKILLS_ROOT
+    if not base.is_dir():
+        return set()
+    return {p.name for p in base.iterdir() if p.is_dir()}
+
+
+# ---------------------------------------------------------------------------
+# Manifest summary (shared by report)
+# ---------------------------------------------------------------------------
+
+
+def parse_manifest_fallback(text: str) -> dict[str, Any]:
+    """Conservative line parser for Foundations manifest metadata.
+
+    Top-level scalar metadata is read only from unindented lines, so identical
+    keys nested under ``pmos:`` cannot overwrite the Foundations values. Skill
+    ids are limited to the ``foundations:`` section so PMOS skill ids do not
+    inflate this repo's local count.
+    """
+    summary: dict[str, Any] = {"skills": [], "skill_paths": [], "auto_generated_subfiles": []}
+
+    foundations_text = text
+    foundations_match = re.search(r"(?ms)^foundations:\n(?P<body>.*?)(?=^\S|\Z)", text)
+    if foundations_match:
+        foundations_text = foundations_match.group("body")
+
+    for line in text.splitlines():
+        # Top-level scalars only (no leading whitespace).
+        if line[:1].isspace():
+            continue
+        for key in ("manifest_version", "generated_at", "last_verified", "salesforce_release_active"):
+            prefix = key + ":"
+            if line.startswith(prefix):
+                summary[key] = line[len(prefix):].strip().strip('"').strip("'")
+
+    for line in foundations_text.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("- id:"):
+            summary["skills"].append(stripped.split(":", 1)[1].strip())
+        elif stripped.startswith("path: .cursor/skills/"):
+            summary["skill_paths"].append(stripped.split(":", 1)[1].strip())
+        elif stripped.startswith("- .cursor/skills/cci-orchestration/"):
+            summary["auto_generated_subfiles"].append(stripped[2:].strip())
+    return summary
+
+
+def summarize_manifest(root: Path) -> dict[str, Any]:
+    manifest = root / MANIFEST_PATH
+    if not manifest.is_file():
+        return {"present": False, "parser": "not run"}
+
+    data, parser = load_yaml_optional(manifest)
+    if data is not None:
+        foundations = data.get("foundations") or {}
+        if not isinstance(foundations, dict):
+            foundations = {}
+        skills = foundations.get("skills") or []
+        if not isinstance(skills, list):
+            skills = []
+        skill_ids = [s.get("id") for s in skills if isinstance(s, dict) and s.get("id")]
+        skill_paths = [s.get("path") for s in skills if isinstance(s, dict) and s.get("path")]
+        generated_subfiles: list[str] = []
+        for s in skills:
+            if isinstance(s, dict):
+                generated_subfiles.extend(s.get("auto_generated_subfiles") or [])
+        return {
+            "present": True,
+            "parser": parser,
+            "manifest_version": _scalar(data.get("manifest_version")),
+            "generated_at": _scalar(data.get("generated_at")),
+            "last_verified": _scalar(data.get("last_verified")),
+            "salesforce_release_active": _scalar(data.get("salesforce_release_active")),
+            "skill_count": len(skill_ids),
+            "skill_ids": sorted(str(s) for s in skill_ids),
+            "skill_paths": sorted(str(p) for p in skill_paths),
+            "auto_generated_subfiles": sorted(str(p) for p in generated_subfiles),
+        }
+
+    fb = parse_manifest_fallback(read_text(manifest))
+    return {
+        "present": True,
+        "parser": parser,
+        "manifest_version": fb.get("manifest_version"),
+        "generated_at": fb.get("generated_at"),
+        "last_verified": fb.get("last_verified"),
+        "salesforce_release_active": fb.get("salesforce_release_active"),
+        "skill_count": len(fb.get("skills", [])),
+        "skill_ids": sorted(fb.get("skills", [])),
+        "skill_paths": sorted(fb.get("skill_paths", [])),
+        "auto_generated_subfiles": sorted(fb.get("auto_generated_subfiles", [])),
+    }
+
+
+def _scalar(value: Any) -> Any:
+    if isinstance(value, (str, int, float, bool)) or value is None:
+        return value
+    return str(value)
+
+
+# ===========================================================================
+# Subcommand: check  (stdlib-only pass/fail gate)
+# ===========================================================================
+
+
+@dataclass(frozen=True)
+class CheckResult:
+    name: str
+    ok: bool
+    detail: str
+
+
+def check_required_files(root: Path) -> CheckResult:
+    targets = REQUIRED_FILES + BASELINE_EXTRA_FILES + GENERATED_CCI_REFERENCE_FILES
+    missing = [t for t in targets if not (root / t).is_file()]
+    if missing:
+        return CheckResult("required files", False, "missing: " + ", ".join(sorted(missing)))
+    return CheckResult("required files", True, f"found {len(targets)} baseline files")
+
+
+def check_python_syntax(root: Path) -> CheckResult:
+    ai_dir = root / "scripts" / "ai"
+    failures: list[str] = []
+    for path in sorted(ai_dir.glob("*.py")):
+        try:
+            ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        except SyntaxError as exc:
+            failures.append(f"{rel(path, root)}:{exc.lineno}: {exc.msg}")
+        except (OSError, UnicodeDecodeError) as exc:
+            failures.append(f"{rel(path, root)}: unreadable ({exc.__class__.__name__})")
+    if failures:
+        return CheckResult("python syntax", False, "; ".join(failures))
+    return CheckResult("python syntax", True, "all scripts/ai/*.py parse with ast")
+
+
+def check_baseline_imports(root: Path) -> CheckResult:
+    path = root / "scripts" / "ai" / "analyze_agent_tooling.py"
+    if not path.is_file():
+        return CheckResult("baseline imports", False, f"missing {rel(path, root)}")
+    try:
+        imports = top_level_imports(path)
+    except (SyntaxError, OSError, UnicodeDecodeError) as exc:
+        return CheckResult("baseline imports", False, f"could not parse imports: {exc}")
+    external = sorted(imports - stdlib_module_names())
+    if external:
+        return CheckResult(
+            "baseline imports", False,
+            f"analyze_agent_tooling.py imports non-stdlib modules: {', '.join(external)}",
+        )
+    return CheckResult("baseline imports", True, "analyze_agent_tooling.py uses stdlib imports only")
+
+
+def check_optional_dependency_messages(root: Path) -> CheckResult:
+    expected = {
+        "scripts/ai/generate_cci_reference.py": ["PyYAML"],
+        "scripts/ai/skill_manifest.py": ["PyYAML", "minimal fallback"],
+    }
+    missing: list[str] = []
+    for rel_path, needles in expected.items():
+        path = root / rel_path
+        if not path.is_file():
+            missing.append(f"{rel_path} missing")
+            continue
+        text = read_text(path)
+        for needle in needles:
+            if needle not in text:
+                missing.append(f"{rel_path} missing {needle!r}")
+    if missing:
+        return CheckResult("dependency guidance", False, "; ".join(missing))
+    return CheckResult("dependency guidance", True, "PyYAML/CCI activation guidance is present")
+
+
+def check_manifest_high_level_keys(root: Path) -> CheckResult:
+    manifest = root / MANIFEST_PATH
+    if not manifest.is_file():
+        return CheckResult("manifest baseline", False, f"missing {MANIFEST_PATH}")
+    text = read_text(manifest)
+    required = ("manifest_version:", "foundations:", "pmos:", "skills:", "grounding:")
+    missing = [k for k in required if k not in text]
+    if missing:
+        return CheckResult("manifest baseline", False, "missing high-level keys: " + ", ".join(missing))
+    return CheckResult("manifest baseline", True, "manifest has required high-level keys")
+
+
+def check_generated_reference_presence(root: Path) -> CheckResult:
+    absent: list[str] = []
+    unmarked: list[str] = []
+    for rel_path in GENERATED_CCI_REFERENCE_FILES:
+        path = root / rel_path
+        if not path.is_file():
+            absent.append(rel_path)
+            continue
+        text = read_text(path)
+        if "Auto-generated" not in text or "scripts/ai/generate_cci_reference.py" not in text:
+            unmarked.append(rel_path)
+    if absent or unmarked:
+        parts = []
+        if absent:
+            parts.append("absent: " + ", ".join(absent))
+        if unmarked:
+            parts.append("missing generator marker: " + ", ".join(unmarked))
+        return CheckResult("generated reference markers", False, "; ".join(parts))
+    return CheckResult("generated reference markers", True, "CCI reference files identify their generator")
+
+
+def check_readme_explains_check_modes(root: Path) -> CheckResult:
+    path = root / AI_README
+    if not path.is_file():
+        return CheckResult("README check modes", False, f"missing {AI_README}")
+    text = read_text(path).lower()
+    # Accept singular or plural ("check" / "checks") to avoid brittle matching.
+    patterns = {
+        "baseline static check": r"baseline static checks?",
+        "full generated-reference check": r"full generated-reference checks?",
+    }
+    missing = [label for label, pat in patterns.items() if not re.search(pat, text)]
+    if missing:
+        return CheckResult("README check modes", False, "missing phrases: " + ", ".join(missing))
+    return CheckResult("README check modes", True, "README documents baseline vs full check modes")
+
+
+def run_baseline_checks(root: Path) -> list[CheckResult]:
+    return [
+        check_required_files(root),
+        check_python_syntax(root),
+        check_baseline_imports(root),
+        check_optional_dependency_messages(root),
+        check_manifest_high_level_keys(root),
+        check_generated_reference_presence(root),
+        check_readme_explains_check_modes(root),
+    ]
+
+
+def run_full_generated_reference_check(root: Path) -> CheckResult:
+    if importlib.util.find_spec("yaml") is None:
+        return CheckResult("full generated-reference dry run", False, FULL_CHECK_ENV_HELP)
+    script = root / "scripts" / "ai" / "generate_cci_reference.py"
+    cmd = [sys.executable, str(script), "--dry-run"]
+    try:
+        proc = subprocess.run(
+            cmd, cwd=str(root), text=True, capture_output=True, check=False, timeout=300
+        )
+    except subprocess.TimeoutExpired:
+        return CheckResult("full generated-reference dry run", False, "generator timed out after 300s")
+    if proc.returncode != 0:
+        detail = (proc.stderr or proc.stdout or "generator returned non-zero exit").strip()
+        return CheckResult("full generated-reference dry run", False, detail)
+    return CheckResult("full generated-reference dry run", True, "generate_cci_reference.py --dry-run completed")
+
+
+def cmd_check(root: Path, full_generated_reference_checks: bool) -> int:
+    results = run_baseline_checks(root)
+    if full_generated_reference_checks:
+        results.append(run_full_generated_reference_check(root))
+    overall_ok = True
+    for result in results:
+        marker = "PASS" if result.ok else "FAIL"
+        print(f"[{marker}] {result.name}: {result.detail}")
+        overall_ok = overall_ok and result.ok
+    print(f"Status: {'PASS' if overall_ok else 'FAIL'} "
+          f"({sum(1 for r in results if not r.ok)} failing of {len(results)} checks)")
+    return 0 if overall_ok else 1
+
+
+# ===========================================================================
+# Subcommand: report  (rich Markdown report + JSON scorecard)
+# ===========================================================================
+
+
+@dataclass
+class FileCheck:
+    name: str
+    ok: bool
+    detail: str
+
+
+@dataclass
+class RuleMapping:
+    rule: str
+    status: str  # skill | standalone | missing
+    target: str
+
+
+@dataclass
+class Analysis:
+    root: Path
+    required_files: list[FileCheck] = field(default_factory=list)
+    skills: list[str] = field(default_factory=list)
+    rules: list[str] = field(default_factory=list)
+    agents_skill_references: list[str] = field(default_factory=list)
+    missing_agents_skill_references: list[str] = field(default_factory=list)
+    rule_mappings: list[RuleMapping] = field(default_factory=list)
+    cci_reference_files: list[FileCheck] = field(default_factory=list)
+    manifest_summary: dict[str, Any] = field(default_factory=dict)
+    warnings: list[str] = field(default_factory=list)
+
+    @property
+    def errors(self) -> list[str]:
+        out: list[str] = []
+        out.extend(c.detail for c in self.required_files if not c.ok)
+        out.extend(c.detail for c in self.cci_reference_files if not c.ok)
+        out.extend(
+            f"AGENTS.md references missing skill file or unmatched glob: {p}"
+            for p in self.missing_agents_skill_references
+        )
+        out.extend(
+            f"{m.rule} has no corresponding skill or stand-alone note"
+            for m in self.rule_mappings if m.status == "missing"
+        )
+        return out
+
+    @property
+    def passed(self) -> bool:
+        return not self.errors
+
+
+def extract_agents_skill_references(agents_text: str, root: Path) -> list[str]:
+    """Advertised ``.cursor/skills/*.md`` references from AGENTS.md prose.
+
+    Fenced code blocks are stripped first, and glob/template tokens are
+    ignored, so only concrete skill-file references are checked.
+    """
+    skill_dirs = first_level_skill_dirs(root)
+    prose = strip_fenced_code(agents_text)
+    refs: set[str] = set()
+    for match in BACKTICK_MD_RE.finditer(prose):
+        token = match.group(1).strip()
+        if not looks_like_concrete_path(token):
+            continue
+        if token.startswith(".cursor/skills/"):
+            refs.add(token)
+            continue
+        if token.startswith(("docs/", ".github/", ".claude/", "scripts/", "templates/")):
+            continue
+        first = token.split("/", 1)[0]
+        if "/" in token and first in skill_dirs:
+            refs.add(f".cursor/skills/{token}")
+    return sorted(refs)
+
+
+def normalize_equivalent_skill(cell: str) -> tuple[str, str]:
+    lowered = cell.lower()
+    if "stand-alone" in lowered or "standalone" in lowered:
+        return "standalone", cell.strip()
+    # Prefer a backtick token that names a Markdown skill file; fall back to the
+    # first backtick token only if no `.md` reference is present. This avoids
+    # mis-reading an incidental non-skill token earlier in the cell.
+    md_match = re.search(r"`([^`]+\.md)`", cell)
+    match = md_match or re.search(r"`([^`]+)`", cell)
+    if not match:
+        return "missing", cell.strip()
+    ref = match.group(1).strip()
+    if ref.startswith(".cursor/skills/"):
+        return "skill", ref
+    if ref.endswith(".md"):
+        return "skill", f".cursor/skills/{ref}"
+    return "missing", ref
+
+
+def split_table_row(line: str) -> list[str]:
+    return [c.strip() for c in line.strip().strip("|").split("|")]
+
+
+def is_separator_row(cells: list[str]) -> bool:
+    return all(set(c) <= set("-: ") and c for c in cells) if cells else False
+
+
+def extract_rule_mappings(agents_text: str, rules: Iterable[str]) -> list[RuleMapping]:
+    by_rule: dict[str, tuple[str, str]] = {}
+    for line in agents_text.splitlines():
+        if not line.lstrip().startswith("|") or ".mdc" not in line:
+            continue
+        cells = split_table_row(line)
+        if len(cells) < 3 or is_separator_row(cells):
+            continue
+        rule_match = re.search(r"`?([^`\s|]+\.mdc)`?", cells[0])
+        if not rule_match:
+            continue
+        rule = Path(rule_match.group(1)).name
+        kind, target = normalize_equivalent_skill(cells[-1])
+        by_rule[rule] = (kind, target)
+
+    results: list[RuleMapping] = []
+    for rule_path in rules:
+        name = Path(rule_path).name
+        if name not in by_rule:
+            results.append(RuleMapping(name, "missing", "No row in AGENTS.md File-Specific Rules table"))
+            continue
+        kind, target = by_rule[name]
+        results.append(RuleMapping(name, kind, target))
+    return sorted(results, key=lambda m: m.rule)
+
+
+def analyze(root: Path) -> Analysis:
+    analysis = Analysis(root=root)
+
+    for rel_path in REQUIRED_FILES:
+        exists = (root / rel_path).is_file()
+        analysis.required_files.append(
+            FileCheck(rel_path, exists, f"Found {rel_path}" if exists else f"Missing required file: {rel_path}")
+        )
+
+    analysis.skills = sorted_relative_files(root, SKILLS_ROOT, "**/*.md")
+    analysis.rules = sorted_relative_files(root, RULES_ROOT, "*.mdc")
+
+    agents_text = read_text(root / AGENTS_PATH)
+    analysis.agents_skill_references = extract_agents_skill_references(agents_text, root)
+    analysis.missing_agents_skill_references = [
+        r for r in analysis.agents_skill_references if not path_reference_exists(root, r)
+    ]
+    analysis.rule_mappings = extract_rule_mappings(agents_text, analysis.rules)
+
+    for rel_path in GENERATED_CCI_REFERENCE_FILES:
+        exists = (root / rel_path).is_file()
+        analysis.cci_reference_files.append(
+            FileCheck(rel_path, exists, f"Found {rel_path}" if exists else f"Missing generated CCI reference file: {rel_path}")
+        )
+
+    analysis.manifest_summary = summarize_manifest(root)
+    manifest_skill_paths = analysis.manifest_summary.get("skill_paths", []) or []
+    missing_paths = [p for p in manifest_skill_paths if not path_reference_exists(root, p)]
+    if missing_paths:
+        analysis.warnings.append("Manifest references missing skill paths: " + ", ".join(sorted(missing_paths)))
+
+    return analysis
+
+
+def _icon(ok: bool) -> str:
+    return "✅" if ok else "❌"
+
+
+def render_report_markdown(a: Analysis) -> str:
+    lines: list[str] = [
+        "# Agent Tooling Optimization Report",
+        "",
+        "> **Auto-generated** by `scripts/ai/analyze_agent_tooling.py report`.",
+        "> Do not edit manually — re-run the analyzer after changing agent docs,",
+        "> skills, rules, or the skill manifest.",
+        "",
+        "## Summary",
+        "",
+        f"- Overall status: **{'PASS' if a.passed else 'FAIL'}**",
+        f"- Required files: **{sum(1 for c in a.required_files if c.ok)}/{len(a.required_files)}** present",
+        f"- Skills inventoried: **{len(a.skills)}** Markdown files under `.cursor/skills/`",
+        f"- Cursor rules inventoried: **{len(a.rules)}** `.mdc` files under `.cursor/rules/`",
+        f"- AGENTS.md skill references: **{len(a.agents_skill_references)}** checked, "
+        f"**{len(a.missing_agents_skill_references)}** missing",
+        f"- Generated CCI references: **{sum(1 for c in a.cci_reference_files if c.ok)}/"
+        f"{len(a.cci_reference_files)}** present",
+        f"- Errors: **{len(a.errors)}**",
+        f"- Warnings: **{len(a.warnings)}**",
+        "",
+        "## Required Agent Entry Points",
+        "",
+    ]
+    for c in a.required_files:
+        lines.append(f"- {_icon(c.ok)} `{c.name}` — {c.detail}")
+
+    lines += ["", "## Skill Inventory", ""]
+    lines += [f"- `{s}`" for s in a.skills] or ["- (none found)"]
+
+    lines += ["", "## Cursor Rule Inventory", ""]
+    lines += [f"- `{r}`" for r in a.rules] or ["- (none found)"]
+
+    lines += ["", "## AGENTS.md Skill Reference Check", ""]
+    for ref in a.agents_skill_references:
+        ok = ref not in a.missing_agents_skill_references
+        lines.append(f"- {_icon(ok)} `{ref}`")
+    if not a.agents_skill_references:
+        lines.append("- (no concrete skill references found)")
+
+    lines += [
+        "", "## Cursor Rule Coverage", "",
+        "Each `.cursor/rules/*.mdc` is checked against the AGENTS.md File-Specific "
+        "Rules table for an equivalent skill or an explicit stand-alone note. See "
+        "`.agents/context/rule-skill-coverage.md` for the full coverage matrix and "
+        "recommendations.", "",
+    ]
+    for m in a.rule_mappings:
+        if m.status == "skill":
+            lines.append(f"- ✅ `{m.rule}` — mapped to `{m.target}`")
+        elif m.status == "standalone":
+            lines.append(f"- ✅ `{m.rule}` — explicit stand-alone note")
+        else:
+            lines.append(f"- ❌ `{m.rule}` — {m.target}")
+
+    lines += ["", "## Generated CCI Reference Files", ""]
+    for c in a.cci_reference_files:
+        lines.append(f"- {_icon(c.ok)} `{c.name}` — {c.detail}")
+
+    m = a.manifest_summary
+    lines += [
+        "", "## Skill Manifest Snapshot", "",
+        f"- Present: **{m.get('present', False)}**",
+        f"- Parser: `{m.get('parser', 'unknown')}`",
+        f"- Manifest version: `{m.get('manifest_version')}`",
+        f"- Last verified: `{m.get('last_verified')}`",
+        f"- Active Salesforce release: `{m.get('salesforce_release_active')}`",
+        f"- Manifest skill count: **{m.get('skill_count', 0)}**",
+    ]
+    for sid in m.get("skill_ids", []) or []:
+        lines.append(f"  - `{sid}`")
+
+    lines += ["", "## Findings", ""]
+    if a.errors:
+        lines += ["### Errors", ""]
+        lines += [f"- ❌ {e}" for e in a.errors]
+    else:
+        lines.append("- ✅ No blocking errors found.")
+    if a.warnings:
+        lines += ["", "### Warnings", ""]
+        lines += [f"- ⚠️ {w}" for w in a.warnings]
+
+    lines += [
+        "", "## Notes", "",
+        "- Generated by `scripts/ai/analyze_agent_tooling.py report`.",
+        "- The analyzer needs no third-party dependencies. With PyYAML installed, "
+        "manifest reporting is richer; otherwise a line-oriented fallback is used.",
+        "",
+    ]
+    return "\n".join(lines)
+
+
+def to_scorecard(a: Analysis) -> dict[str, Any]:
+    return {
+        "status": "pass" if a.passed else "fail",
+        "counts": {
+            "required_files_present": sum(1 for c in a.required_files if c.ok),
+            "required_files_total": len(a.required_files),
+            "skills_markdown_files": len(a.skills),
+            "cursor_rules": len(a.rules),
+            "agents_skill_references": len(a.agents_skill_references),
+            "missing_agents_skill_references": len(a.missing_agents_skill_references),
+            "generated_cci_reference_files_present": sum(1 for c in a.cci_reference_files if c.ok),
+            "generated_cci_reference_files_total": len(a.cci_reference_files),
+            "errors": len(a.errors),
+            "warnings": len(a.warnings),
+        },
+        "required_files": {c.name: c.ok for c in a.required_files},
+        "skills": a.skills,
+        "rules": a.rules,
+        "agents_skill_references": {
+            "checked": a.agents_skill_references,
+            "missing": a.missing_agents_skill_references,
+        },
+        "rule_mappings": [
+            {"rule": m.rule, "status": m.status, "target": m.target} for m in a.rule_mappings
+        ],
+        "generated_cci_reference_files": {c.name: c.ok for c in a.cci_reference_files},
+        "manifest": a.manifest_summary,
+        "errors": a.errors,
+        "warnings": a.warnings,
+    }
+
+
+def cmd_report(root: Path, do_check: bool, do_json: bool) -> int:
+    a = analyze(root)
+    report = root / REPORT_PATH
+    scorecard = root / SCORECARD_PATH
+    report.parent.mkdir(parents=True, exist_ok=True)
+    scorecard.parent.mkdir(parents=True, exist_ok=True)
+    report.write_text(render_report_markdown(a), encoding="utf-8")
+    scorecard.write_text(json.dumps(to_scorecard(a), indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+    if do_json:
+        print(json.dumps(to_scorecard(a), indent=2, sort_keys=True))
+    else:
+        print(f"Wrote {REPORT_PATH}")
+        print(f"Wrote {SCORECARD_PATH}")
+        print(f"Status: {'PASS' if a.passed else 'FAIL'} ({len(a.errors)} errors, {len(a.warnings)} warnings)")
+
+    if do_check and not a.passed:
+        return 1
+    return 0
+
+
+# ===========================================================================
+# Subcommand: coverage  (rule / skill coverage matrix)
+# ===========================================================================
+
+COVERAGE_HEADER = (
+    "> **Auto-generated** by `scripts/ai/analyze_agent_tooling.py coverage`.\n"
+    "> Do not edit manually — re-run the analyzer after changing `AGENTS.md`, "
+    "`.cursor/rules/`, or `.cursor/skills/README.md`."
+)
+
+
+@dataclass(frozen=True)
+class RuleInfo:
+    path: str
+    name: str
+    globs: tuple[str, ...]
+    equivalent_skill: str
+    has_do_not: bool
+    appears_in_agents: bool
+    listed_in_skill_readme: bool
+    owner: str
+
+
+@dataclass(frozen=True)
+class RecommendedSkillRule:
+    skill_path: str
+    suggested_rule: str
+    suggested_globs: tuple[str, ...]
+    owner: str
+    reason: str
+
+
+@dataclass(frozen=True)
+class HighRiskPath:
+    path: str
+    owner: str
+    source: str
+    expected_rule: str
+    explicit_analyzer_check: str
+    reason: str
+
+
+RECOMMENDED_SKILL_RULES: tuple[RecommendedSkillRule, ...] = (
+    RecommendedSkillRule("schema-validation/SKILL.md", "schema-validation.mdc",
+        ("docs/erds/**", "scripts/erd/**/*.py"), "Schema Validation",
+        "ERD/schema files are safety-critical and the skill has no file-triggered rule today."),
+    RecommendedSkillRule("release-enablement/SKILL.md", "release-enablement.mdc",
+        ("docs/enablement/**", "docs/salesforce/**"), "Release Enablement",
+        "Enablement docs have release-specific source/extract conventions that are easy to miss."),
+    RecommendedSkillRule("rlm-business-apis/SKILL.md", "rlm-business-apis.mdc",
+        ("postman/**", "scripts/soql/**"), "Business APIs",
+        "API collections and SOQL files benefit from endpoint/auth/query guardrails at edit time."),
+    RecommendedSkillRule("pmos-integration/SKILL.md", "pmos-integration.mdc",
+        (".claude/skill-manifest.yml",), "PMOS Integration",
+        "The cross-repo skill manifest is a single integration point with no auto-injected rule."),
+    RecommendedSkillRule("revenue-cloud-docs/SKILL.md", "revenue-cloud-docs.mdc",
+        ("docs/salesforce/**", "docs/enablement/**"), "Revenue Cloud Docs",
+        "Grounding product claims against Salesforce Help is high-risk but not file-triggered."),
+    RecommendedSkillRule("repo-integration/ux-assembly-retrieve.md", "post-ux-generated-output.mdc",
+        ("unpackaged/post_ux/**",), "UX Assembly",
+        "`unpackaged/post_ux/` is generated output and should warn on any direct edit."),
+)
+
+HIGH_RISK_PATHS: tuple[HighRiskPath, ...] = (
+    HighRiskPath("unpackaged/post_ux/**", "UX Assembly", "AGENTS.md DO NOT #1 and Repository Layout",
+        "post-ux-generated-output.mdc", "", "Generated UX output must not be edited directly."),
+    HighRiskPath("force-app/**/profiles/*.profile-meta.xml", "UX Assembly / Profiles", "AGENTS.md DO NOT #2",
+        "force-app-profile-safety.mdc", "", "Force-app profiles should stay classAccesses-only; layout/application visibility belongs in templates."),
+    HighRiskPath("force-app/**/*.object-meta.xml", "UX Assembly / Objects", "AGENTS.md DO NOT #3",
+        "force-app-object-safety.mdc", "", "Object actionOverrides/compact layout assignment belong in templates, not force-app objects."),
+    HighRiskPath("datasets/sfdmu/**/export.json", "SFDMU Data Plans", "AGENTS.md SFDMU v5 critical rules",
+        "sfdmu-export-json.mdc", "scripts/validate_sfdmu_v5_datasets.py", "SFDMU v5 operation/externalId/deleteOldData choices can be destructive."),
+    HighRiskPath("datasets/sfdmu/**/*.csv", "SFDMU Data Plans", "AGENTS.md SFDMU v5 critical rules",
+        "sfdmu-csv-data.mdc", "scripts/validate_sfdmu_v5_datasets.py", "CSV header/composite key drift can break idempotency or data loads."),
+    HighRiskPath("tasks/**/*.py", "CCI Orchestration", "AGENTS.md Org Identity: CCI vs SF CLI",
+        "cci-python-tasks.mdc", "", "Python CCI tasks must not pass access tokens to sf CLI commands."),
+    HighRiskPath("templates/flexipages/**", "UX Assembly", "AGENTS.md DO NOT #6",
+        "ux-templates.mdc", "", "EmailTemplatePage flexipages cannot deploy via Metadata API."),
+    HighRiskPath("**/rlm.network-meta.xml", "PRM Network", "AGENTS.md DO NOT #7",
+        "network-email-safety.mdc", "", "Network metadata must keep placeholder emails; deploy tasks patch/revert real values."),
+)
+
+OWNER_KEYWORDS: tuple[tuple[str, str], ...] = (
+    ("sfdmu", "SFDMU Data Plans"), ("cci", "CCI Orchestration"), ("apex", "Apex"),
+    ("lwc", "Lightning Web Components"), ("ux", "UX Assembly"), ("robot", "Robot Testing"),
+    ("doc", "Doc Consistency"), ("schema", "Schema Validation"), ("release", "Release Enablement"),
+    ("business", "Business APIs"), ("pmos", "PMOS Integration"),
+)
+
+
+def extract_frontmatter(text: str) -> str:
+    if not text.lstrip("﻿").startswith("---"):
+        return ""
+    # Tolerate CRLF line endings and an optional trailing newline after the
+    # closing fence so a rule file's globs are not silently dropped.
+    text = text.replace("\r\n", "\n").replace("\r", "\n")
+    match = re.match(r"^---\n(.*?)\n---\s*(?:\n|$)", text, flags=re.DOTALL)
+    return match.group(1) if match else ""
+
+
+def _split_flow_list(inline: str) -> list[str]:
+    """Split a YAML inline flow-list body on commas at brace/quote depth 0.
+
+    Keeps brace expansions (``*.{html,js}``) and quoted items intact instead of
+    splitting on every comma.
+    """
+    parts: list[str] = []
+    buf: list[str] = []
+    depth = 0
+    quote = ""
+    for ch in inline:
+        if quote:
+            buf.append(ch)
+            if ch == quote:
+                quote = ""
+            continue
+        if ch in "'\"":
+            quote = ch
+            buf.append(ch)
+        elif ch in "{[(":
+            depth += 1
+            buf.append(ch)
+        elif ch in "}])":
+            depth = max(0, depth - 1)
+            buf.append(ch)
+        elif ch == "," and depth == 0:
+            parts.append("".join(buf))
+            buf = []
+        else:
+            buf.append(ch)
+    if buf:
+        parts.append("".join(buf))
+    return [p.strip().strip("'\"") for p in parts if p.strip()]
+
+
+def parse_globs(frontmatter: str) -> tuple[str, ...]:
+    lines = frontmatter.splitlines()
+    for index, line in enumerate(lines):
+        stripped = line.strip()
+        if not stripped.startswith("globs:"):
+            continue
+        inline = stripped.split(":", 1)[1].strip()
+        if inline:
+            # Strip surrounding flow-list brackets: globs: [a/**, b/**]
+            if inline.startswith("[") and inline.endswith("]"):
+                inline = inline[1:-1]
+            return tuple(_split_flow_list(inline))
+        globs: list[str] = []
+        for child in lines[index + 1:]:
+            if not child.startswith((" ", "\t")):
+                break
+            child_stripped = child.strip()
+            if child_stripped.startswith("-"):
+                globs.append(child_stripped[1:].strip().strip("'\""))
+        return tuple(globs)
+    return ()
+
+
+def has_do_not_section(text: str) -> bool:
+    return bool(re.search(r"^##+\s+DO NOT\b", text, flags=re.MULTILINE | re.IGNORECASE))
+
+
+def parse_rule_table(markdown: str) -> dict[str, dict[str, str]]:
+    """Parse Markdown rule tables (columns: Rule, Triggers On, Equivalent Skill)."""
+    rows: dict[str, dict[str, str]] = {}
+    for line in markdown.splitlines():
+        if not line.lstrip().startswith("|"):
+            continue
+        cells = split_table_row(line)
+        if len(cells) < 3 or is_separator_row(cells):
+            continue
+        if cells[0].lower() in {"rule", "rule file", "i need to..."}:
+            continue
+        rule_match = re.search(r"`?([^`\s|]+\.mdc)`?", cells[0])
+        if not rule_match:
+            continue
+        name = Path(rule_match.group(1)).name
+        skill_match = re.search(r"`?([^`\s|]+\.md)`?", cells[2])
+        rows[name] = {
+            "triggers": cells[1],
+            "skill": skill_match.group(1) if skill_match else cells[2],
+        }
+    return rows
+
+
+def infer_owner(rule_name: str, skill_path: str) -> str:
+    haystack = f"{rule_name} {skill_path}".lower()
+    for keyword, owner in OWNER_KEYWORDS:
+        if keyword in haystack:
+            return owner
+    return "Repository Integration"
+
+
+def glob_covers(rules: list[RuleInfo], candidate: str) -> bool:
+    """True if any rule glob matches the candidate high-risk path.
+
+    This is an intentional approximation: ``fnmatch`` has no path-segment
+    awareness (``*`` spans ``/``), so coverage matching errs toward broad. It is
+    a planning aid for the coverage report, not an access-control decision.
+    """
+    normalized = candidate.rstrip("/")
+    samples = {
+        normalized,
+        normalized.replace("**", "x").replace("*", "x"),
+        normalized.replace("**/", ""),
+    }
+    for rule in rules:
+        for pattern in rule.globs:
+            if pattern == candidate:
+                return True
+            for sample in samples:
+                # fnmatch(name, pattern): the candidate is the name to match.
+                if fnmatch.fnmatch(sample, pattern):
+                    return True
+    return False
+
+
+def collect_rules(root: Path) -> list[RuleInfo]:
+    agents_rules = parse_rule_table(read_text(root / AGENTS_PATH))
+    readme_rules = parse_rule_table(read_text(root / SKILLS_README))
+    rules_dir = root / RULES_ROOT
+
+    rules: list[RuleInfo] = []
+    for rule_path in sorted(rules_dir.glob("*.mdc")):
+        text = read_text(rule_path)
+        name = rule_path.name
+        skill = readme_rules.get(name, {}).get("skill") or agents_rules.get(name, {}).get("skill") or ""
+        rules.append(RuleInfo(
+            path=rel(rule_path, root),
+            name=name,
+            globs=parse_globs(extract_frontmatter(text)),
+            equivalent_skill=skill,
+            has_do_not=has_do_not_section(text),
+            appears_in_agents=name in agents_rules,
+            listed_in_skill_readme=name in readme_rules,
+            owner=infer_owner(name, skill),
+        ))
+    return rules
+
+
+def _md_escape(value: str) -> str:
+    return value.replace("|", "\\|").replace("\n", "<br>")
+
+
+def _yes_no(value: bool) -> str:
+    return "Yes" if value else "No"
+
+
+def _format_globs(globs: tuple[str, ...]) -> str:
+    return "<br>".join(f"`{g}`" for g in globs) if globs else "—"
+
+
+def render_coverage_markdown(root: Path) -> str:
+    rules = collect_rules(root)
+    rule_names = {r.name for r in rules}
+    rules_not_in_readme = [r for r in rules if not r.listed_in_skill_readme]
+    recommended_gaps = [g for g in RECOMMENDED_SKILL_RULES if g.suggested_rule not in rule_names]
+    high_risk_gaps = [
+        risk for risk in HIGH_RISK_PATHS
+        if not glob_covers(rules, risk.path) and not risk.explicit_analyzer_check
+    ]
+
+    lines: list[str] = [
+        "# Rule / Skill Coverage Matrix", "", COVERAGE_HEADER, "",
+        "## Summary", "",
+        f"- Cursor rule files found: **{len(rules)}**",
+        f"- Rules not listed in `.cursor/skills/README.md`: **{len(rules_not_in_readme)}**",
+        f"- Recommended skill rules still missing: **{len(recommended_gaps)}**",
+        f"- High-risk AGENTS.md paths lacking both a rule and analyzer check: **{len(high_risk_gaps)}**",
+        "",
+        "## Rule Matrix", "",
+        "| Rule file path | Glob pattern | Equivalent skill path | Has DO NOT section "
+        "| Appears in AGENTS.md | Listed in skill README | Recommended owner/domain |",
+        "|---|---|---|---|---|---|---|",
+    ]
+    for r in rules:
+        lines.append("| " + " | ".join([
+            f"`{r.path}`", _format_globs(r.globs),
+            f"`{r.equivalent_skill}`" if r.equivalent_skill else "—",
+            _yes_no(r.has_do_not), _yes_no(r.appears_in_agents),
+            _yes_no(r.listed_in_skill_readme), _md_escape(r.owner),
+        ]) + " |")
+
+    lines += ["", "## Flags", "", "### 1. Rules not listed in the skill README", ""]
+    if rules_not_in_readme:
+        for r in rules_not_in_readme:
+            lines.append(f"- `{r.path}` — owner/domain: **{r.owner}**; add it to "
+                         "`.cursor/skills/README.md` or document why it is intentionally omitted.")
+    else:
+        lines.append("- None.")
+
+    lines += [
+        "", "### 2. Skills with no corresponding rule where file-specific "
+        "auto-injection would reduce risk", "",
+        "| Skill path | Suggested rule | Suggested glob(s) | Owner/domain | Reason |",
+        "|---|---|---|---|---|",
+    ]
+    if recommended_gaps:
+        for g in recommended_gaps:
+            lines.append("| " + " | ".join([
+                f"`{g.skill_path}`", f"`{g.suggested_rule}`", _format_globs(g.suggested_globs),
+                _md_escape(g.owner), _md_escape(g.reason),
+            ]) + " |")
+    else:
+        lines.append("| — | — | — | — | None. |")
+
+    lines += [
+        "", "### 3. High-risk paths from AGENTS.md that lack a rule or explicit analyzer check", "",
+        "| Path | Owner/domain | AGENTS.md source | Expected rule | Explicit analyzer check | Reason |",
+        "|---|---|---|---|---|---|",
+    ]
+    if high_risk_gaps:
+        for risk in high_risk_gaps:
+            lines.append("| " + " | ".join([
+                f"`{risk.path}`", _md_escape(risk.owner), _md_escape(risk.source),
+                f"`{risk.expected_rule}`",
+                f"`{risk.explicit_analyzer_check}`" if risk.explicit_analyzer_check else "—",
+                _md_escape(risk.reason),
+            ]) + " |")
+    else:
+        lines.append("| — | — | — | — | — | None. |")
+
+    lines += [
+        "", "## Notes", "",
+        "- `Appears in AGENTS.md` is true when the rule filename is present in the root "
+        "`AGENTS.md` file-specific rule table.",
+        "- `Listed in skill README` is true when the rule filename is present in "
+        "`.cursor/skills/README.md`.",
+        "- High-risk path coverage is satisfied by either a matching `.cursor/rules/*.mdc` "
+        "glob or an explicit analyzer/validator script listed in this report.",
+        "",
+    ]
+    return "\n".join(lines)
+
+
+def cmd_coverage(root: Path, dry_run: bool, output: Path | None) -> int:
+    report = render_coverage_markdown(root)
+    if dry_run:
+        print(report, end="" if report.endswith("\n") else "\n")
+        return 0
+    out_path = Path(os.path.abspath(output)) if output is not None else (root / COVERAGE_PATH)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(report, encoding="utf-8")
+    print(f"Wrote {rel(out_path, root)}")
+    return 0
+
+
+# ===========================================================================
+# CLI
+# ===========================================================================
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Analyze the repository's AI-agent tooling surface. "
+                    "Defaults to the stdlib-only 'check' gate when no subcommand is given.",
+    )
+    parser.add_argument("--repo-root", type=Path, default=None,
+                        help="Repository root (default: auto-detect from this script).")
+    sub = parser.add_subparsers(dest="command")
+
+    p_check = sub.add_parser("check", help="stdlib-only pass/fail gate (default)")
+    p_check.add_argument("--full-generated-reference-checks", action="store_true",
+                         help="also dry-run generate_cci_reference.py (requires PyYAML/CumulusCI)")
+
+    p_report = sub.add_parser("report", help="write Markdown report + JSON scorecard")
+    p_report.add_argument("--check", action="store_true", dest="report_check",
+                          help="exit non-zero if blocking errors are found")
+    p_report.add_argument("--json", action="store_true", dest="report_json",
+                          help="print the scorecard JSON to stdout")
+
+    p_cov = sub.add_parser("coverage", help="write the rule/skill coverage matrix")
+    p_cov.add_argument("--dry-run", action="store_true", help="print the matrix instead of writing it")
+    p_cov.add_argument("--output", type=Path, default=None, help="override the output path")
+
+    sub.add_parser("all", help="run check, then report, then coverage")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv if argv is not None else sys.argv[1:])
+    root = (args.repo_root or find_repo_root()).resolve()
+    command = args.command or "check"
+
+    if command == "check":
+        return cmd_check(root, getattr(args, "full_generated_reference_checks", False))
+    if command == "report":
+        return cmd_report(root, getattr(args, "report_check", False), getattr(args, "report_json", False))
+    if command == "coverage":
+        return cmd_coverage(root, getattr(args, "dry_run", False), getattr(args, "output", None))
+    if command == "all":
+        gate = cmd_check(root, False)
+        print()
+        cmd_report(root, False, False)
+        print()
+        cmd_coverage(root, False, None)
+        return gate
+    parser.error(f"unknown command: {command}")
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ai/analyze_agent_tooling.py
+++ b/scripts/ai/analyze_agent_tooling.py
@@ -643,9 +643,32 @@ def is_separator_row(cells: list[str]) -> bool:
     return all(set(c) <= set("-: ") and c for c in cells) if cells else False
 
 
+def file_specific_rules_region(markdown: str) -> str:
+    """Return the markdown under a 'File-Specific Rules' heading up to the next
+    heading, so rule-table parsing is anchored to that section and is not
+    polluted by any other pipe table that happens to mention a `.mdc` token.
+
+    Falls back to the whole document if the heading is not found.
+    """
+    lines = markdown.splitlines()
+    start = None
+    for i, line in enumerate(lines):
+        if re.match(r"^#{1,6}\s+File-Specific Rules", line):
+            start = i + 1
+            break
+    if start is None:
+        return markdown
+    end = len(lines)
+    for j in range(start, len(lines)):
+        if re.match(r"^#{1,6}\s", lines[j]):
+            end = j
+            break
+    return "\n".join(lines[start:end])
+
+
 def extract_rule_mappings(agents_text: str, rules: Iterable[str]) -> list[RuleMapping]:
     by_rule: dict[str, tuple[str, str]] = {}
-    for line in agents_text.splitlines():
+    for line in file_specific_rules_region(agents_text).splitlines():
         if not line.lstrip().startswith("|") or ".mdc" not in line:
             continue
         cells = split_table_row(line)
@@ -868,6 +891,7 @@ class RuleInfo:
     name: str
     globs: tuple[str, ...]
     equivalent_skill: str
+    standalone: bool
     has_do_not: bool
     appears_in_agents: bool
     listed_in_skill_readme: bool
@@ -1013,10 +1037,16 @@ def has_do_not_section(text: str) -> bool:
     return bool(re.search(r"^##+\s+DO NOT\b", text, flags=re.MULTILINE | re.IGNORECASE))
 
 
-def parse_rule_table(markdown: str) -> dict[str, dict[str, str]]:
-    """Parse Markdown rule tables (columns: Rule, Triggers On, Equivalent Skill)."""
-    rows: dict[str, dict[str, str]] = {}
-    for line in markdown.splitlines():
+def parse_rule_table(markdown: str) -> dict[str, dict[str, Any]]:
+    """Parse Markdown rule tables (columns: Rule, Triggers On, Equivalent Skill).
+
+    The Equivalent Skill cell is classified with ``normalize_equivalent_skill``
+    (shared with the report subcommand), so a stand-alone note that merely
+    *mentions* a skill (e.g. "complements `repo-integration/SKILL.md`") is
+    recorded as stand-alone rather than as that skill.
+    """
+    rows: dict[str, dict[str, Any]] = {}
+    for line in file_specific_rules_region(markdown).splitlines():
         if not line.lstrip().startswith("|"):
             continue
         cells = split_table_row(line)
@@ -1028,10 +1058,19 @@ def parse_rule_table(markdown: str) -> dict[str, dict[str, str]]:
         if not rule_match:
             continue
         name = Path(rule_match.group(1)).name
-        skill_match = re.search(r"`?([^`\s|]+\.md)`?", cells[2])
+        # The Equivalent Skill cell is the LAST column; use cells[-1] (matching
+        # extract_rule_mappings) so a stray pipe in the Triggers cell can't make
+        # the two subcommands read different cells and disagree.
+        kind, _target = normalize_equivalent_skill(cells[-1])
+        skill = ""
+        if kind == "skill":
+            # Preserve the cell's own (relative) skill path for display.
+            skill_match = re.search(r"`?([^`\s|]+\.md)`?", cells[-1])
+            skill = skill_match.group(1) if skill_match else ""
         rows[name] = {
             "triggers": cells[1],
-            "skill": skill_match.group(1) if skill_match else cells[2],
+            "skill": skill,
+            "standalone": kind == "standalone",
         }
     return rows
 
@@ -1078,12 +1117,16 @@ def collect_rules(root: Path) -> list[RuleInfo]:
     for rule_path in sorted(rules_dir.glob("*.mdc")):
         text = read_text(rule_path)
         name = rule_path.name
-        skill = readme_rules.get(name, {}).get("skill") or agents_rules.get(name, {}).get("skill") or ""
+        readme_row = readme_rules.get(name, {})
+        agents_row = agents_rules.get(name, {})
+        skill = readme_row.get("skill") or agents_row.get("skill") or ""
+        standalone = bool(readme_row.get("standalone") or agents_row.get("standalone"))
         rules.append(RuleInfo(
             path=rel(rule_path, root),
             name=name,
             globs=parse_globs(extract_frontmatter(text)),
             equivalent_skill=skill,
+            standalone=standalone,
             has_do_not=has_do_not_section(text),
             appears_in_agents=name in agents_rules,
             listed_in_skill_readme=name in readme_rules,
@@ -1128,9 +1171,14 @@ def render_coverage_markdown(root: Path) -> str:
         "|---|---|---|---|---|---|---|",
     ]
     for r in rules:
+        if r.standalone:
+            equiv = "(stand-alone)"
+        elif r.equivalent_skill:
+            equiv = f"`{r.equivalent_skill}`"
+        else:
+            equiv = "—"
         lines.append("| " + " | ".join([
-            f"`{r.path}`", _format_globs(r.globs),
-            f"`{r.equivalent_skill}`" if r.equivalent_skill else "—",
+            f"`{r.path}`", _format_globs(r.globs), equiv,
             _yes_no(r.has_do_not), _yes_no(r.appears_in_agents),
             _yes_no(r.listed_in_skill_readme), _md_escape(r.owner),
         ]) + " |")

--- a/scripts/ai/analyze_agent_tooling.py
+++ b/scripts/ai/analyze_agent_tooling.py
@@ -267,6 +267,14 @@ def parse_manifest_fallback(text: str) -> dict[str, Any]:
     if foundations_match:
         foundations_text = foundations_match.group("body")
 
+    # Scope skill extraction to the foundations ``skills:`` block (indent 2),
+    # ending at the next sibling key, so ``- id:`` lines under cci_tasks,
+    # sfdmu_shapes, grounding, etc. are not miscounted as skills.
+    skills_text = ""
+    skills_match = re.search(r"(?ms)^  skills:\n(?P<body>.*?)(?=^  \S|\Z)", foundations_text)
+    if skills_match:
+        skills_text = skills_match.group("body")
+
     for line in text.splitlines():
         # Top-level scalars only (no leading whitespace).
         if line[:1].isspace():
@@ -276,7 +284,7 @@ def parse_manifest_fallback(text: str) -> dict[str, Any]:
             if line.startswith(prefix):
                 summary[key] = line[len(prefix):].strip().strip('"').strip("'")
 
-    for line in foundations_text.splitlines():
+    for line in skills_text.splitlines():
         stripped = line.strip()
         if stripped.startswith("- id:"):
             summary["skills"].append(stripped.split(":", 1)[1].strip())
@@ -287,12 +295,24 @@ def parse_manifest_fallback(text: str) -> dict[str, Any]:
     return summary
 
 
+def _version_str(value: Any) -> Any:
+    """Render a version-like scalar as a string so PyYAML (int 2) and the
+    line fallback (str '2') produce identical, environment-independent output."""
+    return None if value is None else str(value)
+
+
 def summarize_manifest(root: Path) -> dict[str, Any]:
+    """Summarize the skill manifest.
+
+    The output is environment-independent: the PyYAML and line-fallback paths
+    produce the same data, and no ``parser`` label is recorded, so a committed
+    artifact does not drift just because PyYAML is (or is not) installed.
+    """
     manifest = root / MANIFEST_PATH
     if not manifest.is_file():
-        return {"present": False, "parser": "not run"}
+        return {"present": False}
 
-    data, parser = load_yaml_optional(manifest)
+    data, _parser = load_yaml_optional(manifest)
     if data is not None:
         foundations = data.get("foundations") or {}
         if not isinstance(foundations, dict):
@@ -308,11 +328,10 @@ def summarize_manifest(root: Path) -> dict[str, Any]:
                 generated_subfiles.extend(s.get("auto_generated_subfiles") or [])
         return {
             "present": True,
-            "parser": parser,
-            "manifest_version": _scalar(data.get("manifest_version")),
+            "manifest_version": _version_str(data.get("manifest_version")),
             "generated_at": _scalar(data.get("generated_at")),
             "last_verified": _scalar(data.get("last_verified")),
-            "salesforce_release_active": _scalar(data.get("salesforce_release_active")),
+            "salesforce_release_active": _version_str(data.get("salesforce_release_active")),
             "skill_count": len(skill_ids),
             "skill_ids": sorted(str(s) for s in skill_ids),
             "skill_paths": sorted(str(p) for p in skill_paths),
@@ -322,11 +341,10 @@ def summarize_manifest(root: Path) -> dict[str, Any]:
     fb = parse_manifest_fallback(read_text(manifest))
     return {
         "present": True,
-        "parser": parser,
-        "manifest_version": fb.get("manifest_version"),
+        "manifest_version": _version_str(fb.get("manifest_version")),
         "generated_at": fb.get("generated_at"),
         "last_verified": fb.get("last_verified"),
-        "salesforce_release_active": fb.get("salesforce_release_active"),
+        "salesforce_release_active": _version_str(fb.get("salesforce_release_active")),
         "skill_count": len(fb.get("skills", [])),
         "skill_ids": sorted(fb.get("skills", [])),
         "skill_paths": sorted(fb.get("skill_paths", [])),
@@ -744,7 +762,6 @@ def render_report_markdown(a: Analysis) -> str:
     lines += [
         "", "## Skill Manifest Snapshot", "",
         f"- Present: **{m.get('present', False)}**",
-        f"- Parser: `{m.get('parser', 'unknown')}`",
         f"- Manifest version: `{m.get('manifest_version')}`",
         f"- Last verified: `{m.get('last_verified')}`",
         f"- Active Salesforce release: `{m.get('salesforce_release_active')}`",

--- a/scripts/ai/generate_cci_reference.py
+++ b/scripts/ai/generate_cci_reference.py
@@ -25,14 +25,15 @@ import sys
 from collections import defaultdict
 from pathlib import Path
 
-# PyYAML is optional at import time. find_spec can report a module that still
-# fails to import (broken/partial install), so guard the actual import.
+# PyYAML is optional at import time. Any import-time failure — module missing,
+# a broken/partial install, a SyntaxError or runtime error in the module, or a
+# find_spec error — leaves yaml as None so load_cci() emits clean guidance.
 yaml = None
-if importlib.util.find_spec("yaml") is not None:
-    try:
+try:
+    if importlib.util.find_spec("yaml") is not None:
         yaml = importlib.import_module("yaml")
-    except ImportError:
-        yaml = None
+except Exception:
+    yaml = None
 
 ROOT = Path(__file__).resolve().parent.parent.parent
 CCI_YML = ROOT / "cumulusci.yml"
@@ -62,8 +63,13 @@ def _pyyaml_error() -> str:
 def load_cci() -> dict:
     if yaml is None:
         raise SystemExit(_pyyaml_error())
-    with open(CCI_YML, "r", encoding="utf-8") as f:
-        return yaml.safe_load(f)
+    try:
+        with open(CCI_YML, "r", encoding="utf-8") as f:
+            return yaml.safe_load(f) or {}
+    except (OSError, UnicodeDecodeError) as exc:
+        raise SystemExit(f"ERROR: cannot read {CCI_YML}: {exc}")
+    except yaml.YAMLError as exc:
+        raise SystemExit(f"ERROR: cannot parse {CCI_YML}: {exc}")
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/ai/generate_cci_reference.py
+++ b/scripts/ai/generate_cci_reference.py
@@ -18,12 +18,21 @@ Usage:
 No external dependencies beyond PyYAML.
 """
 import argparse
+import importlib
+import importlib.util
 import re
 import sys
 from collections import defaultdict
 from pathlib import Path
 
-import yaml
+# PyYAML is optional at import time. find_spec can report a module that still
+# fails to import (broken/partial install), so guard the actual import.
+yaml = None
+if importlib.util.find_spec("yaml") is not None:
+    try:
+        yaml = importlib.import_module("yaml")
+    except ImportError:
+        yaml = None
 
 ROOT = Path(__file__).resolve().parent.parent.parent
 CCI_YML = ROOT / "cumulusci.yml"
@@ -40,7 +49,19 @@ HEADER_NOTE = (
 # YAML loading
 # ---------------------------------------------------------------------------
 
+def _pyyaml_error() -> str:
+    return (
+        "generate_cci_reference.py requires PyYAML for full cumulusci.yml parsing.\n"
+        "Activate the project CumulusCI environment, or install PyYAML with one of:\n"
+        "  - pipx inject cumulusci PyYAML\n"
+        "  - python -m pip install PyYAML\n"
+        "  - python -m pip install cumulusci\n"
+    )
+
+
 def load_cci() -> dict:
+    if yaml is None:
+        raise SystemExit(_pyyaml_error())
     with open(CCI_YML, "r") as f:
         return yaml.safe_load(f)
 
@@ -50,7 +71,8 @@ def load_cci() -> dict:
 # ---------------------------------------------------------------------------
 
 def generate_tasks_reference(data: dict) -> str:
-    tasks: dict = data.get("tasks", {})
+    # `or {}` guards an empty top-level `tasks:` (YAML null) against AttributeError.
+    tasks: dict = data.get("tasks") or {}
     by_group: dict[str, list] = defaultdict(list)
 
     for name, cfg in sorted(tasks.items()):
@@ -149,7 +171,7 @@ def _format_step(step_num, step_cfg, indent=0) -> list[str]:
 
 
 def generate_flows_reference(data: dict) -> str:
-    flows: dict = data.get("flows", {})
+    flows: dict = data.get("flows") or {}
     by_group: dict[str, list] = defaultdict(list)
 
     for name, cfg in flows.items():
@@ -208,8 +230,8 @@ def generate_flows_reference(data: dict) -> str:
 def _scan_when_clauses(data: dict) -> dict[str, list[str]]:
     """Scan all when: clauses in flows and build a flag → [usage context] map."""
     usage: dict[str, list[str]] = defaultdict(list)
-    flows = data.get("flows", {})
-    custom_keys = set(data.get("project", {}).get("custom", {}).keys())
+    flows = data.get("flows") or {}
+    custom_keys = set((data.get("project") or {}).get("custom", {}).keys())
 
     for flow_name, flow_cfg in flows.items():
         if not flow_cfg or "steps" not in flow_cfg:
@@ -238,7 +260,7 @@ def _scan_when_clauses(data: dict) -> dict[str, list[str]]:
 
 
 def generate_feature_flags(data: dict) -> str:
-    custom: dict = data.get("project", {}).get("custom", {})
+    custom: dict = (data.get("project") or {}).get("custom") or {}
     usage_map = _scan_when_clauses(data)
 
     boolean_flags = []
@@ -375,8 +397,8 @@ def main():
         print(f"ERROR: {CCI_YML} not found", file=sys.stderr)
         sys.exit(1)
 
-    print(f"Parsing {CCI_YML.relative_to(ROOT)} ...")
     data = load_cci()
+    print(f"Parsed {CCI_YML.relative_to(ROOT)}.")
 
     generate_all = not (args.tasks_only or args.flows_only or args.flags_only)
 

--- a/scripts/ai/generate_cci_reference.py
+++ b/scripts/ai/generate_cci_reference.py
@@ -52,7 +52,8 @@ HEADER_NOTE = (
 
 def _pyyaml_error() -> str:
     return (
-        "generate_cci_reference.py requires PyYAML for full cumulusci.yml parsing.\n"
+        "generate_cci_reference.py needs PyYAML for full cumulusci.yml parsing, "
+        "but it is not available (not installed, or failed to import).\n"
         "Activate the project CumulusCI environment, or install PyYAML with one of:\n"
         "  - pipx inject cumulusci PyYAML\n"
         "  - python -m pip install PyYAML\n"

--- a/scripts/ai/generate_cci_reference.py
+++ b/scripts/ai/generate_cci_reference.py
@@ -62,7 +62,7 @@ def _pyyaml_error() -> str:
 def load_cci() -> dict:
     if yaml is None:
         raise SystemExit(_pyyaml_error())
-    with open(CCI_YML, "r") as f:
+    with open(CCI_YML, "r", encoding="utf-8") as f:
         return yaml.safe_load(f)
 
 

--- a/scripts/ai/skill_manifest.py
+++ b/scripts/ai/skill_manifest.py
@@ -43,14 +43,15 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Iterable
 
-# PyYAML is optional at import time. find_spec can report a module that still
-# fails to import (broken/partial install), so guard the actual import.
+# PyYAML is optional at import time. Any import-time failure — module missing,
+# a broken/partial install, a SyntaxError or runtime error in the module, or a
+# find_spec error — degrades to the stdlib-only minimal fallback.
 yaml = None
-if importlib.util.find_spec("yaml") is not None:
-    try:
+try:
+    if importlib.util.find_spec("yaml") is not None:
         yaml = importlib.import_module("yaml")
-    except ImportError:
-        yaml = None
+except Exception:
+    yaml = None
 
 
 MANIFEST_FILENAME = ".claude/skill-manifest.yml"
@@ -377,7 +378,10 @@ def load_manifest(path: Path | None = None) -> dict[str, Any]:
         print(PY_YAML_HELP, file=sys.stderr)
         data = _load_manifest_minimal(manifest_text)
     else:
-        data: dict[str, Any] = yaml.safe_load(manifest_text) or {}
+        try:
+            data: dict[str, Any] = yaml.safe_load(manifest_text) or {}
+        except yaml.YAMLError as exc:
+            raise SystemExit(f"skill_manifest.py: cannot parse {manifest_path}: {exc}")
         if not isinstance(data, dict):
             data = {}
 

--- a/scripts/ai/skill_manifest.py
+++ b/scripts/ai/skill_manifest.py
@@ -102,160 +102,131 @@ def _parse_scalar(value: str) -> Any:
     if value == "[]":
         return []
     if value.startswith("[") and value.endswith("]"):
+        # Inline flow list. Drop empty segments so a trailing comma ("[a, b,]")
+        # matches yaml.safe_load rather than injecting a None.
         inner = value[1:-1].strip()
         if not inner:
             return []
-        return [_parse_scalar(part.strip()) for part in inner.split(",")]
+        return [_parse_scalar(part.strip()) for part in inner.split(",") if part.strip()]
     if (value.startswith('"') and value.endswith('"')) or (
         value.startswith("'") and value.endswith("'")
     ):
         return value[1:-1]
-    # Only coerce plain base-10 integers. Leave zero-padded codes ("007") and
-    # underscore-grouped values ("1_000") as strings so they are not corrupted
-    # — this matches yaml.safe_load for these forms.
-    if re.fullmatch(r"-?[1-9][0-9]*|0", value):
+    # Coerce plain decimal integers (including a signed zero). Zero-padded codes
+    # ("007") and underscore-grouped values ("1_000") are INTENTIONALLY kept as
+    # strings to avoid corrupting identifiers; this diverges from yaml.safe_load
+    # (YAML 1.1 would coerce them), but the manifest contains no such values.
+    if re.fullmatch(r"-?(?:0|[1-9][0-9]*)", value):
         return int(value)
     return value
 
 
-def _load_manifest_minimal(text: str) -> dict[str, Any]:
-    """Load enough manifest structure for baseline checks without PyYAML.
+def _split_key_value(content: str) -> tuple[str, str | None]:
+    """Split a ``key: value`` line at the first ``:`` that is outside quotes and
+    followed by whitespace or end-of-line (YAML's mapping separator).
 
-    Accepts the already-read manifest text (the caller is responsible for
-    reading it, so I/O errors are handled in one place). This fallback
-    intentionally does not try to be a general YAML parser. It recognizes the
-    manifest's top-level metadata, repo sections, local path hints, simple
-    grounding/context_files path entries, and skill ``id`` / ``path`` /
-    ``purpose`` fields so diagnostics can still run in a fresh checkout.
-    Complex nested YAML remains a PyYAML-only feature.
+    Returns ``(key, value)``, or ``(content, None)`` when there is no separator
+    (so a quoted key containing a colon, e.g. ``"a:b": 1``, is not split mid-key).
     """
-    data: dict[str, Any] = {"_minimal_fallback": True}
-    current_repo: str | None = None
-    current_list: str | None = None
-    current_skill: dict[str, Any] | None = None
-    current_mapping: str | None = None
-    current_mapping_key: str | None = None
+    in_single = in_double = False
+    for i, ch in enumerate(content):
+        if ch == "'" and not in_double:
+            in_single = not in_single
+        elif ch == '"' and not in_single:
+            in_double = not in_double
+        elif ch == ":" and not in_single and not in_double:
+            if i + 1 >= len(content) or content[i + 1] in " \t":
+                return content[:i], content[i + 1:]
+    return content, None
 
-    for raw_line in text.splitlines():
-        if not raw_line.strip() or raw_line.lstrip().startswith("#"):
+
+def _reject_block_scalar(value: str) -> None:
+    """Raise on a YAML block-scalar indicator (``|``/``>`` with optional
+    chomping/indent modifiers). The fallback cannot fold multi-line block
+    scalars, so fail loudly rather than silently truncating to ``|``/``>``."""
+    if re.fullmatch(r"[|>][+-]?[0-9]?", value.strip()):
+        raise ValueError(
+            "block scalars (| or >) are not supported by the no-PyYAML "
+            "fallback; install PyYAML for full manifest parsing"
+        )
+
+
+def _load_manifest_minimal(text: str) -> dict[str, Any]:
+    """Parse the manifest without PyYAML, via a generic indent-based parser.
+
+    Accepts the already-read manifest text (the caller reads it, so I/O errors
+    are handled in one place). It supports the block-YAML subset the manifest
+    uses — nested mappings, block lists (``- item``), inline flow lists
+    (``[a, b]``), scalars (str/int/bool/null), quoted strings, and ``#``
+    comments — and for that structure reproduces ``yaml.safe_load``. It is NOT a
+    general YAML parser: anchors/aliases, merge keys, block scalars (``|``/``>``)
+    and flow maps are unsupported (the manifest uses none of them). For the
+    current manifest the output is verified to equal ``yaml.safe_load``.
+    """
+    # Tokenize: (indent, content) for non-blank, non-comment-only lines, with
+    # trailing inline comments stripped (respecting quotes) so a line like
+    # `key:   # note` is seen as an empty-valued key, not a scalar.
+    tokens: list[tuple[int, str]] = []
+    for raw in text.splitlines():
+        stripped = raw.strip()
+        if not stripped or stripped.startswith("#"):
             continue
-        indent = len(raw_line) - len(raw_line.lstrip(" "))
-        line = raw_line.strip()
+        content = _strip_inline_comment(stripped)
+        if not content:
+            continue
+        tokens.append((len(raw) - len(raw.lstrip(" ")), content))
 
-        if indent == 0 and line.endswith(":"):
-            key = line[:-1]
-            if key in ("foundations", "pmos"):
-                current_repo = key
-                data.setdefault(key, {})
+    pos = [0]  # boxed index so the nested parsers can advance it
+
+    def parse_block(indent: int) -> Any:
+        if pos[0] >= len(tokens):
+            return None
+        content = tokens[pos[0]][1]
+        if content == "-" or content.startswith("- "):
+            return parse_list(indent)
+        return parse_map(indent)
+
+    def parse_map(indent: int) -> dict[str, Any]:
+        result: dict[str, Any] = {}
+        while pos[0] < len(tokens):
+            cur_indent, content = tokens[pos[0]]
+            if cur_indent != indent or content.startswith("- "):
+                break
+            key_raw, val_raw = _split_key_value(content)
+            key = key_raw.strip()
+            if len(key) >= 2 and key[0] == key[-1] and key[0] in "\"'":
+                key = key[1:-1]  # unquote a quoted mapping key
+            pos[0] += 1
+            val = (val_raw or "").strip()
+            if val == "":
+                child_indent = tokens[pos[0]][0] if pos[0] < len(tokens) else -1
+                result[key] = parse_block(child_indent) if child_indent > indent else None
             else:
-                data.setdefault(key, {})
-                current_repo = None
-            current_list = None
-            current_skill = None
-            current_mapping = None
-            current_mapping_key = None
-            continue
+                _reject_block_scalar(val)
+                result[key] = _parse_scalar(val)
+        return result
 
-        if indent == 0 and ":" in line:
-            key, value = line.split(":", 1)
-            data[key] = _parse_scalar(value)
-            current_repo = None
-            current_list = None
-            current_mapping = None
-            current_mapping_key = None
-            continue
-
-        if current_repo is None:
-            continue
-        section = data.setdefault(current_repo, {})
-
-        if indent == 2 and line.endswith(":"):
-            key = line[:-1]
-            if key in ("local_path_hints", "skills"):
-                section.setdefault(key, [])
-                current_list = key
-                current_mapping = None
-            elif key in ("grounding", "context_files"):
-                section.setdefault(key, {})
-                current_mapping = key
-                current_list = None
+    def parse_list(indent: int) -> list[Any]:
+        result: list[Any] = []
+        while pos[0] < len(tokens):
+            cur_indent, content = tokens[pos[0]]
+            if cur_indent != indent or not (content == "-" or content.startswith("- ")):
+                break
+            item = content[1:].strip()
+            # A mapping list item ("- key: value") starts a mapping whose keys
+            # sit at indent + 2 (the columns after "- "). Quote-aware detection
+            # via _split_key_value handles quoted keys that contain a colon.
+            _, item_val = _split_key_value(item)
+            if item_val is not None:
+                tokens[pos[0]] = (indent + 2, item)
+                result.append(parse_map(indent + 2))
             else:
-                section.setdefault(key, {})
-                current_list = None
-                current_mapping = None
-            current_skill = None
-            current_mapping_key = None
-            continue
+                pos[0] += 1
+                result.append(_parse_scalar(item))
+        return result
 
-        if indent == 2 and ":" in line:
-            key, value = line.split(":", 1)
-            section[key] = _parse_scalar(value)
-            current_list = None
-            current_skill = None
-            current_mapping = None
-            current_mapping_key = None
-            continue
-
-        if (
-            current_list == "local_path_hints"
-            and indent == 4
-            and line.startswith("- ")
-        ):
-            section.setdefault("local_path_hints", []).append(_parse_scalar(line[2:]))
-            continue
-
-        if current_list == "skills" and indent == 4 and line.startswith("- "):
-            current_skill = {}
-            section.setdefault("skills", []).append(current_skill)
-            item = line[2:]
-            if ":" in item:
-                key, value = item.split(":", 1)
-                current_skill[key] = _parse_scalar(value)
-            continue
-
-        if (
-            current_list == "skills"
-            and current_skill is not None
-            and indent == 6
-            and ":" in line
-        ):
-            key, value = line.split(":", 1)
-            # Baseline diagnostics only need simple scalar skill metadata.
-            if key in ("id", "path", "purpose"):
-                current_skill[key] = _parse_scalar(value)
-            continue
-
-        if (
-            current_mapping in ("grounding", "context_files")
-            and indent == 4
-            and ":" in line
-        ):
-            key, value = line.split(":", 1)
-            mapping = section.setdefault(current_mapping, {})
-            parsed_value = _parse_scalar(value)
-            mapping[key] = {} if parsed_value is None else parsed_value
-            current_mapping_key = key
-            continue
-
-        if (
-            current_mapping in ("grounding", "context_files")
-            and current_mapping_key
-            and indent == 6
-            and ":" in line
-        ):
-            key, value = line.split(":", 1)
-            entry = section.setdefault(current_mapping, {}).setdefault(
-                current_mapping_key, {}
-            )
-            # Capture every scalar sub-key, not just ``path`` — structured
-            # grounding entries carry multiple path-like keys (e.g. path,
-            # manifest, index, or cci_reference: {tasks, flows, flags}) that
-            # the old ``path``-only branch silently dropped.
-            if isinstance(entry, dict):
-                entry[key] = _parse_scalar(value)
-            continue
-
-    return data
+    data = parse_block(0)
+    return data if isinstance(data, dict) else {}
 
 # ─── Repo discovery ─────────────────────────────────────────────────────────
 
@@ -376,7 +347,13 @@ def load_manifest(path: Path | None = None) -> dict[str, Any]:
         raise SystemExit(f"skill_manifest.py: cannot read {manifest_path}: {exc}")
     if yaml is None:
         print(PY_YAML_HELP, file=sys.stderr)
-        data = _load_manifest_minimal(manifest_text)
+        try:
+            data = _load_manifest_minimal(manifest_text)
+        except Exception as exc:
+            # Mirror the PyYAML branch: any fallback parse failure (e.g. an
+            # over-nested manifest, or an unsupported block scalar) becomes a
+            # clean diagnostic rather than a raw traceback.
+            raise SystemExit(f"skill_manifest.py: cannot parse {manifest_path}: {exc}")
     else:
         try:
             data: dict[str, Any] = yaml.safe_load(manifest_text) or {}

--- a/scripts/ai/skill_manifest.py
+++ b/scripts/ai/skill_manifest.py
@@ -369,7 +369,7 @@ def load_manifest(path: Path | None = None) -> dict[str, Any]:
         print(PY_YAML_HELP, file=sys.stderr)
         data = _load_manifest_minimal(manifest_path)
     else:
-        with manifest_path.open("r") as f:
+        with manifest_path.open("r", encoding="utf-8") as f:
             data: dict[str, Any] = yaml.safe_load(f) or {}
 
     # Stash where we found it so callers can debug

--- a/scripts/ai/skill_manifest.py
+++ b/scripts/ai/skill_manifest.py
@@ -57,7 +57,8 @@ except Exception:
 MANIFEST_FILENAME = ".claude/skill-manifest.yml"
 
 PY_YAML_HELP = (
-    "PyYAML is not installed, so skill_manifest.py is using its minimal fallback. "
+    "PyYAML is not available (not installed, or failed to import), so "
+    "skill_manifest.py is using its minimal fallback. "
     "The fallback supports baseline diagnostics only: file presence, high-level "
     "manifest keys, repo discovery, and simple skill path listing. For full YAML "
     "support, activate the project CumulusCI environment or install PyYAML with "

--- a/scripts/ai/skill_manifest.py
+++ b/scripts/ai/skill_manifest.py
@@ -34,24 +34,225 @@ CLI usage (for diagnostics):
 from __future__ import annotations
 
 import argparse
+import importlib
+import importlib.util
 import os
+import re
 import sys
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Iterable
 
-try:
-    import yaml
-except ImportError:  # pragma: no cover
-    sys.stderr.write(
-        "skill_manifest.py requires PyYAML. Install via "
-        "`pipx inject cumulusci PyYAML` (CCI venv) or `pip install pyyaml`.\n"
-    )
-    sys.exit(2)
+# PyYAML is optional at import time. find_spec can report a module that still
+# fails to import (broken/partial install), so guard the actual import.
+yaml = None
+if importlib.util.find_spec("yaml") is not None:
+    try:
+        yaml = importlib.import_module("yaml")
+    except ImportError:
+        yaml = None
 
 
 MANIFEST_FILENAME = ".claude/skill-manifest.yml"
 
+PY_YAML_HELP = (
+    "PyYAML is not installed, so skill_manifest.py is using its minimal fallback. "
+    "The fallback supports baseline diagnostics only: file presence, high-level "
+    "manifest keys, repo discovery, and simple skill path listing. For full YAML "
+    "support, activate the project CumulusCI environment or install PyYAML with "
+    "`pipx inject cumulusci PyYAML`, `python -m pip install PyYAML`, or "
+    "`python -m pip install cumulusci`."
+)
+
+
+def _strip_inline_comment(value: str) -> str:
+    """Remove simple YAML comments outside quoted values for fallback parsing.
+
+    A ``#`` only starts a comment when it is at the start of the value or
+    preceded by whitespace (YAML semantics). This keeps ``#`` inside unquoted
+    path fragments (e.g. ``docs/foo#section``) intact.
+    """
+    in_single = False
+    in_double = False
+    for idx, char in enumerate(value):
+        if char == "'" and not in_double:
+            in_single = not in_single
+        elif char == '"' and not in_single:
+            in_double = not in_double
+        elif (
+            char == "#"
+            and not in_single
+            and not in_double
+            and (idx == 0 or value[idx - 1].isspace())
+        ):
+            return value[:idx].rstrip()
+    return value.strip()
+
+
+def _parse_scalar(value: str) -> Any:
+    """Parse a tiny subset of YAML scalars used by baseline diagnostics."""
+    value = _strip_inline_comment(value.strip())
+    if value in ("", "null", "Null", "NULL", "~"):
+        return None
+    if value in ("true", "True", "TRUE"):
+        return True
+    if value in ("false", "False", "FALSE"):
+        return False
+    if value == "[]":
+        return []
+    if value.startswith("[") and value.endswith("]"):
+        inner = value[1:-1].strip()
+        if not inner:
+            return []
+        return [_parse_scalar(part.strip()) for part in inner.split(",")]
+    if (value.startswith('"') and value.endswith('"')) or (
+        value.startswith("'") and value.endswith("'")
+    ):
+        return value[1:-1]
+    # Only coerce plain base-10 integers. Leave zero-padded codes ("007") and
+    # underscore-grouped values ("1_000") as strings so they are not corrupted
+    # — this matches yaml.safe_load for these forms.
+    if re.fullmatch(r"-?[1-9][0-9]*|0", value):
+        return int(value)
+    return value
+
+
+def _load_manifest_minimal(manifest_path: Path) -> dict[str, Any]:
+    """Load enough manifest structure for baseline checks without PyYAML.
+
+    This fallback intentionally does not try to be a general YAML parser. It
+    recognizes the manifest's top-level metadata, repo sections, local path
+    hints, simple grounding/context_files path entries, and skill ``id`` /
+    ``path`` / ``purpose`` fields so diagnostics can still run in a fresh
+    checkout. Complex nested YAML remains a PyYAML-only feature.
+    """
+    data: dict[str, Any] = {"_minimal_fallback": True}
+    current_repo: str | None = None
+    current_list: str | None = None
+    current_skill: dict[str, Any] | None = None
+    current_mapping: str | None = None
+    current_mapping_key: str | None = None
+
+    for raw_line in manifest_path.read_text(encoding="utf-8").splitlines():
+        if not raw_line.strip() or raw_line.lstrip().startswith("#"):
+            continue
+        indent = len(raw_line) - len(raw_line.lstrip(" "))
+        line = raw_line.strip()
+
+        if indent == 0 and line.endswith(":"):
+            key = line[:-1]
+            if key in ("foundations", "pmos"):
+                current_repo = key
+                data.setdefault(key, {})
+            else:
+                data.setdefault(key, {})
+                current_repo = None
+            current_list = None
+            current_skill = None
+            current_mapping = None
+            current_mapping_key = None
+            continue
+
+        if indent == 0 and ":" in line:
+            key, value = line.split(":", 1)
+            data[key] = _parse_scalar(value)
+            current_repo = None
+            current_list = None
+            current_mapping = None
+            current_mapping_key = None
+            continue
+
+        if current_repo is None:
+            continue
+        section = data.setdefault(current_repo, {})
+
+        if indent == 2 and line.endswith(":"):
+            key = line[:-1]
+            if key in ("local_path_hints", "skills"):
+                section.setdefault(key, [])
+                current_list = key
+                current_mapping = None
+            elif key in ("grounding", "context_files"):
+                section.setdefault(key, {})
+                current_mapping = key
+                current_list = None
+            else:
+                section.setdefault(key, {})
+                current_list = None
+                current_mapping = None
+            current_skill = None
+            current_mapping_key = None
+            continue
+
+        if indent == 2 and ":" in line:
+            key, value = line.split(":", 1)
+            section[key] = _parse_scalar(value)
+            current_list = None
+            current_skill = None
+            current_mapping = None
+            current_mapping_key = None
+            continue
+
+        if (
+            current_list == "local_path_hints"
+            and indent == 4
+            and line.startswith("- ")
+        ):
+            section.setdefault("local_path_hints", []).append(_parse_scalar(line[2:]))
+            continue
+
+        if current_list == "skills" and indent == 4 and line.startswith("- "):
+            current_skill = {}
+            section.setdefault("skills", []).append(current_skill)
+            item = line[2:]
+            if ":" in item:
+                key, value = item.split(":", 1)
+                current_skill[key] = _parse_scalar(value)
+            continue
+
+        if (
+            current_list == "skills"
+            and current_skill is not None
+            and indent == 6
+            and ":" in line
+        ):
+            key, value = line.split(":", 1)
+            # Baseline diagnostics only need simple scalar skill metadata.
+            if key in ("id", "path", "purpose"):
+                current_skill[key] = _parse_scalar(value)
+            continue
+
+        if (
+            current_mapping in ("grounding", "context_files")
+            and indent == 4
+            and ":" in line
+        ):
+            key, value = line.split(":", 1)
+            mapping = section.setdefault(current_mapping, {})
+            parsed_value = _parse_scalar(value)
+            mapping[key] = {} if parsed_value is None else parsed_value
+            current_mapping_key = key
+            continue
+
+        if (
+            current_mapping in ("grounding", "context_files")
+            and current_mapping_key
+            and indent == 6
+            and ":" in line
+        ):
+            key, value = line.split(":", 1)
+            entry = section.setdefault(current_mapping, {}).setdefault(
+                current_mapping_key, {}
+            )
+            # Capture every scalar sub-key, not just ``path`` — structured
+            # grounding entries carry multiple path-like keys (e.g. path,
+            # manifest, index, or cci_reference: {tasks, flows, flags}) that
+            # the old ``path``-only branch silently dropped.
+            if isinstance(entry, dict):
+                entry[key] = _parse_scalar(value)
+            continue
+
+    return data
 
 # ─── Repo discovery ─────────────────────────────────────────────────────────
 
@@ -83,6 +284,10 @@ def _discover_repo(
     env_var: str | None = None
 
     for hint in hints:
+        # Skip non-string hints (a malformed manifest could yield ints/lists),
+        # which would otherwise raise TypeError in expanduser/expandvars.
+        if not isinstance(hint, str):
+            continue
         # Expand env vars and ~. If the var is unset, expandvars leaves "$FOO"
         # as-is; we filter those out below.
         expanded = os.path.expandvars(os.path.expanduser(hint))
@@ -160,8 +365,12 @@ def find_manifest(start: Path | None = None) -> Path:
 def load_manifest(path: Path | None = None) -> dict[str, Any]:
     """Load and lightly normalize the manifest. Discovers repo locations."""
     manifest_path = path or find_manifest()
-    with manifest_path.open("r") as f:
-        data: dict[str, Any] = yaml.safe_load(f) or {}
+    if yaml is None:
+        print(PY_YAML_HELP, file=sys.stderr)
+        data = _load_manifest_minimal(manifest_path)
+    else:
+        with manifest_path.open("r") as f:
+            data: dict[str, Any] = yaml.safe_load(f) or {}
 
     # Stash where we found it so callers can debug
     data["_manifest_path"] = str(manifest_path)
@@ -171,7 +380,9 @@ def load_manifest(path: Path | None = None) -> dict[str, Any]:
     # Discover both repos' clones, anchoring relative hints to the manifest's
     # repo root (NOT process cwd) so discovery is stable from any subdirectory.
     for key in ("foundations", "pmos"):
-        if key in data:
+        # An empty `foundations:`/`pmos:` section parses to None; only resolve
+        # when the section is actually a mapping.
+        if isinstance(data.get(key), dict):
             data[key]["_resolved"] = _discover_repo(data[key], manifest_root)
 
     return data

--- a/scripts/ai/skill_manifest.py
+++ b/scripts/ai/skill_manifest.py
@@ -117,14 +117,16 @@ def _parse_scalar(value: str) -> Any:
     return value
 
 
-def _load_manifest_minimal(manifest_path: Path) -> dict[str, Any]:
+def _load_manifest_minimal(text: str) -> dict[str, Any]:
     """Load enough manifest structure for baseline checks without PyYAML.
 
-    This fallback intentionally does not try to be a general YAML parser. It
-    recognizes the manifest's top-level metadata, repo sections, local path
-    hints, simple grounding/context_files path entries, and skill ``id`` /
-    ``path`` / ``purpose`` fields so diagnostics can still run in a fresh
-    checkout. Complex nested YAML remains a PyYAML-only feature.
+    Accepts the already-read manifest text (the caller is responsible for
+    reading it, so I/O errors are handled in one place). This fallback
+    intentionally does not try to be a general YAML parser. It recognizes the
+    manifest's top-level metadata, repo sections, local path hints, simple
+    grounding/context_files path entries, and skill ``id`` / ``path`` /
+    ``purpose`` fields so diagnostics can still run in a fresh checkout.
+    Complex nested YAML remains a PyYAML-only feature.
     """
     data: dict[str, Any] = {"_minimal_fallback": True}
     current_repo: str | None = None
@@ -133,7 +135,7 @@ def _load_manifest_minimal(manifest_path: Path) -> dict[str, Any]:
     current_mapping: str | None = None
     current_mapping_key: str | None = None
 
-    for raw_line in manifest_path.read_text(encoding="utf-8").splitlines():
+    for raw_line in text.splitlines():
         if not raw_line.strip() or raw_line.lstrip().startswith("#"):
             continue
         indent = len(raw_line) - len(raw_line.lstrip(" "))
@@ -365,12 +367,19 @@ def find_manifest(start: Path | None = None) -> Path:
 def load_manifest(path: Path | None = None) -> dict[str, Any]:
     """Load and lightly normalize the manifest. Discovers repo locations."""
     manifest_path = path or find_manifest()
+    # Read once, with a guard, so an unreadable manifest produces a clear
+    # diagnostic (not a traceback) in both the PyYAML and fallback paths.
+    try:
+        manifest_text = manifest_path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError) as exc:
+        raise SystemExit(f"skill_manifest.py: cannot read {manifest_path}: {exc}")
     if yaml is None:
         print(PY_YAML_HELP, file=sys.stderr)
-        data = _load_manifest_minimal(manifest_path)
+        data = _load_manifest_minimal(manifest_text)
     else:
-        with manifest_path.open("r", encoding="utf-8") as f:
-            data: dict[str, Any] = yaml.safe_load(f) or {}
+        data: dict[str, Any] = yaml.safe_load(manifest_text) or {}
+        if not isinstance(data, dict):
+            data = {}
 
     # Stash where we found it so callers can debug
     data["_manifest_path"] = str(manifest_path)


### PR DESCRIPTION
### Motivation

PRs #196, #197, #200, and #201 each independently added a `scripts/ai/analyze_agent_tooling.py` from scratch. Despite the shared filename they are **four different programs** with conflicting argparse and three different output targets — they cannot coexist. This PR collapses all four into one coherent, tool-agnostic analyzer and supersedes them.

### What this does

A single subcommand-based analyzer (mirroring `query_erd.py`), importing only the Python standard library at import time so the gate runs in a fresh checkout:

```
python scripts/ai/analyze_agent_tooling.py            # 'check' (default)
python scripts/ai/analyze_agent_tooling.py check       # stdlib-only pass/fail gate
python scripts/ai/analyze_agent_tooling.py report      # docs/analysis/tooling-optimization-report.md + .agents/context/tooling-scorecard.json
python scripts/ai/analyze_agent_tooling.py coverage    # .agents/context/rule-skill-coverage.md
python scripts/ai/analyze_agent_tooling.py all         # check, then report, then coverage
```

- **check** = PR #201's baseline gate (stdlib-only, exits non-zero on failure)
- **report** = PR #197's report + scorecard
- **coverage** = PR #200's rule/skill coverage matrix
- The GitHub Actions workflow from PR #196, retargeted: the baseline gate runs on `schedule` + `pull_request` with zero dependencies; `workflow_dispatch` with `deep_checks=true` installs PyYAML, regenerates the artifacts, and opens a drift PR.
- PR #201's PyYAML-optional hardening applied to `generate_cci_reference.py` and `skill_manifest.py`.

PyYAML is loaded lazily/optionally — `report`/`coverage` degrade to a line-oriented fallback, and `check` never needs it. Committed artifacts are deterministic (no embedded wall-clock timestamps) so scheduled regeneration only diffs on a real change.

### Bug fixes (all review comments + an independent audit)

All 10 bugs flagged across the four PRs' reviews are fixed, plus additional defects found by an independent multi-agent audit:

- `datetime.UTC` (3.11+) eliminated — artifacts carry no run timestamp (py3.10-safe)
- `fnmatch.fnmatch(candidate, pattern)` arg order corrected (coverage matching)
- backtick path extraction skips fenced code blocks and filters `*`/`{}` template tokens
- no-PyYAML manifest fallback scoped correctly (foundations skills; top-level metadata not overwritten by `pmos:`); guards `skills: null`
- no-PyYAML grounding fallback now captures structured shapes (`cci_reference: {tasks, flows, flags}`, `help_corpus: {path, manifest, index}`) instead of only `path:`
- `--output` absolute paths no longer crash (`os.path.abspath`, guarded `relative_to`)
- `yaml` import guarded with `try/except ImportError` in all three scripts
- workflow installs PyYAML before deep checks
- README check-mode phrase match accepts singular and plural
- `parse_globs` handles inline flow-list globs (`[a/**, b/**]`); robust table/separator parsing; unguarded `read_text`/syntax checks hardened against `UnicodeDecodeError`/missing files; `subprocess` timeout added

Closes #196, #197, #200, #201.

### Testing

- `python scripts/ai/analyze_agent_tooling.py check` → all 7 checks PASS (Python 3.13; stdlib-only, no PyYAML installed)
- `report`, `coverage`, and `all` run clean and are byte-deterministic across reruns
- `skill_manifest.py --check` and `generate_cci_reference.py --dry-run` both degrade gracefully without PyYAML
- Independent multi-agent audit + adversarial verification pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
