### PR TITLE
policy(agents): resolve automated-review threads, not just reply

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -203,6 +203,34 @@ indexes, and more.
 
 ---
 
+## Responding to Automated PR Reviews
+
+Automated reviewers (GitHub Copilot, the Codex / `chatgpt-codex-connector` bot, and
+similar) post inline comments on PRs. **Policy — every agent, every PR:** each review
+comment is handled to completion, and **every review round ends with zero unresolved
+threads.** For each comment:
+
+1. **Verify against the code.** Don't trust the bot — confirm the claim in the actual
+   source and classify it *real*, *partial*, or *false positive*.
+2. **Sweep the whole class.** If a finding is real, fix **every** instance of that
+   pattern across the change, not just the cited line.
+3. **Reply in-thread** with the resolution **and the commit SHA** (or a clear,
+   evidence-backed refutation for a false positive):
+   `gh api --method POST repos/<owner>/<repo>/pulls/<n>/comments/<id>/replies -f body="…"`
+4. **React** 👍 on a valid comment:
+   `gh api --method POST repos/<owner>/<repo>/pulls/comments/<id>/reactions -H "Accept: application/vnd.github.squirrel-girl-preview+json" -f content=+1`
+5. **Resolve the thread** (REST cannot — use GraphQL): get the thread id from
+   `pullRequest(number:N){reviewThreads(first:100){nodes{id isResolved comments(first:1){nodes{databaseId path line}}}}}`,
+   then `mutation($tid:ID!){resolveReviewThread(input:{threadId:$tid}){thread{isResolved}}}`.
+6. **Confirm clean** — re-query `reviewThreads` and verify `unresolved == 0` for the round.
+
+Refute false positives (with evidence) rather than changing correct code — but still
+reply, and resolve the thread once the point is settled. This matters most on branches
+headed for `main`, which mirror to the internal Salesforce repo for audit: a left-open
+thread is a finding the audit will re-raise.
+
+---
+
 ## AI Agent Skill Index
 
 Skills are detailed guides for specific tasks. They live in

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -218,7 +218,7 @@ threads.** For each comment:
    evidence-backed refutation for a false positive):
    `gh api --method POST repos/<owner>/<repo>/pulls/<n>/comments/<id>/replies -f body="…"`
 4. **React** 👍 on a valid comment:
-   `gh api --method POST repos/<owner>/<repo>/pulls/comments/<id>/reactions -H "Accept: application/vnd.github.squirrel-girl-preview+json" -f content=+1`
+   `gh api --method POST repos/<owner>/<repo>/pulls/comments/<id>/reactions -H "Accept: application/vnd.github+json" -f content="+1"`
 5. **Resolve the thread** (REST cannot — use GraphQL). List threads with the full query
    root — `reviewThreads` lives under `repository(owner:, name:){ pullRequest(number:N){ … } }`
    (`pullRequest` is **not** a GraphQL root field) — and **paginate** so PRs with >100

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -219,10 +219,15 @@ threads.** For each comment:
    `gh api --method POST repos/<owner>/<repo>/pulls/<n>/comments/<id>/replies -f body="…"`
 4. **React** 👍 on a valid comment:
    `gh api --method POST repos/<owner>/<repo>/pulls/comments/<id>/reactions -H "Accept: application/vnd.github.squirrel-girl-preview+json" -f content=+1`
-5. **Resolve the thread** (REST cannot — use GraphQL): get the thread id from
-   `pullRequest(number:N){reviewThreads(first:100){nodes{id isResolved comments(first:1){nodes{databaseId path line}}}}}`,
-   then `mutation($tid:ID!){resolveReviewThread(input:{threadId:$tid}){thread{isResolved}}}`.
-6. **Confirm clean** — re-query `reviewThreads` and verify `unresolved == 0` for the round.
+5. **Resolve the thread** (REST cannot — use GraphQL). List threads with the full query
+   root — `reviewThreads` lives under `repository(owner:, name:){ pullRequest(number:N){ … } }`
+   (`pullRequest` is **not** a GraphQL root field) — and **paginate** so PRs with >100
+   threads aren't truncated:
+   `repository(owner:$o,name:$r){ pullRequest(number:$n){ reviewThreads(first:100, after:$cursor){ pageInfo{ hasNextPage endCursor } nodes{ id isResolved comments(first:1){ nodes{ databaseId path line } } } } } }`
+   — loop, passing `endCursor` as `after`, until `hasNextPage` is false. Resolve each
+   unresolved id with `mutation($tid:ID!){ resolveReviewThread(input:{threadId:$tid}){ thread{ isResolved } } }`.
+6. **Confirm clean** — re-query `reviewThreads` across **all** pages (same pagination) and
+   verify `unresolved == 0` for the round.
 
 Refute false positives (with evidence) rather than changing correct code — but still
 reply, and resolve the thread once the point is settled. This matters most on branches


### PR DESCRIPTION
## What

Adds a **"Responding to Automated PR Reviews"** policy section to `AGENTS.md` — the canonical instruction file every agent reads (Claude Code, Cursor, Copilot, Codex, …) via `CLAUDE.md` and `.github/copilot-instructions.md`.

## Policy (every agent, every PR)

Each automated-review comment is handled to completion, and **every review round ends with zero unresolved threads**:
1. Verify against the code (classify real / partial / false positive)
2. Sweep the whole finding-class (fix every instance, not just the cited line)
3. Reply in-thread with the commit SHA (or an evidence-backed refutation)
4. 👍 react on valid comments
5. **Resolve the thread** — via GraphQL `resolveReviewThread` (REST can't)
6. Confirm `unresolved == 0` for the round

## Why

This branch family (`262 → main`) mirrors to the internal Salesforce repo for audit before Salesforce Labs release. A left-open review thread is a finding the internal audit will re-raise — so threads get reply **and** resolve, not just reply.

Self-contained (no dependency on other in-flight PRs). Docs-only; no code or behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)