### PR TITLE
fix(ci): Node.js 24 opt-in + context API network resilience

### DIFF
--- a/.github/workflows/prepare-rlm-org.yml
+++ b/.github/workflows/prepare-rlm-org.yml
@@ -32,6 +32,9 @@ concurrency:
   group: prepare-rlm-org-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: false
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   prepare-rlm-org:
     # Run on manual dispatch, or when the trigger label is applied to a

--- a/.github/workflows/prepare-rlm-org.yml
+++ b/.github/workflows/prepare-rlm-org.yml
@@ -33,7 +33,7 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 
 jobs:
   prepare-rlm-org:

--- a/tasks/rlm_extend_stdctx.py
+++ b/tasks/rlm_extend_stdctx.py
@@ -96,7 +96,7 @@ class ExtendStandardContext(SFDXBaseTask):
     def _extend_context_definition(self):
         developer_name = self.options.get("developerName")
         self.logger.info(f"[1/4] Creating context definition: {developer_name}...")
-        self.logger.info("      (this API call may take up to 5 minutes on some org types — please wait)")
+        self.logger.info("      (this API call may take 5-10 minutes on some org types — please wait)")
         url, headers = self._build_url_and_headers("connect/context-definitions")
         payload = {
             "name": self.options.get("name"),

--- a/tasks/rlm_extend_stdctx.py
+++ b/tasks/rlm_extend_stdctx.py
@@ -109,7 +109,7 @@ class ExtendStandardContext(SFDXBaseTask):
         # POST is NOT idempotent — don't retry it. If the network drops after
         # the server processes the request, retrying would create a duplicate.
         response = self._make_request("post", url, headers=headers, json=payload, retryable=False)
-        if response:
+        if response is not None:
             self.context_id = response.get("contextDefinitionId")
         else:
             # Network likely dropped after server-side creation succeeded.
@@ -135,7 +135,7 @@ class ExtendStandardContext(SFDXBaseTask):
         url, headers = self._build_url_and_headers("connect/context-definitions")
         for attempt in range(1, _MAX_RETRIES + 1):
             response = self._make_request("get", url, headers=headers)
-            if response:
+            if response is not None:
                 for ctx_def in response.get("contextDefinitions", []):
                     if ctx_def.get("developerName") == developer_name:
                         self.logger.info(f"      Recovered context definition from org.")
@@ -156,7 +156,7 @@ class ExtendStandardContext(SFDXBaseTask):
             f"connect/context-definitions/{self.context_id}"
         )
         response = self._make_request("get", url, headers=headers)
-        if response:
+        if response is not None:
             version_list = response.get("contextDefinitionVersionList", [])
             self.logger.info(f"      Found {len(version_list)} version(s)")
             if version_list:
@@ -257,7 +257,7 @@ class ExtendStandardContext(SFDXBaseTask):
             f"connect/context-definitions/{self.context_id}"
         )
         response = self._make_request("get", url, headers=headers)
-        if not response:
+        if response is None:
             return []
         versions = response.get("contextDefinitionVersionList", [])
         if not versions:

--- a/tasks/rlm_extend_stdctx.py
+++ b/tasks/rlm_extend_stdctx.py
@@ -112,11 +112,11 @@ class ExtendStandardContext(SFDXBaseTask):
         response = self._make_request("post", url, headers=headers, json=payload)
         if response is not None:
             self.context_id = response.get("contextDefinitionId")
-        else:
-            # Network likely dropped after server-side creation succeeded.
-            # Recover the context definition ID by querying for it.
+        # Recover by querying the org if we didn't get a context ID — covers both
+        # network failures (response is None) and empty/unexpected response bodies.
+        if not self.context_id:
             self.logger.warning(
-                f"      POST response lost — attempting to recover context definition by developerName..."
+                f"      contextDefinitionId not in response — attempting to recover by developerName..."
             )
             self.context_id = self._recover_context_id(developer_name)
         if self.context_id:

--- a/tasks/rlm_extend_stdctx.py
+++ b/tasks/rlm_extend_stdctx.py
@@ -346,9 +346,16 @@ class ExtendStandardContext(SFDXBaseTask):
             try:
                 response = requests.request(method, url, **kwargs)
                 if response.ok:
-                    if response.status_code == 204 or not response.text:
+                    if response.status_code == 204 or not response.text.strip():
                         return {}
-                    return response.json()
+                    try:
+                        return response.json()
+                    except ValueError:
+                        self.logger.warning(
+                            f"      Non-JSON response body on {response.status_code}: "
+                            f"{response.text[:200]}"
+                        )
+                        return {}
                 # 5xx = server-side transient; retry if allowed.
                 if response.status_code >= 500 and attempt < max_attempts:
                     wait = _RETRY_BACKOFF * (2 ** (attempt - 1))

--- a/tasks/rlm_extend_stdctx.py
+++ b/tasks/rlm_extend_stdctx.py
@@ -123,9 +123,9 @@ class ExtendStandardContext(SFDXBaseTask):
             self.logger.info(f"      Context Definition ID: {self.context_id}")
             self._process_context_id()
         else:
-            self.logger.error(
-                f"      Could not obtain context definition ID for '{developer_name}'. "
-                f"The creation may have failed — check the org manually."
+            raise RuntimeError(
+                f"Could not obtain context definition ID for '{developer_name}' "
+                f"after creation and recovery attempts. The org may need manual inspection."
             )
 
     def _recover_context_id(self, developer_name):
@@ -138,7 +138,8 @@ class ExtendStandardContext(SFDXBaseTask):
             f"connect/context-definitions/{developer_name}"
         )
         for attempt in range(1, _MAX_RETRIES + 1):
-            response = self._make_request("get", url, headers=headers)
+            # Disable _make_request's own retries — this loop owns the backoff
+            response = self._make_request("get", url, headers=headers, retryable=False)
             if response is not None:
                 # The API returns isSuccess:false for unknown definitions
                 if response.get("isSuccess") is not False:

--- a/tasks/rlm_extend_stdctx.py
+++ b/tasks/rlm_extend_stdctx.py
@@ -1,9 +1,17 @@
 from abc import abstractmethod
 import json
+import time
 import requests
+from requests.exceptions import ConnectionError, Timeout, ChunkedEncodingError
 
 from cumulusci.core.keychain import BaseProjectKeychain
 from cumulusci.tasks.sfdx import SFDXBaseTask
+
+# Network resilience settings for long-running Salesforce APIs
+_CONNECT_TIMEOUT = 30       # seconds to establish TCP connection
+_READ_TIMEOUT = 600         # seconds to wait for response (context APIs can take 5-10 min)
+_MAX_RETRIES = 3            # total attempts on transient failures
+_RETRY_BACKOFF = 30         # seconds between retries (doubles each attempt)
 
 
 # ExtendStandardContext is a custom task that extends the SFDXBaseTask provided by CumulusCI.
@@ -277,16 +285,44 @@ class ExtendStandardContext(SFDXBaseTask):
         }
         return url, headers
 
-    # Make an HTTP request using the requests library and handle the response
+    # Make an HTTP request with retry logic for transient network failures.
+    # Context definition APIs can take 5-10 minutes; intermediate network
+    # devices (NAT gateways, load balancers) may drop idle TCP connections.
     def _make_request(self, method, url, **kwargs):
-        response = requests.request(method, url, **kwargs)
-        if response.ok:
-            return response.json()
-        else:
-            self.logger.error(
-                f"Failed {method.upper()} request to {url}: {response.text}"
-            )
-            return None
+        kwargs.setdefault("timeout", (_CONNECT_TIMEOUT, _READ_TIMEOUT))
+        last_exc = None
+        for attempt in range(1, _MAX_RETRIES + 1):
+            try:
+                response = requests.request(method, url, **kwargs)
+                if response.ok:
+                    return response.json()
+                # 5xx = server-side transient; retry. 4xx = client error; don't retry.
+                if response.status_code >= 500 and attempt < _MAX_RETRIES:
+                    wait = _RETRY_BACKOFF * (2 ** (attempt - 1))
+                    self.logger.warning(
+                        f"      Received {response.status_code} on attempt {attempt}/{_MAX_RETRIES}. "
+                        f"Retrying in {wait}s..."
+                    )
+                    time.sleep(wait)
+                    continue
+                self.logger.error(
+                    f"Failed {method.upper()} request to {url}: {response.text}"
+                )
+                return None
+            except (ConnectionError, Timeout, ChunkedEncodingError, OSError) as exc:
+                last_exc = exc
+                if attempt < _MAX_RETRIES:
+                    wait = _RETRY_BACKOFF * (2 ** (attempt - 1))
+                    self.logger.warning(
+                        f"      Network error on attempt {attempt}/{_MAX_RETRIES}: {exc}. "
+                        f"Retrying in {wait}s..."
+                    )
+                    time.sleep(wait)
+                else:
+                    self.logger.error(
+                        f"Failed {method.upper()} request to {url} after {_MAX_RETRIES} attempts: {last_exc}"
+                    )
+        return None
 
     # Abstract method to get the keychain class, needs to be implemented by subclasses
     @abstractmethod

--- a/tasks/rlm_extend_stdctx.py
+++ b/tasks/rlm_extend_stdctx.py
@@ -336,6 +336,8 @@ class ExtendStandardContext(SFDXBaseTask):
             try:
                 response = requests.request(method, url, **kwargs)
                 if response.ok:
+                    if response.status_code == 204 or not response.text:
+                        return {}
                     return response.json()
                 # 5xx = server-side transient; retry if allowed.
                 if response.status_code >= 500 and attempt < max_attempts:

--- a/tasks/rlm_extend_stdctx.py
+++ b/tasks/rlm_extend_stdctx.py
@@ -106,9 +106,10 @@ class ExtendStandardContext(SFDXBaseTask):
             "startDate": self.options.get("startDate"),
             "contextTtl": self.options.get("contextTtl")
         }
-        # POST is NOT idempotent — don't retry it. If the network drops after
-        # the server processes the request, retrying would create a duplicate.
-        response = self._make_request("post", url, headers=headers, json=payload, retryable=False)
+        # POST is NOT idempotent — default retryable=None means no retry for POST.
+        # If the network drops after the server processes the request, we recover
+        # the context definition ID by querying the org (see _recover_context_id).
+        response = self._make_request("post", url, headers=headers, json=payload)
         if response is not None:
             self.context_id = response.get("contextDefinitionId")
         else:
@@ -132,14 +133,19 @@ class ExtendStandardContext(SFDXBaseTask):
         self.logger.info(f"      Querying for existing context definition '{developer_name}'...")
         # Wait briefly for server-side commit to propagate
         time.sleep(10)
-        url, headers = self._build_url_and_headers("connect/context-definitions")
+        # Use the direct lookup endpoint (avoids paging the full list)
+        url, headers = self._build_url_and_headers(
+            f"connect/context-definitions/{developer_name}"
+        )
         for attempt in range(1, _MAX_RETRIES + 1):
             response = self._make_request("get", url, headers=headers)
             if response is not None:
-                for ctx_def in response.get("contextDefinitions", []):
-                    if ctx_def.get("developerName") == developer_name:
+                # The API returns isSuccess:false for unknown definitions
+                if response.get("isSuccess") is not False:
+                    ctx_id = response.get("contextDefinitionId")
+                    if ctx_id:
                         self.logger.info(f"      Recovered context definition from org.")
-                        return ctx_def.get("contextDefinitionId")
+                        return ctx_id
             if attempt < _MAX_RETRIES:
                 wait = _RETRY_BACKOFF * (2 ** (attempt - 1))
                 self.logger.warning(
@@ -326,10 +332,14 @@ class ExtendStandardContext(SFDXBaseTask):
     # Context definition APIs can take 5-10 minutes; intermediate network
     # devices (NAT gateways, load balancers) may drop idle TCP connections.
     #
-    # retryable=True (default): retries on network errors and 5xx (safe for GET/PATCH)
-    # retryable=False: no retries (use for non-idempotent POST to avoid duplicates)
-    def _make_request(self, method, url, retryable=True, **kwargs):
+    # retryable: controls retry behavior on network errors and 5xx responses.
+    #   None (default) = auto: retry GET/PATCH (idempotent), don't retry POST
+    #   True  = force retry regardless of method
+    #   False = never retry
+    def _make_request(self, method, url, retryable=None, **kwargs):
         kwargs.setdefault("timeout", (_CONNECT_TIMEOUT, _READ_TIMEOUT))
+        if retryable is None:
+            retryable = method.lower() in ("get", "patch", "put", "delete", "head", "options")
         max_attempts = _MAX_RETRIES if retryable else 1
         last_exc = None
         for attempt in range(1, max_attempts + 1):

--- a/tasks/rlm_extend_stdctx.py
+++ b/tasks/rlm_extend_stdctx.py
@@ -94,23 +94,60 @@ class ExtendStandardContext(SFDXBaseTask):
 
     # Core logic to extend an existing context definition
     def _extend_context_definition(self):
-        self.logger.info(f"[1/4] Creating context definition: {self.options.get('developerName')}...")
+        developer_name = self.options.get("developerName")
+        self.logger.info(f"[1/4] Creating context definition: {developer_name}...")
         self.logger.info("      (this API call may take up to 5 minutes on some org types — please wait)")
         url, headers = self._build_url_and_headers("connect/context-definitions")
         payload = {
             "name": self.options.get("name"),
             "description": self.options.get("description"),
-            "developerName": self.options.get("developerName"),
+            "developerName": developer_name,
             "baseReference": self.options.get("baseReference"),
             "startDate": self.options.get("startDate"),
             "contextTtl": self.options.get("contextTtl")
         }
-        response = self._make_request("post", url, headers=headers, json=payload)
+        # POST is NOT idempotent — don't retry it. If the network drops after
+        # the server processes the request, retrying would create a duplicate.
+        response = self._make_request("post", url, headers=headers, json=payload, retryable=False)
         if response:
             self.context_id = response.get("contextDefinitionId")
-            if self.context_id:
-                self.logger.info(f"      Context Definition ID: {self.context_id}")
-                self._process_context_id()
+        else:
+            # Network likely dropped after server-side creation succeeded.
+            # Recover the context definition ID by querying for it.
+            self.logger.warning(
+                f"      POST response lost — attempting to recover context definition by developerName..."
+            )
+            self.context_id = self._recover_context_id(developer_name)
+        if self.context_id:
+            self.logger.info(f"      Context Definition ID: {self.context_id}")
+            self._process_context_id()
+        else:
+            self.logger.error(
+                f"      Could not obtain context definition ID for '{developer_name}'. "
+                f"The creation may have failed — check the org manually."
+            )
+
+    def _recover_context_id(self, developer_name):
+        """Query the org for an existing context definition by developerName."""
+        self.logger.info(f"      Querying for existing context definition '{developer_name}'...")
+        # Wait briefly for server-side commit to propagate
+        time.sleep(10)
+        url, headers = self._build_url_and_headers("connect/context-definitions")
+        for attempt in range(1, _MAX_RETRIES + 1):
+            response = self._make_request("get", url, headers=headers)
+            if response:
+                for ctx_def in response.get("contextDefinitions", []):
+                    if ctx_def.get("developerName") == developer_name:
+                        self.logger.info(f"      Recovered context definition from org.")
+                        return ctx_def.get("contextDefinitionId")
+            if attempt < _MAX_RETRIES:
+                wait = _RETRY_BACKOFF * (2 ** (attempt - 1))
+                self.logger.warning(
+                    f"      Context definition not found yet (attempt {attempt}/{_MAX_RETRIES}). "
+                    f"Waiting {wait}s for server-side commit..."
+                )
+                time.sleep(wait)
+        return None
 
     # Post-process after getting the context ID - typically to process the version list
     def _process_context_id(self):
@@ -285,22 +322,26 @@ class ExtendStandardContext(SFDXBaseTask):
         }
         return url, headers
 
-    # Make an HTTP request with retry logic for transient network failures.
+    # Make an HTTP request with optional retry logic for transient network failures.
     # Context definition APIs can take 5-10 minutes; intermediate network
     # devices (NAT gateways, load balancers) may drop idle TCP connections.
-    def _make_request(self, method, url, **kwargs):
+    #
+    # retryable=True (default): retries on network errors and 5xx (safe for GET/PATCH)
+    # retryable=False: no retries (use for non-idempotent POST to avoid duplicates)
+    def _make_request(self, method, url, retryable=True, **kwargs):
         kwargs.setdefault("timeout", (_CONNECT_TIMEOUT, _READ_TIMEOUT))
+        max_attempts = _MAX_RETRIES if retryable else 1
         last_exc = None
-        for attempt in range(1, _MAX_RETRIES + 1):
+        for attempt in range(1, max_attempts + 1):
             try:
                 response = requests.request(method, url, **kwargs)
                 if response.ok:
                     return response.json()
-                # 5xx = server-side transient; retry. 4xx = client error; don't retry.
-                if response.status_code >= 500 and attempt < _MAX_RETRIES:
+                # 5xx = server-side transient; retry if allowed.
+                if response.status_code >= 500 and attempt < max_attempts:
                     wait = _RETRY_BACKOFF * (2 ** (attempt - 1))
                     self.logger.warning(
-                        f"      Received {response.status_code} on attempt {attempt}/{_MAX_RETRIES}. "
+                        f"      Received {response.status_code} on attempt {attempt}/{max_attempts}. "
                         f"Retrying in {wait}s..."
                     )
                     time.sleep(wait)
@@ -311,16 +352,16 @@ class ExtendStandardContext(SFDXBaseTask):
                 return None
             except (ConnectionError, Timeout, ChunkedEncodingError, OSError) as exc:
                 last_exc = exc
-                if attempt < _MAX_RETRIES:
+                if attempt < max_attempts:
                     wait = _RETRY_BACKOFF * (2 ** (attempt - 1))
                     self.logger.warning(
-                        f"      Network error on attempt {attempt}/{_MAX_RETRIES}: {exc}. "
+                        f"      Network error on attempt {attempt}/{max_attempts}: {exc}. "
                         f"Retrying in {wait}s..."
                     )
                     time.sleep(wait)
                 else:
                     self.logger.error(
-                        f"Failed {method.upper()} request to {url} after {_MAX_RETRIES} attempts: {last_exc}"
+                        f"Failed {method.upper()} request to {url} after {max_attempts} attempt(s): {last_exc}"
                     )
         return None
 


### PR DESCRIPTION
## Summary

**1. GitHub Actions Node.js 24 opt-in**
- Adds `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24="true"` env var to `prepare-rlm-org.yml`
- Suppresses deprecation warning for `actions/cache@v4`, `actions/setup-node@v4`, `actions/setup-python@v5`

**2. Context definition API network resilience** (`tasks/rlm_extend_stdctx.py`)
- The `extend_context_sales_transaction` step fails in CI because the context definition POST takes 5-10 minutes and intermediate network devices drop the idle TCP connection before the response arrives
- POST is non-retryable to avoid creating duplicates; on network failure, recovers the context definition ID by querying the org by `developerName`
- Subsequent idempotent operations (GET, PATCH) retry up to 3 times with exponential backoff
- Handles 204 No Content responses safely (PATCH activate can return empty body)

## Test plan
- [ ] Merge and re-run Prepare RLM Org workflow
- [ ] Verify Node.js 20 deprecation warning is gone
- [ ] Verify `extend_context_sales_transaction` completes despite slow API response

🤖 Generated with [Claude Code](https://claude.com/claude-code)