### PR TITLE
fix: gracefully skip context extension when base context unavailable

### DIFF
--- a/cumulusci.yml
+++ b/cumulusci.yml
@@ -680,6 +680,7 @@ tasks:
       contextTtl: *default_context_ttl
       defaultMapping: *contracts_context_default_mapping
       activate: true
+      allow_skip_if_unavailable: true
 
   extend_context_contracts_extraction:
     description: Extend Standard Contracts Extraction Context Definition
@@ -694,6 +695,7 @@ tasks:
       contextTtl: *default_context_ttl
       defaultMapping: *contracts_extraction_context_default_mapping
       activate: true
+      allow_skip_if_unavailable: true
 
   extend_context_asset:
     group: Revenue Lifecycle Management
@@ -807,8 +809,9 @@ tasks:
       baseReference: *cart_context_base_reference
       startDate: *default_context_start_date
       contextTtl: *default_context_ttl
-      defaultMapping: *cart_context_default_mapping  
+      defaultMapping: *cart_context_default_mapping
       activate: true
+      allow_skip_if_unavailable: true
 
   extend_context_billing:
     description: Extend Standard Billing Context
@@ -823,6 +826,7 @@ tasks:
       contextTtl: *default_context_ttl
       defaultMapping: *billing_context_default_mapping
       activate: true
+      allow_skip_if_unavailable: true
 
   extend_context_fulfillment_asset:
     description: Extend Standard Fulfillment Asset Context Definition
@@ -837,6 +841,7 @@ tasks:
       contextTtl: *default_context_ttl
       defaultMapping: *fulfillment_asset_context_default_mapping
       activate: true
+      allow_skip_if_unavailable: true
 
   extend_context_collection_plan_segment:
     description: Extend Standard Collection Plan Segment Context Definition
@@ -851,6 +856,7 @@ tasks:
       contextTtl: *default_context_ttl
       defaultMapping: *collection_plan_segment_context_default_mapping
       activate: true
+      allow_skip_if_unavailable: true
 
   extend_context_rate_management:
     description: Extend Standard Rate Management Context Definition
@@ -865,6 +871,7 @@ tasks:
       contextTtl: *default_context_ttl
       defaultMapping: *rate_management_context_default_mapping
       activate: true
+      allow_skip_if_unavailable: true
 
   extend_context_rating_discovery:
     description: Extend Standard Rating Discovery Context Definition
@@ -879,6 +886,7 @@ tasks:
       contextTtl: *default_context_ttl
       defaultMapping: *rating_discovery_context_default_mapping
       activate: true
+      allow_skip_if_unavailable: true
 
 #--------------#
 # DEPLOY TASKS #

--- a/tasks/rlm_extend_stdctx.py
+++ b/tasks/rlm_extend_stdctx.py
@@ -110,22 +110,30 @@ class ExtendStandardContext(SFDXBaseTask):
         # If the network drops after the server processes the request, we recover
         # the context definition ID by querying the org (see _recover_context_id).
         self.context_id = None
-        self._last_request_failure = None
+        self._last_response_status = None
+        self._last_response_body = None
         response = self._make_request("post", url, headers=headers, json=payload)
         if response is not None:
             self.context_id = response.get("contextDefinitionId")
-        # Determine how to handle failure based on failure mode:
-        # - api_error: Salesforce explicitly rejected (e.g. base context not available).
-        #   This is not recoverable — warn and return gracefully.
-        # - network_error: connection dropped, server may have processed the request.
-        #   Attempt recovery by querying the org.
+        # Determine how to handle failure:
+        # - UNKNOWN_EXCEPTION = base context definition not available in this org.
+        #   This is expected for optional contexts (e.g. Contracts when CLM feature
+        #   is not fully enabled). Skip gracefully.
+        # - Other API errors (401, 403, 400, etc.) = fail loudly.
+        # - Network error (no response status) = attempt recovery by querying org.
         if not self.context_id:
-            if self._last_request_failure == "api_error":
+            if self._last_response_status is not None and self._is_missing_base_context_error():
                 self.logger.warning(
-                    f"      Salesforce rejected the request for '{developer_name}'. "
-                    f"The base context definition may not be available in this org. Skipping."
+                    f"      Base context definition not available for '{developer_name}'. "
+                    f"Skipping — the required feature may not be enabled in this org."
                 )
                 return
+            if self._last_response_status is not None:
+                # Non-recoverable API error (auth, validation, etc.) — fail loudly
+                raise RuntimeError(
+                    f"Salesforce API error creating context definition '{developer_name}': "
+                    f"HTTP {self._last_response_status} — {self._last_response_body[:300]}"
+                )
             # Network failure or missing ID in response — attempt recovery
             self.logger.warning(
                 f"      contextDefinitionId not in response — attempting to recover by developerName..."
@@ -139,6 +147,24 @@ class ExtendStandardContext(SFDXBaseTask):
                 f"Could not obtain context definition ID for '{developer_name}' "
                 f"after creation and recovery attempts. The org may need manual inspection."
             )
+
+    def _is_missing_base_context_error(self):
+        """Check if the last API error indicates the base context is unavailable.
+
+        Salesforce returns UNKNOWN_EXCEPTION when the base context definition
+        referenced by baseReference does not exist in the org (feature not enabled).
+        """
+        if not self._last_response_body:
+            return False
+        try:
+            errors = json.loads(self._last_response_body)
+            if isinstance(errors, list):
+                return any(
+                    e.get("errorCode") == "UNKNOWN_EXCEPTION" for e in errors
+                )
+        except (ValueError, TypeError):
+            pass
+        return False
 
     def _recover_context_id(self, developer_name):
         """Query the org for an existing context definition by developerName."""
@@ -381,7 +407,8 @@ class ExtendStandardContext(SFDXBaseTask):
                 self.logger.error(
                     f"Failed {method.upper()} request to {url}: {response.text}"
                 )
-                self._last_request_failure = "api_error"
+                self._last_response_status = response.status_code
+                self._last_response_body = response.text
                 return None
             except (ConnectionError, Timeout, ChunkedEncodingError, OSError) as exc:
                 last_exc = exc
@@ -396,7 +423,8 @@ class ExtendStandardContext(SFDXBaseTask):
                     self.logger.error(
                         f"Failed {method.upper()} request to {url} after {max_attempts} attempt(s): {last_exc}"
                     )
-                    self._last_request_failure = "network_error"
+                    self._last_response_status = None
+                    self._last_response_body = None
         return None
 
     # Abstract method to get the keychain class, needs to be implemented by subclasses

--- a/tasks/rlm_extend_stdctx.py
+++ b/tasks/rlm_extend_stdctx.py
@@ -119,6 +119,8 @@ class ExtendStandardContext(SFDXBaseTask):
         # - UNKNOWN_EXCEPTION = base context definition not available in this org.
         #   This is expected for optional contexts (e.g. Contracts when CLM feature
         #   is not fully enabled). Skip gracefully.
+        # - DUPLICATE_VALUE = context definition already exists. Recover the ID
+        #   and continue with configuration (set default mapping, activate, etc.).
         # - Other API errors (401, 403, 400, etc.) = fail loudly.
         # - Network error (no response status) = attempt recovery by querying org.
         if not self.context_id:
@@ -128,17 +130,24 @@ class ExtendStandardContext(SFDXBaseTask):
                     f"Skipping — the required feature may not be enabled in this org."
                 )
                 return
-            if self._last_response_status is not None:
+            if self._last_response_status is not None and self._is_duplicate_value_error():
+                self.logger.info(
+                    f"      Context definition '{developer_name}' already exists. "
+                    f"Recovering ID to continue configuration..."
+                )
+                self.context_id = self._recover_context_id(developer_name)
+            elif self._last_response_status is not None:
                 # Non-recoverable API error (auth, validation, etc.) — fail loudly
                 raise RuntimeError(
                     f"Salesforce API error creating context definition '{developer_name}': "
                     f"HTTP {self._last_response_status} — {self._last_response_body[:300]}"
                 )
-            # Network failure or missing ID in response — attempt recovery
-            self.logger.warning(
-                f"      contextDefinitionId not in response — attempting to recover by developerName..."
-            )
-            self.context_id = self._recover_context_id(developer_name)
+            else:
+                # Network failure or missing ID in response — attempt recovery
+                self.logger.warning(
+                    f"      contextDefinitionId not in response — attempting to recover by developerName..."
+                )
+                self.context_id = self._recover_context_id(developer_name)
         if self.context_id:
             self.logger.info(f"      Context Definition ID: {self.context_id}")
             self._process_context_id()
@@ -154,13 +163,26 @@ class ExtendStandardContext(SFDXBaseTask):
         Salesforce returns UNKNOWN_EXCEPTION when the base context definition
         referenced by baseReference does not exist in the org (feature not enabled).
         """
+        return self._has_error_code("UNKNOWN_EXCEPTION")
+
+    def _is_duplicate_value_error(self):
+        """Check if the last API error indicates the context definition already exists.
+
+        Salesforce returns DUPLICATE_VALUE when a definition with the same
+        Name or DeveloperName already exists. The task should recover the
+        existing ID and continue with configuration steps.
+        """
+        return self._has_error_code("DUPLICATE_VALUE")
+
+    def _has_error_code(self, error_code):
+        """Check if the last response body contains a specific Salesforce errorCode."""
         if not self._last_response_body:
             return False
         try:
             errors = json.loads(self._last_response_body)
             if isinstance(errors, list):
                 return any(
-                    e.get("errorCode") == "UNKNOWN_EXCEPTION" for e in errors
+                    e.get("errorCode") == error_code for e in errors
                 )
         except (ValueError, TypeError):
             pass

--- a/tasks/rlm_extend_stdctx.py
+++ b/tasks/rlm_extend_stdctx.py
@@ -58,6 +58,12 @@ class ExtendStandardContext(SFDXBaseTask):
         "plan_file": {
             "description": "Optional JSON plan with nodes/mappings/tags to apply after creation",
             "required": False,
+        },
+        "allow_skip_if_unavailable": {
+            "description": "If true, skip gracefully when the base context definition "
+                           "is not available (UNKNOWN_EXCEPTION). Use for optional contexts "
+                           "whose base may not be provisioned. Defaults to false.",
+            "required": False,
         }
     }
 
@@ -124,12 +130,19 @@ class ExtendStandardContext(SFDXBaseTask):
         # - Other API errors (401, 403, 400, etc.) = fail loudly.
         # - Network error (no response status) = attempt recovery by querying org.
         if not self.context_id:
+            allow_skip = str(self.options.get("allow_skip_if_unavailable", "false")).lower() == "true"
             if self._last_response_status is not None and self._is_missing_base_context_error():
-                self.logger.warning(
-                    f"      Base context definition not available for '{developer_name}'. "
-                    f"Skipping — the required feature may not be enabled in this org."
+                if allow_skip:
+                    self.logger.warning(
+                        f"      Base context definition not available for '{developer_name}'. "
+                        f"Skipping — allow_skip_if_unavailable is set."
+                    )
+                    return
+                raise RuntimeError(
+                    f"Base context definition not available for '{developer_name}'. "
+                    f"Salesforce returned UNKNOWN_EXCEPTION. If this context is optional, "
+                    f"set allow_skip_if_unavailable: true in the task options."
                 )
-                return
             if self._last_response_status is not None and self._is_duplicate_value_error():
                 self.logger.info(
                     f"      Context definition '{developer_name}' already exists. "

--- a/tasks/rlm_extend_stdctx.py
+++ b/tasks/rlm_extend_stdctx.py
@@ -110,12 +110,23 @@ class ExtendStandardContext(SFDXBaseTask):
         # If the network drops after the server processes the request, we recover
         # the context definition ID by querying the org (see _recover_context_id).
         self.context_id = None
+        self._last_request_failure = None
         response = self._make_request("post", url, headers=headers, json=payload)
         if response is not None:
             self.context_id = response.get("contextDefinitionId")
-        # Recover by querying the org if we didn't get a context ID — covers both
-        # network failures (response is None) and empty/unexpected response bodies.
+        # Determine how to handle failure based on failure mode:
+        # - api_error: Salesforce explicitly rejected (e.g. base context not available).
+        #   This is not recoverable — warn and return gracefully.
+        # - network_error: connection dropped, server may have processed the request.
+        #   Attempt recovery by querying the org.
         if not self.context_id:
+            if self._last_request_failure == "api_error":
+                self.logger.warning(
+                    f"      Salesforce rejected the request for '{developer_name}'. "
+                    f"The base context definition may not be available in this org. Skipping."
+                )
+                return
+            # Network failure or missing ID in response — attempt recovery
             self.logger.warning(
                 f"      contextDefinitionId not in response — attempting to recover by developerName..."
             )
@@ -370,6 +381,7 @@ class ExtendStandardContext(SFDXBaseTask):
                 self.logger.error(
                     f"Failed {method.upper()} request to {url}: {response.text}"
                 )
+                self._last_request_failure = "api_error"
                 return None
             except (ConnectionError, Timeout, ChunkedEncodingError, OSError) as exc:
                 last_exc = exc
@@ -384,6 +396,7 @@ class ExtendStandardContext(SFDXBaseTask):
                     self.logger.error(
                         f"Failed {method.upper()} request to {url} after {max_attempts} attempt(s): {last_exc}"
                     )
+                    self._last_request_failure = "network_error"
         return None
 
     # Abstract method to get the keychain class, needs to be implemented by subclasses


### PR DESCRIPTION
## Summary

Distinguishes between **API errors**, **known-skippable errors**, and **network failures** in `ExtendStandardContext` so the `prepare_rlm_org` flow handles each correctly.

**Error handling matrix:**

| Failure | Behavior |
|---|---|
| `UNKNOWN_EXCEPTION` + `allow_skip_if_unavailable: true` | Warn and skip (base context not provisioned) |
| `UNKNOWN_EXCEPTION` without opt-in | Raise `RuntimeError` (required context) |
| `DUPLICATE_VALUE` | Recover existing ID, continue configuring |
| Other API errors (401, 403, 400) | Raise `RuntimeError` |
| Network failure (connection dropped) | Attempt recovery by querying org, raise if that fails |

**Implementation:**
- Tracks failure context via `_last_response_status` and `_last_response_body` attributes set in `_make_request`
- `_is_missing_base_context_error()` checks for `UNKNOWN_EXCEPTION` errorCode
- `_is_duplicate_value_error()` checks for `DUPLICATE_VALUE` errorCode
- New task option `allow_skip_if_unavailable` (default false) gates graceful skipping
- Optional contexts (contracts, billing, cart, fulfillment, collection_plan_segment, rate_management, rating_discovery) set the option in `cumulusci.yml`
- Required contexts (sales_transaction, product_discovery, asset) do not — they fail loudly on any error

## Test plan
- [ ] Run `prepare_rlm_org` on an org without CLM — verify Contracts steps skip gracefully
- [ ] Run on an org with all features — verify all contexts create and activate
- [ ] Verify a 401/403 error on a required context raises RuntimeError

🤖 Generated with [Claude Code](https://claude.com/claude-code)