### PR TITLE
feat(ci): repo-wide automated-PR-review tooling (pr_review.py + /pr-review)

### DIFF
--- a/.agents/adapters/agentforce.md
+++ b/.agents/adapters/agentforce.md
@@ -17,6 +17,9 @@ instructions instead of introducing a parallel guidance stack.
   skills and grounding artifacts are shared across repos.
 - **Copilot pointer:** `.github/copilot-instructions.md` is specific to GitHub
   Copilot and should be treated as an adapter, not as a separate authority.
+- **Automated PR reviews:** drive review threads to **zero unresolved** using
+  `python scripts/ai/pr_review.py` (`status` / `handle` / `verify`), per
+  `AGENTS.md` §"Responding to Automated PR Reviews".
 
 ## Authoritative files
 

--- a/.agents/adapters/claude-code.md
+++ b/.agents/adapters/claude-code.md
@@ -13,6 +13,10 @@ separate Claude-only contract.
   but Claude Code can reuse their guidance manually for matching file types.
 - **Cross-repo discovery:** `.claude/skill-manifest.yml` is the manifest for
   resolving shared skills and artifacts across Foundations and related repos.
+- **Automated PR reviews:** drive review threads to **zero unresolved** using
+  `python scripts/ai/pr_review.py` (`status` / `handle` / `verify`) — or the
+  `/pr-review <pr>` slash command — per `AGENTS.md` §"Responding to Automated PR
+  Reviews".
 
 ## Authoritative files
 

--- a/.agents/adapters/codex.md
+++ b/.agents/adapters/codex.md
@@ -14,6 +14,9 @@ project contract for every task in this repository.
 - **Cross-repo discovery:** use `.claude/skill-manifest.yml` and
   `scripts/ai/skill_manifest.py` when a task needs PMOS/Foundation skill or
   artifact resolution.
+- **Automated PR reviews:** drive review threads to **zero unresolved** using
+  `python scripts/ai/pr_review.py` (`status` / `handle` / `verify`), per
+  `AGENTS.md` §"Responding to Automated PR Reviews".
 
 ## Authoritative files
 

--- a/.agents/adapters/copilot.md
+++ b/.agents/adapters/copilot.md
@@ -15,6 +15,9 @@ Copilot instruction file.
   injection, but Copilot can reuse their guidance manually.
 - **Cross-repo discovery:** `.claude/skill-manifest.yml` supports cross-repo
   skill and artifact resolution.
+- **Automated PR reviews:** drive review threads to **zero unresolved** using
+  `python scripts/ai/pr_review.py` (`status` / `handle` / `verify`), per
+  `AGENTS.md` §"Responding to Automated PR Reviews".
 
 ## Authoritative files
 

--- a/.agents/adapters/cursor.md
+++ b/.agents/adapters/cursor.md
@@ -15,6 +15,9 @@ file-pattern rule files in this repository.
 - **Cross-repo discovery:** use `.claude/skill-manifest.yml` and
   `scripts/ai/skill_manifest.py` when resolving cross-repo skills or grounding
   artifacts.
+- **Automated PR reviews:** drive review threads to **zero unresolved** using
+  `python scripts/ai/pr_review.py` (`status` / `handle` / `verify`), per
+  `AGENTS.md` §"Responding to Automated PR Reviews".
 
 ## Authoritative files
 

--- a/.claude/commands/pr-review.md
+++ b/.claude/commands/pr-review.md
@@ -1,0 +1,29 @@
+---
+description: Drive automated PR-review comments to zero unresolved (verify → sweep → reply+👍+resolve)
+argument-hint: <pr-number>
+---
+
+Process **every** automated review comment on **PR #$ARGUMENTS** to **zero
+unresolved threads**, following AGENTS.md §"Responding to Automated PR Reviews".
+Use the helper `scripts/ai/pr_review.py`.
+
+1. **List open threads:**
+   `python scripts/ai/pr_review.py status $ARGUMENTS`
+
+2. **For each open comment** (do NOT trust the bot):
+   - **Verify against the code** — open the cited file; classify the finding
+     *real*, *partial*, or *false positive*.
+   - **Sweep the class** — if real, fix **every** instance of that pattern across
+     the change, not just the cited line. Commit the fix; note the SHA.
+   - **Resolve it** — replies in-thread with the SHA, adds 👍, and resolves the
+     thread in one call:
+     `python scripts/ai/pr_review.py handle $ARGUMENTS --comment <id> --body "<resolution + commit SHA>"`
+     For a false positive, put an evidence-backed refutation in `--body` (still
+     reply + resolve; don't change correct code).
+
+3. **Confirm clean:**
+   `python scripts/ai/pr_review.py verify $ARGUMENTS` → must report **0
+   unresolved**. If any remain, handle them and re-run.
+
+Never leave a thread open: branches headed for `main` mirror to the internal
+Salesforce repo for audit, which re-raises any open thread.

--- a/.claude/commands/pr-review.md
+++ b/.claude/commands/pr-review.md
@@ -15,11 +15,12 @@ Use the helper `scripts/ai/pr_review.py`.
      *real*, *partial*, or *false positive*.
    - **Sweep the class** — if real, fix **every** instance of that pattern across
      the change, not just the cited line. Commit the fix; note the SHA.
-   - **Resolve it** — replies in-thread with the SHA, adds 👍, and resolves the
-     thread in one call:
+   - **Resolve it** — for a **valid** finding, reply in-thread with the SHA, 👍,
+     and resolve in one call:
      `python scripts/ai/pr_review.py handle $ARGUMENTS --comment <id> --body "<resolution + commit SHA>"`
-     For a false positive, put an evidence-backed refutation in `--body` (still
-     reply + resolve; don't change correct code).
+     For a **false positive**, put an evidence-backed refutation in `--body` and add
+     `--no-react` — reply + resolve but **don't** 👍, and don't change correct code.
+     (👍 only on valid comments, per AGENTS.md.)
 
 3. **Confirm clean:**
    `python scripts/ai/pr_review.py verify $ARGUMENTS` → must report **0

--- a/.cursor/skills/audit-review/SKILL.md
+++ b/.cursor/skills/audit-review/SKILL.md
@@ -28,6 +28,9 @@
    on each thread; 👍 valid comments; then **resolve the thread** (GraphQL — REST can't).
    **Every review round ends with zero unresolved threads** — that is the audit trail.
    See `AGENTS.md` "Responding to Automated PR Reviews" for the canonical command set.
+   **Tooling:** `python scripts/ai/pr_review.py` (`status` / `handle` / `verify`) automates the
+   reply + 👍 + resolve + paginated 0-unresolved check; the `/pr-review <pr>` Claude command drives
+   the full round with it. Both default to the current repo (`--repo owner/name` to override).
 7. **Re-sweep after each round** — a new commit can introduce a new instance of an
    old class.
 

--- a/.gitignore
+++ b/.gitignore
@@ -112,12 +112,13 @@ selenium-screenshot*.png
 **/*.tsbuildinfo
 agents256*/**
 unpackaged/*bak/**
-# Cross-repo skill manifest is a tracked artifact (PMOS ↔ Foundations contract);
+# Cross-repo skill manifest + shared slash commands are tracked artifacts;
 # everything else under .claude/ (settings.local.json, worktrees/, launch.json)
-# stays local. Pattern is .claude/* (not .claude/) so the negation below works —
+# stays local. Pattern is .claude/* (not .claude/) so the negations below work —
 # git refuses to re-include a file whose parent directory itself is ignored.
 .claude/*
 !.claude/skill-manifest.yml
+!.claude/commands/
 datasets/sfdmu/reconcile/**
 datasets/sfdmu/extractions/**
 datasets/sfdmu/**/*.csv.bak

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -213,8 +213,9 @@ threads.**
 **Tooling — `python scripts/ai/pr_review.py`** (or the `/pr-review <pr>` command in Claude
 Code) automates the mechanical steps so a round can't be left half-finished:
 `status <pr>` lists unresolved threads (paginated), `handle <pr> --comment <id> --body "…"`
-replies + 👍 + resolves one thread, and `verify <pr>` confirms 0 unresolved (exit 1 if any
-remain). It's tool-agnostic (shells out to `gh`); defaults to the current repo, or pass
+replies + resolves one thread (adds 👍 **by default** — pass `--no-react` to refute a false
+positive without the 👍, per the "react on valid comments" rule below), and `verify <pr>`
+confirms 0 unresolved (exit 1 if any remain). It's tool-agnostic (shells out to `gh`); defaults to the current repo, or pass
 `--repo owner/name`. Verifying findings and sweeping the class (steps 1–2) stay your job.
 
 For each comment:
@@ -339,7 +340,7 @@ python scripts/ai/generate_cci_reference.py                 # Regenerate CCI doc
 python scripts/ai/skill_manifest.py --check                 # Verify cross-repo skill manifest can resolve PMOS clone
 python scripts/ai/skill_manifest.py --list-skills foundations
 python scripts/ai/pr_review.py status <pr>                  # Automated-PR-review helper: list unresolved threads
-python scripts/ai/pr_review.py handle <pr> --comment <id> --body "…"   # reply + 👍 + resolve one thread
+python scripts/ai/pr_review.py handle <pr> --comment <id> --body "…"   # reply + resolve one thread (👍 by default; --no-react to refute a false positive)
 python scripts/ai/pr_review.py verify <pr>                  # confirm 0 unresolved (paginated)
 ```
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -208,7 +208,16 @@ indexes, and more.
 Automated reviewers (GitHub Copilot, the Codex / `chatgpt-codex-connector` bot, and
 similar) post inline comments on PRs. **Policy — every agent, every PR:** each review
 comment is handled to completion, and **every review round ends with zero unresolved
-threads.** For each comment:
+threads.**
+
+**Tooling — `python scripts/ai/pr_review.py`** (or the `/pr-review <pr>` command in Claude
+Code) automates the mechanical steps so a round can't be left half-finished:
+`status <pr>` lists unresolved threads (paginated), `handle <pr> --comment <id> --body "…"`
+replies + 👍 + resolves one thread, and `verify <pr>` confirms 0 unresolved (exit 1 if any
+remain). It's tool-agnostic (shells out to `gh`); defaults to the current repo, or pass
+`--repo owner/name`. Verifying findings and sweeping the class (steps 1–2) stay your job.
+
+For each comment:
 
 1. **Verify against the code.** Don't trust the bot — confirm the claim in the actual
    source and classify it *real*, *partial*, or *false positive*.
@@ -329,7 +338,12 @@ python scripts/ai/query_erd.py domain Pricing               # List domain object
 python scripts/ai/generate_cci_reference.py                 # Regenerate CCI docs
 python scripts/ai/skill_manifest.py --check                 # Verify cross-repo skill manifest can resolve PMOS clone
 python scripts/ai/skill_manifest.py --list-skills foundations
+python scripts/ai/pr_review.py status <pr>                  # Automated-PR-review helper: list unresolved threads
+python scripts/ai/pr_review.py handle <pr> --comment <id> --body "…"   # reply + 👍 + resolve one thread
+python scripts/ai/pr_review.py verify <pr>                  # confirm 0 unresolved (paginated)
 ```
+
+`scripts/ai/pr_review.py` executes the mechanical half of **Responding to Automated PR Reviews** (above); the `/pr-review <pr>` Claude command drives the full protocol with it.
 
 `scripts/ai/skill_manifest.py` is the resolver for the cross-repo skill manifest at `.claude/skill-manifest.yml` — see `.cursor/skills/pmos-integration/SKILL.md` for the integration pattern.
 

--- a/scripts/ai/README.md
+++ b/scripts/ai/README.md
@@ -109,6 +109,29 @@ without it they degrade gracefully to a line-oriented fallback.
 **Used by:** `.github/workflows/agent-tooling-optimization.yml`, the `.agents/`
 tool-agnostic layer.
 
+### `pr_review.py`
+
+Automates the *mechanical* half of the "Responding to Automated PR Reviews"
+protocol in `AGENTS.md`, so review rounds reliably end with **zero unresolved
+threads**. Tool-agnostic — shells out to the authenticated `gh` CLI. Repo
+defaults to the current checkout (`gh repo view`); override with
+`--repo owner/name`.
+
+```bash
+python scripts/ai/pr_review.py status 213                              # list unresolved threads (paginated)
+python scripts/ai/pr_review.py handle 213 --comment <id> --body "Fixed in <sha> …"   # reply + 👍 + resolve
+python scripts/ai/pr_review.py handle 213 --comment <id> --body "…" --no-react        # refute a false positive (no 👍)
+python scripts/ai/pr_review.py verify 213                              # confirm 0 unresolved (exit 1 if any remain)
+```
+
+The *judgment* half stays with the agent: verify each finding against the code,
+classify it real / partial / false-positive, and sweep the whole class before
+resolving (see `AGENTS.md` and `.cursor/skills/audit-review/SKILL.md`).
+
+**Used by:** `AGENTS.md` §"Responding to Automated PR Reviews", the `/pr-review`
+Claude command (`.claude/commands/pr-review.md`),
+`.cursor/skills/audit-review/SKILL.md`
+
 ---
 
 ## Dependencies

--- a/scripts/ai/pr_review.py
+++ b/scripts/ai/pr_review.py
@@ -123,10 +123,14 @@ def _loc(comment):
     return f"{comment.get('path', '?')}:{line}"
 
 
-def cmd_status(repo, pr, show_all):
+def cmd_status(repo, pr, show_all, repo_arg=None):
     threads = fetch_threads(repo, pr)
     unresolved = [t for t in threads if not t["isResolved"]]
     shown = threads if show_all else unresolved
+    # Carry an explicit --repo through to the copy/paste `handle` suggestion so it
+    # targets the same repo, not the current checkout. (--repo is a top-level arg,
+    # so it must precede the subcommand.)
+    repo_flag = f"--repo {repo_arg} " if repo_arg else ""
     print(f"PR #{pr} ({repo}): {len(threads)} thread(s), {len(unresolved)} unresolved")
     if not shown:
         print("  ✅ nothing to handle" if not show_all else "  (no threads)")
@@ -141,7 +145,7 @@ def cmd_status(repo, pr, show_all):
         print(f"  {snippet}")
         if not t["isResolved"]:
             print(
-                f"  → resolve: python scripts/ai/pr_review.py handle {pr} "
+                f"  → resolve: python scripts/ai/pr_review.py {repo_flag}handle {pr} "
                 f"--comment {c.get('databaseId')} --body \"<fix + commit SHA>\""
             )
             print("             (👍 added by default; add --no-react to refute a false positive)")
@@ -221,7 +225,10 @@ def main():
 
     h = sub.add_parser("handle", help="reply + 👍 + resolve one thread")
     h.add_argument("pr", type=int)
-    h.add_argument("--comment", required=True, help="original review comment databaseId")
+    h.add_argument(
+        "--comment", required=True, type=int,
+        help="original review comment databaseId",
+    )
     h.add_argument("--body", help="reply body (resolution + commit SHA, or refutation)")
     h.add_argument("--body-file", help="read reply body from a file ('-' for stdin)")
     h.add_argument("--no-react", action="store_true", help="skip the 👍 reaction")
@@ -230,7 +237,7 @@ def main():
     repo = resolve_repo(a.repo)
 
     if a.cmd == "status":
-        sys.exit(cmd_status(repo, a.pr, a.all))
+        sys.exit(cmd_status(repo, a.pr, a.all, a.repo))
     if a.cmd == "verify":
         sys.exit(cmd_verify(repo, a.pr))
     if a.cmd == "handle":

--- a/scripts/ai/pr_review.py
+++ b/scripts/ai/pr_review.py
@@ -7,7 +7,8 @@ threads**:
 
 * ``status``  — list review threads (unresolved by default), paginated, with the
   comment id, location, and body needed to act on each.
-* ``handle``  — reply in-thread + 👍 react + resolve a single thread, in one call.
+* ``handle``  — reply in-thread + 👍 + resolve a single thread, in one call
+  (👍 by default; pass ``--no-react`` to refute a false positive without it).
 * ``verify``  — confirm 0 unresolved across all pages (exit 1 if any remain).
 
 The *judgment* half stays with the agent: verify each finding against the code,
@@ -90,8 +91,19 @@ def fetch_threads(repo, pr):
         ]
         if cursor:
             args += ["-f", f"cursor={cursor}"]
-        data = _json(args)
-        rt = data["data"]["repository"]["pullRequest"]["reviewThreads"]
+        res = _run(args, check=False)
+        try:
+            data = json.loads(res.stdout) if res.stdout.strip() else {}
+        except json.JSONDecodeError:
+            data = {}
+        if data.get("errors"):
+            msgs = "; ".join(e.get("message", str(e)) for e in data["errors"])
+            raise SystemExit(f"GraphQL error for PR #{pr} in {repo}: {msgs}")
+        pr_node = ((data.get("data") or {}).get("repository") or {}).get("pullRequest")
+        if pr_node is None:  # bad repo/auth/network, or PR missing with no errors block
+            detail = res.stderr.strip() or res.stdout.strip() or "unknown error"
+            raise SystemExit(f"Could not read PR #{pr} in {repo}: {detail}")
+        rt = pr_node["reviewThreads"]
         nodes.extend(rt["nodes"])
         if rt["pageInfo"]["hasNextPage"]:
             cursor = rt["pageInfo"]["endCursor"]
@@ -127,9 +139,10 @@ def cmd_status(repo, pr, show_all):
         print(f"  {snippet}")
         if not t["isResolved"]:
             print(
-                f"  → handle: python scripts/ai/pr_review.py handle {pr} "
-                f"--comment {c.get('databaseId')} --body \"<resolution + commit SHA>\""
+                f"  → resolve: python scripts/ai/pr_review.py handle {pr} "
+                f"--comment {c.get('databaseId')} --body \"<fix + commit SHA>\""
             )
+            print("             (👍 added by default; add --no-react to refute a false positive)")
     return 0
 
 

--- a/scripts/ai/pr_review.py
+++ b/scripts/ai/pr_review.py
@@ -69,14 +69,16 @@ def _json(args, input_text=None):
 
 
 def resolve_repo(repo):
-    if repo:
-        return repo
-    out = _run(
-        ["repo", "view", "--json", "nameWithOwner", "-q", ".nameWithOwner"]
-    ).stdout.strip()
-    if not out:
-        raise SystemExit("Could not determine repo; pass --repo owner/name")
-    return out
+    if not repo:
+        repo = _run(
+            ["repo", "view", "--json", "nameWithOwner", "-q", ".nameWithOwner"]
+        ).stdout.strip()
+        if not repo:
+            raise SystemExit("Could not determine repo; pass --repo owner/name")
+    parts = repo.split("/")
+    if len(parts) != 2 or not parts[0] or not parts[1]:
+        raise SystemExit(f"--repo must be in owner/name format, got: {repo!r}")
+    return repo
 
 
 def fetch_threads(repo, pr):
@@ -234,9 +236,11 @@ def main():
     if a.cmd == "handle":
         body = a.body
         if a.body_file:
-            body = sys.stdin.read() if a.body_file == "-" else open(
-                a.body_file, encoding="utf-8"
-            ).read()
+            if a.body_file == "-":
+                body = sys.stdin.read()
+            else:
+                with open(a.body_file, encoding="utf-8") as fh:
+                    body = fh.read()
         if not body or not body.strip():
             raise SystemExit("handle requires --body or --body-file")
         sys.exit(cmd_handle(repo, a.pr, a.comment, body, react=not a.no_react))

--- a/scripts/ai/pr_review.py
+++ b/scripts/ai/pr_review.py
@@ -176,14 +176,21 @@ def cmd_handle(repo, pr, comment_id, body, react):
         "-f", f"body={body}",
     ])
     print(f"  ✓ replied in-thread on comment {comment_id}")
-    # 2. 👍 the original comment (GA reactions header).
+    # 2. 👍 the original comment (GA reactions header). Non-fatal: a failed
+    #    reaction must NOT abort the all-important resolve step below — that
+    #    would leave the half-finished state (reply posted, thread open) this
+    #    tool exists to prevent. Warn and continue.
     if react:
-        _run([
+        res = _run([
             "api", "--method", "POST",
             f"repos/{owner}/{name}/pulls/comments/{comment_id}/reactions",
             "-H", "Accept: application/vnd.github+json", "-f", "content=+1",
-        ])
-        print("  ✓ 👍 reaction added")
+        ], check=False)
+        if res.returncode == 0:
+            print("  ✓ 👍 reaction added")
+        else:
+            detail = (res.stderr or res.stdout or "").strip()
+            print(f"  ⚠ 👍 reaction failed (continuing to resolve): {detail[:200]}")
     # 3. Resolve the thread (REST can't — GraphQL). Match the thread whose first
     #    comment is the cited (original) review comment.
     target = next(

--- a/scripts/ai/pr_review.py
+++ b/scripts/ai/pr_review.py
@@ -1,0 +1,233 @@
+#!/usr/bin/env python3
+"""Automate the repo's automated-PR-review protocol.
+
+Implements the *mechanical* half of the "Responding to Automated PR Reviews"
+policy in AGENTS.md so review rounds reliably end with **zero unresolved
+threads**:
+
+* ``status``  — list review threads (unresolved by default), paginated, with the
+  comment id, location, and body needed to act on each.
+* ``handle``  — reply in-thread + 👍 react + resolve a single thread, in one call.
+* ``verify``  — confirm 0 unresolved across all pages (exit 1 if any remain).
+
+The *judgment* half stays with the agent: verify each finding against the code,
+classify it real / partial / false-positive, and sweep the whole class before
+resolving (see AGENTS.md and .cursor/skills/audit-review/SKILL.md).
+
+Tool-agnostic: shells out to the authenticated ``gh`` CLI. Repo defaults to the
+current checkout (``gh repo view``); override with ``--repo owner/name`` to run
+against any repo.
+
+Examples:
+    python scripts/ai/pr_review.py status 212
+    python scripts/ai/pr_review.py handle 212 --comment 3369933169 \\
+        --body "Fixed in abc1234 — guarded the empty case."
+    python scripts/ai/pr_review.py verify 212
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+
+THREADS_QUERY = """query($owner:String!,$name:String!,$pr:Int!,$cursor:String){
+  repository(owner:$owner,name:$name){
+    pullRequest(number:$pr){
+      reviewThreads(first:100, after:$cursor){
+        pageInfo{ hasNextPage endCursor }
+        nodes{
+          id isResolved isOutdated
+          comments(first:1){ nodes{ databaseId author{login} path line originalLine body } }
+        }
+      }
+    }
+  }
+}"""
+
+RESOLVE_MUTATION = (
+    "mutation($tid:ID!){ resolveReviewThread(input:{threadId:$tid})"
+    "{ thread{ isResolved } } }"
+)
+
+
+def _run(args, check=True, input_text=None):
+    res = subprocess.run(
+        ["gh", *args], capture_output=True, text=True, input=input_text
+    )
+    if check and res.returncode != 0:
+        sys.stderr.write(res.stdout)
+        sys.stderr.write(res.stderr)
+        raise SystemExit(f"`gh {' '.join(args)}` failed (exit {res.returncode})")
+    return res
+
+
+def _json(args, input_text=None):
+    out = _run(args, input_text=input_text).stdout.strip()
+    return json.loads(out) if out else None
+
+
+def resolve_repo(repo):
+    if repo:
+        return repo
+    out = _run(
+        ["repo", "view", "--json", "nameWithOwner", "-q", ".nameWithOwner"]
+    ).stdout.strip()
+    if not out:
+        raise SystemExit("Could not determine repo; pass --repo owner/name")
+    return out
+
+
+def fetch_threads(repo, pr):
+    """Return all review-thread nodes for the PR, following pagination."""
+    owner, name = repo.split("/", 1)
+    cursor, nodes = None, []
+    while True:
+        args = [
+            "api", "graphql",
+            "-f", f"query={THREADS_QUERY}",
+            "-f", f"owner={owner}", "-f", f"name={name}", "-F", f"pr={pr}",
+        ]
+        if cursor:
+            args += ["-f", f"cursor={cursor}"]
+        data = _json(args)
+        rt = data["data"]["repository"]["pullRequest"]["reviewThreads"]
+        nodes.extend(rt["nodes"])
+        if rt["pageInfo"]["hasNextPage"]:
+            cursor = rt["pageInfo"]["endCursor"]
+        else:
+            return nodes
+
+
+def _first(thread):
+    nodes = thread.get("comments", {}).get("nodes", [])
+    return nodes[0] if nodes else {}
+
+
+def _loc(comment):
+    line = comment.get("line") or comment.get("originalLine") or "?"
+    return f"{comment.get('path', '?')}:{line}"
+
+
+def cmd_status(repo, pr, show_all):
+    threads = fetch_threads(repo, pr)
+    unresolved = [t for t in threads if not t["isResolved"]]
+    shown = threads if show_all else unresolved
+    print(f"PR #{pr} ({repo}): {len(threads)} thread(s), {len(unresolved)} unresolved")
+    if not shown:
+        print("  ✅ nothing to handle" if not show_all else "  (no threads)")
+        return 0
+    for t in shown:
+        c = _first(t)
+        state = "RESOLVED" if t["isResolved"] else "OPEN"
+        author = (c.get("author") or {}).get("login", "?")
+        body = " ".join((c.get("body") or "").split())
+        snippet = (body[:160] + "…") if len(body) > 160 else body
+        print(f"\n[{state}] {author} — {_loc(c)}  (comment id {c.get('databaseId')})")
+        print(f"  {snippet}")
+        if not t["isResolved"]:
+            print(
+                f"  → handle: python scripts/ai/pr_review.py handle {pr} "
+                f"--comment {c.get('databaseId')} --body \"<resolution + commit SHA>\""
+            )
+    return 0
+
+
+def cmd_verify(repo, pr):
+    threads = fetch_threads(repo, pr)
+    unresolved = [t for t in threads if not t["isResolved"]]
+    print(f"PR #{pr} ({repo}): {len(threads)} thread(s), {len(unresolved)} unresolved")
+    if unresolved:
+        for t in unresolved:
+            c = _first(t)
+            author = (c.get("author") or {}).get("login", "?")
+            print(f"  OPEN: {author} — {_loc(c)} (comment id {c.get('databaseId')})")
+        print("❌ NOT clean — unresolved threads remain")
+        return 1
+    print("✅ 0 unresolved")
+    return 0
+
+
+def cmd_handle(repo, pr, comment_id, body, react):
+    owner, name = repo.split("/", 1)
+    # 1. Reply in-thread (resolution + commit SHA, or an evidence-backed refutation).
+    _run([
+        "api", "--method", "POST",
+        f"repos/{owner}/{name}/pulls/{pr}/comments/{comment_id}/replies",
+        "-f", f"body={body}",
+    ])
+    print(f"  ✓ replied in-thread on comment {comment_id}")
+    # 2. 👍 the original comment (GA reactions header).
+    if react:
+        _run([
+            "api", "--method", "POST",
+            f"repos/{owner}/{name}/pulls/comments/{comment_id}/reactions",
+            "-H", "Accept: application/vnd.github+json", "-f", "content=+1",
+        ])
+        print("  ✓ 👍 reaction added")
+    # 3. Resolve the thread (REST can't — GraphQL). Match the thread whose first
+    #    comment is the cited (original) review comment.
+    target = next(
+        (t for t in fetch_threads(repo, pr)
+         if _first(t).get("databaseId") == int(comment_id)),
+        None,
+    )
+    if target is None:
+        print(
+            f"  ⚠ no thread found whose first comment is {comment_id} "
+            "(a reply id, or wrong PR?). Reply/react done; resolve manually."
+        )
+        return 1
+    if target["isResolved"]:
+        print("  ✓ thread already resolved")
+        return 0
+    data = _json([
+        "api", "graphql",
+        "-f", f"query={RESOLVE_MUTATION}", "-f", f"tid={target['id']}",
+    ])
+    ok = data["data"]["resolveReviewThread"]["thread"]["isResolved"]
+    print("  ✓ thread resolved" if ok else "  ⚠ resolve returned isResolved=false")
+    return 0 if ok else 1
+
+
+def main():
+    p = argparse.ArgumentParser(
+        description="Automate the repo's automated-PR-review protocol (see AGENTS.md)."
+    )
+    p.add_argument("--repo", help="owner/name (default: current repo via gh)")
+    sub = p.add_subparsers(dest="cmd", required=True)
+
+    s = sub.add_parser("status", help="list review threads (unresolved by default)")
+    s.add_argument("pr", type=int)
+    s.add_argument("--all", action="store_true", help="include resolved threads")
+
+    v = sub.add_parser("verify", help="confirm 0 unresolved (exit 1 if any remain)")
+    v.add_argument("pr", type=int)
+
+    h = sub.add_parser("handle", help="reply + 👍 + resolve one thread")
+    h.add_argument("pr", type=int)
+    h.add_argument("--comment", required=True, help="original review comment databaseId")
+    h.add_argument("--body", help="reply body (resolution + commit SHA, or refutation)")
+    h.add_argument("--body-file", help="read reply body from a file ('-' for stdin)")
+    h.add_argument("--no-react", action="store_true", help="skip the 👍 reaction")
+
+    a = p.parse_args()
+    repo = resolve_repo(a.repo)
+
+    if a.cmd == "status":
+        sys.exit(cmd_status(repo, a.pr, a.all))
+    if a.cmd == "verify":
+        sys.exit(cmd_verify(repo, a.pr))
+    if a.cmd == "handle":
+        body = a.body
+        if a.body_file:
+            body = sys.stdin.read() if a.body_file == "-" else open(
+                a.body_file, encoding="utf-8"
+            ).read()
+        if not body or not body.strip():
+            raise SystemExit("handle requires --body or --body-file")
+        sys.exit(cmd_handle(repo, a.pr, a.comment, body, react=not a.no_react))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Makes the repo's **"Responding to Automated PR Reviews"** policy (AGENTS.md) executable, so review rounds reliably end at **zero unresolved threads** without the manual gh/GraphQL toil.

## What's added
- **`scripts/ai/pr_review.py`** — tool-agnostic helper (shells out to `gh`, any agent can call it):
  - `status <pr>` — list unresolved review threads (paginated), with comment id / location / snippet
  - `handle <pr> --comment <id> --body "…"` — reply in-thread + 👍 + resolve the thread, in one call
  - `verify <pr>` — confirm 0 unresolved across all pages (exit 1 if any remain)
  - defaults to the current repo; `--repo owner/name` to target any repo
- **`.claude/commands/pr-review.md`** — `/pr-review <pr>` drives the full protocol with the script: verify each finding against the code → sweep the class → `handle` each → `verify` clean
- **Wiring** — AGENTS.md ("Responding to Automated PR Reviews" + AI Utility Scripts) and `.cursor/skills/audit-review/SKILL.md` now point to the helper/command
- **`.gitignore`** — un-ignore `.claude/commands/` so shared slash commands are tracked (local files like `settings.local.json` stay ignored)

## Division of labor
The script does the **mechanical** half (list / reply+👍+resolve / paginated 0-check). The **judgment** half stays with the agent: verify each finding real/partial/false-positive and sweep the whole class before resolving.

## Validation
`status` / `verify` tested read-only against #207 (4 threads, 0 unresolved) and #208 — pagination + parsing confirmed. `handle` mirrors the exact reply/react/resolve calls used across the 262→main review rounds; not live-tested to avoid mutating a real PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)