### PR TITLE
fix(scratch): durable repair for SF CLI isScratch=false on EE scratch orgs

### DIFF
--- a/.cursor/skills/cci-orchestration/feature-flags.md
+++ b/.cursor/skills/cci-orchestration/feature-flags.md
@@ -118,8 +118,8 @@ Boolean flags that gate task/flow execution via `when:` clauses.
 
 ### `breconfig` (default: `False`)
 
-- `prepare_core` step 14 → `create_rule_library`
-- `prepare_core` step 15 → `create_dro_rule_library`
+- `prepare_core` step 15 → `create_rule_library`
+- `prepare_core` step 16 → `create_dro_rule_library`
 
 ### `calmdelete` (default: `True`)
 
@@ -178,7 +178,7 @@ Boolean flags that gate task/flow execution via `when:` clauses.
 
 ### `dro` (default: `True`)
 
-- `prepare_core` step 15 → `create_dro_rule_library`
+- `prepare_core` step 16 → `create_dro_rule_library`
 - `extend_context_definitions` step 6 → `extend_context_fulfillment_asset`
 - `prepare_dro` step 1 → `manage_fulfillment_scope_cnfg`
 - `prepare_dro` step 2 → `insert_qb_dro_data`
@@ -360,8 +360,8 @@ Boolean flags that gate task/flow execution via `when:` clauses.
 
 ### `tso` (default: `False`)
 
-- `prepare_core` step 11 → `recalculate_permission_set_groups`
-- `prepare_core` step 12 → `assign_permission_set_groups_tolerant`
+- `prepare_core` step 12 → `recalculate_permission_set_groups`
+- `prepare_core` step 13 → `assign_permission_set_groups_tolerant`
 - `assign_feature_psls` step 4 → `assign_permission_set_licenses`
 - `assign_feature_permission_sets` step 1 → `assign_permission_sets`
 - `prepare_tso` step 1 → `assign_permission_set_groups`
@@ -384,7 +384,8 @@ Boolean flags that gate task/flow execution via `when:` clauses.
 
 ### `org_config.scratch` (runtime)
 
-- `prepare_core` step 1 → `set_scratch_org_password`
+- `prepare_core` step 1 → `fix_scratch_org_identity`
+- `prepare_core` step 2 → `set_scratch_org_password`
 - `prepare_dro` step 3 → `insert_q3_dro_data_scratch`
 - `prepare_dro` step 4 → `insert_q3_dro_data_prod`
 

--- a/.cursor/skills/cci-orchestration/flows-reference.md
+++ b/.cursor/skills/cci-orchestration/flows-reference.md
@@ -234,27 +234,28 @@ Create Self-Service Billing Portal community and optionally deploy site content.
 
 **Steps:**
 
-1. **task** `set_scratch_org_password`  `when: org_config.scratch`
-2. **task** `validate_setup`
-3. **task** `assign_permission_set_licenses`
+1. **task** `fix_scratch_org_identity`  `when: org_config.scratch`
+2. **task** `set_scratch_org_password`  `when: org_config.scratch`
+3. **task** `validate_setup`
+4. **task** `assign_permission_set_licenses`
    - `api_names`: `['BREDesigner', 'BRERuntime', 'CorePricingDesignTime', 'DataProcessingEnginePsl', 'DecimalQuantit...`
-4. **task** `cleanup_settings_for_dev`
-5. **task** `exclude_active_decision_tables`
-6. **task** `deploy_pre`
-7. **task** `restore_decision_tables`
-8. **flow** `assign_feature_psls`
-9. **task** `recalculate_permission_set_groups`
+5. **task** `cleanup_settings_for_dev`
+6. **task** `exclude_active_decision_tables`
+7. **task** `deploy_pre`
+8. **task** `restore_decision_tables`
+9. **flow** `assign_feature_psls`
+10. **task** `recalculate_permission_set_groups`
    - `api_names`: `['RLM_QB_AI', 'RLM_RCB', 'RLM_RMI', 'RLM_CFG', 'RLM_CLM', 'RLM_DOC', 'RLM_DRO', 'RLM_NGP', 'RLM_P...`
-10. **task** `assign_permission_set_groups_tolerant`
+11. **task** `assign_permission_set_groups_tolerant`
    - `api_names`: `['RLM_QB_AI', 'RLM_RCB', 'RLM_RMI', 'RLM_CFG', 'RLM_CLM', 'RLM_DOC', 'RLM_DRO', 'RLM_NGP', 'RLM_P...`
-11. **task** `recalculate_permission_set_groups`  `when: project_config.project__custom__tso`
+12. **task** `recalculate_permission_set_groups`  `when: project_config.project__custom__tso`
    - `api_names`: `['RLM_TSO']`
-12. **task** `assign_permission_set_groups_tolerant`  `when: project_config.project__custom__tso`
+13. **task** `assign_permission_set_groups_tolerant`  `when: project_config.project__custom__tso`
    - `api_names`: `['RLM_TSO']`
-13. **flow** `extend_context_definitions`
-14. **task** `create_rule_library`  `when: project_config.project__custom__breconfig`
-15. **task** `create_dro_rule_library`  `when: project_config.project__custom__dro and project_config.project__custom__breconfig`
-16. **flow** `assign_feature_permission_sets`
+14. **flow** `extend_context_definitions`
+15. **task** `create_rule_library`  `when: project_config.project__custom__breconfig`
+16. **task** `create_dro_rule_library`  `when: project_config.project__custom__dro and project_config.project__custom__breconfig`
+17. **flow** `assign_feature_permission_sets`
 
 ---
 

--- a/.cursor/skills/cci-orchestration/tasks-reference.md
+++ b/.cursor/skills/cci-orchestration/tasks-reference.md
@@ -3,7 +3,7 @@
 > **Auto-generated** by `scripts/ai/generate_cci_reference.py` from `cumulusci.yml`.  
 > Do not edit manually — re-run the script after changing `cumulusci.yml`.
 
-**222 tasks** across **10 groups**.
+**223 tasks** across **10 groups**.
 
 ---
 
@@ -770,7 +770,7 @@
 
 ## Revenue Lifecycle Management
 
-*135 task(s)*
+*136 task(s)*
 
 ### `activate_and_deploy_expression_sets`
 
@@ -1608,6 +1608,7 @@
 - `contextTtl`: `30`
 - `defaultMapping`: `BSGEntitiesMapping`
 - `activate`: `True`
+- `allow_skip_if_unavailable`: `True`
 
 ---
 
@@ -1627,6 +1628,7 @@
 - `contextTtl`: `30`
 - `defaultMapping`: `CommerceCartMapping`
 - `activate`: `True`
+- `allow_skip_if_unavailable`: `True`
 
 ---
 
@@ -1646,6 +1648,7 @@
 - `contextTtl`: `30`
 - `defaultMapping`: `CollectionPlanContextMapping`
 - `activate`: `True`
+- `allow_skip_if_unavailable`: `True`
 
 ---
 
@@ -1665,6 +1668,7 @@
 - `contextTtl`: `30`
 - `defaultMapping`: `OppToCntrPersistenceMapping`
 - `activate`: `True`
+- `allow_skip_if_unavailable`: `True`
 
 ---
 
@@ -1684,6 +1688,7 @@
 - `contextTtl`: `30`
 - `defaultMapping`: `DocExtrctPersistenceMapping`
 - `activate`: `True`
+- `allow_skip_if_unavailable`: `True`
 
 ---
 
@@ -1703,6 +1708,7 @@
 - `contextTtl`: `30`
 - `defaultMapping`: `FulfillAssetEntitiesMapping`
 - `activate`: `True`
+- `allow_skip_if_unavailable`: `True`
 
 ---
 
@@ -1741,6 +1747,7 @@
 - `contextTtl`: `30`
 - `defaultMapping`: `DefaultUsageMapping`
 - `activate`: `True`
+- `allow_skip_if_unavailable`: `True`
 
 ---
 
@@ -1760,6 +1767,7 @@
 - `contextTtl`: `30`
 - `defaultMapping`: `CatalogMapping`
 - `activate`: `True`
+- `allow_skip_if_unavailable`: `True`
 
 ---
 
@@ -1807,6 +1815,14 @@
 **Description:** Corrects DocumentTemplate ContentDocument binaries after a batch metadata deploy. Salesforce metadata API bug: all DocumentTemplates deployed in a single batch receive the same ContentDocument binary (first alphabetically). This task uploads the correct .dt binary from the repo for each RLM_ template, replacing the wrong ContentDocument content. Run after deploy_post_docgen + activate_docgen_templates.
 
 **Class:** `tasks.rlm_docgen.FixDocumentTemplateBinaries`
+
+---
+
+### `fix_scratch_org_identity`
+
+**Description:** Repair scratch-org identity in the local SF CLI auth file. Works around an SF CLI bug where Enterprise-Edition scratch orgs created via the DevHub API get isScratch=false in ~/.sfdx/<username>.json, making scratch-only commands (sf org create user, sf org generate password) fail with NonScratchOrgError. Flips isScratch false->true only when a devHubUsername is present. Idempotent; warns and continues on failure unless raise_on_failure is set.
+
+**Class:** `tasks.rlm_fix_scratch_identity.FixScratchOrgIdentity`
 
 ---
 

--- a/.cursor/skills/cci-orchestration/tasks-reference.md
+++ b/.cursor/skills/cci-orchestration/tasks-reference.md
@@ -1820,7 +1820,7 @@
 
 ### `fix_scratch_org_identity`
 
-**Description:** Repair scratch-org identity in the local SF CLI auth file. Works around an SF CLI bug where Enterprise-Edition scratch orgs created via the DevHub API get isScratch=false in ~/.sfdx/<username>.json, making scratch-only commands (sf org create user, sf org generate password) fail with NonScratchOrgError. Flips isScratch false->true only when a devHubUsername is present. Idempotent; warns and continues on failure unless raise_on_failure is set.
+**Description:** Repair scratch-org identity in the local SF CLI auth file. Works around an SF CLI bug where Enterprise-Edition scratch orgs created via the DevHub API get isScratch=false in ~/.sfdx/<username>.json, making scratch-only commands (sf org create user, sf org generate password) fail with NonScratchOrgError. Sets isScratch=true (when false or missing) only when a devHubUsername is present. Idempotent; warns and continues on failure unless raise_on_failure is set.
 
 **Class:** `tasks.rlm_fix_scratch_identity.FixScratchOrgIdentity`
 

--- a/.cursor/skills/troubleshooting/SKILL.md
+++ b/.cursor/skills/troubleshooting/SKILL.md
@@ -88,6 +88,33 @@ sf org list               # shows sf aliases (rlm-base__* prefix)
 cci org info beta         # shows username, instance URL
 ```
 
+### `NonScratchOrgError` ("This command works with only scratch orgs")
+
+**Symptom:** a scratch-only SF CLI command — most often `sf org create user`
+(the `create_persona_user` task in `prepare_personas`), but also
+`sf org generate password` — fails with `NonScratchOrgError` against an org you
+created as a scratch org. Common on **Enterprise-Edition / "ent"** shapes
+(e.g. `orgs/internal/ent-r1.json`).
+
+**Cause:** an SF CLI bug — EE scratch orgs created via the DevHub API get
+`"isScratch": false` written to the local auth file
+(`~/.sfdx/<username>.json`) even though they are real scratch orgs (valid
+`devHubUsername`, listed under `scratchOrgs` in `sf org list`). The CLI then
+refuses scratch-only commands. CCI's own `org_config.scratch` is unaffected, so
+**`prepare_rlm_org` self-heals** — `prepare_core` step 1 runs
+`fix_scratch_org_identity` before any scratch-only CLI command.
+
+**Fix (standalone, when running CLI commands outside the flow):**
+
+```bash
+cci org default ent-r1                      # this CCI build uses the default org (no --org)
+cci task run fix_scratch_org_identity        # flips isScratch false->true when devHubUsername is present
+```
+
+The task is idempotent (no-op when already correct) and only flips
+`false -> true` when the auth file has a `devHubUsername` (so it never
+mis-tags a real non-scratch org).
+
 ---
 
 ## SFDMU Data Loading Errors

--- a/.cursor/skills/troubleshooting/SKILL.md
+++ b/.cursor/skills/troubleshooting/SKILL.md
@@ -91,7 +91,7 @@ cci org info beta         # shows username, instance URL
 ### `NonScratchOrgError` ("This command works with only scratch orgs")
 
 **Symptom:** a scratch-only SF CLI command — most often `sf org create user`
-(the `create_persona_user` task in `prepare_personas`), but also
+(the `create_personas_sales_rep_user` task in `prepare_personas`), but also
 `sf org generate password` — fails with `NonScratchOrgError` against an org you
 created as a scratch org. Common on **Enterprise-Edition / "ent"** shapes
 (e.g. `orgs/internal/ent-r1.json`).
@@ -108,12 +108,12 @@ refuses scratch-only commands. CCI's own `org_config.scratch` is unaffected, so
 
 ```bash
 cci org default ent-r1                      # this CCI build uses the default org (no --org)
-cci task run fix_scratch_org_identity        # flips isScratch false->true when devHubUsername is present
+cci task run fix_scratch_org_identity        # sets isScratch=true (when false or missing) if devHubUsername is present
 ```
 
-The task is idempotent (no-op when already correct) and only flips
-`false -> true` when the auth file has a `devHubUsername` (so it never
-mis-tags a real non-scratch org).
+The task is idempotent (no-op when already correct) and only sets
+`isScratch=true` (when it is false or missing) when the auth file has a
+`devHubUsername` (so it never mis-tags a real non-scratch org).
 
 ---
 

--- a/cumulusci.yml
+++ b/cumulusci.yml
@@ -2510,8 +2510,8 @@ tasks:
       SF CLI bug where Enterprise-Edition scratch orgs created via the DevHub API
       get isScratch=false in ~/.sfdx/<username>.json, making scratch-only commands
       (sf org create user, sf org generate password) fail with NonScratchOrgError.
-      Flips isScratch false->true only when a devHubUsername is present. Idempotent;
-      warns and continues on failure unless raise_on_failure is set.
+      Sets isScratch=true (when false or missing) only when a devHubUsername is
+      present. Idempotent; warns and continues on failure unless raise_on_failure is set.
     class_path: tasks.rlm_fix_scratch_identity.FixScratchOrgIdentity
 
   manage_decision_tables:
@@ -3048,10 +3048,11 @@ flows:
     group: Revenue Lifecycle Management
     steps:
       1:
-        # Repair isScratch=false on EE scratch orgs (SF CLI bug) before any
-        # scratch-only CLI command runs. In this flow that's create_persona_user
-        # (sf org create user, step in prepare_personas), which would otherwise
-        # fail with NonScratchOrgError; also covers manual scratch-only commands.
+        # Repair isScratch (false or missing) on EE scratch orgs (SF CLI bug)
+        # before any scratch-only CLI command runs. In this flow that's the
+        # create_personas_sales_rep_user task (sf org create user, in
+        # prepare_personas), which would otherwise fail with NonScratchOrgError;
+        # also covers manual scratch-only commands.
         task: fix_scratch_org_identity
         when: org_config.scratch
       2:

--- a/cumulusci.yml
+++ b/cumulusci.yml
@@ -2503,6 +2503,17 @@ tasks:
     description: Rebuild the Product Catalog (PCM) search index via Connect API (FULL, IMMEDIATE). Asynchronous - initiates the build and logs the snapshot id. Warns and continues on API failure unless raise_on_failure is set.
     class_path: tasks.rlm_rebuild_search_index.RebuildSearchIndex
 
+  fix_scratch_org_identity:
+    group: Revenue Lifecycle Management
+    description: >
+      Repair scratch-org identity in the local SF CLI auth file. Works around an
+      SF CLI bug where Enterprise-Edition scratch orgs created via the DevHub API
+      get isScratch=false in ~/.sfdx/<username>.json, making scratch-only commands
+      (sf org create user, sf org generate password) fail with NonScratchOrgError.
+      Flips isScratch false->true only when a devHubUsername is present. Idempotent;
+      warns and continues on failure unless raise_on_failure is set.
+    class_path: tasks.rlm_fix_scratch_identity.FixScratchOrgIdentity
+
   manage_decision_tables:
     group: Revenue Lifecycle Management
     description: "Decision Table management: list (with UsageType), query, refresh, activate, deactivate, validate_lists (compare org to project list anchors)"
@@ -3037,54 +3048,61 @@ flows:
     group: Revenue Lifecycle Management
     steps:
       1:
-        task: set_scratch_org_password
+        # Repair isScratch=false on EE scratch orgs (SF CLI bug) before any
+        # scratch-only CLI command runs. In this flow that's create_persona_user
+        # (sf org create user, step in prepare_personas), which would otherwise
+        # fail with NonScratchOrgError; also covers manual scratch-only commands.
+        task: fix_scratch_org_identity
         when: org_config.scratch
       2:
-        task: validate_setup
+        task: set_scratch_org_password
+        when: org_config.scratch
       3:
+        task: validate_setup
+      4:
         task: assign_permission_set_licenses
         options:
           api_names: *rlm_psl_api_names
-      4:
+      5:
         task: cleanup_settings_for_dev
         #when: org_config.scratch
-      5:
+      6:
         task: exclude_active_decision_tables
         #when: org_config.scratch
-      6:
-        task: deploy_pre
       7:
+        task: deploy_pre
+      8:
         task: restore_decision_tables
         #when: org_config.scratch
-      8:
-        flow: assign_feature_psls
       9:
-        task: recalculate_permission_set_groups
-        options:
-          api_names: *rlm_psg_api_names
+        flow: assign_feature_psls
       10:
-        task: assign_permission_set_groups_tolerant
+        task: recalculate_permission_set_groups
         options:
           api_names: *rlm_psg_api_names
       11:
-        task: recalculate_permission_set_groups
-        when: project_config.project__custom__tso
-        options:
-          api_names: *psg_tso
-      12:
         task: assign_permission_set_groups_tolerant
+        options:
+          api_names: *rlm_psg_api_names
+      12:
+        task: recalculate_permission_set_groups
         when: project_config.project__custom__tso
         options:
           api_names: *psg_tso
       13:
-        flow: extend_context_definitions
+        task: assign_permission_set_groups_tolerant
+        when: project_config.project__custom__tso
+        options:
+          api_names: *psg_tso
       14:
+        flow: extend_context_definitions
+      15:
         task: create_rule_library
         when: project_config.project__custom__breconfig
-      15:
+      16:
         task: create_dro_rule_library
         when: project_config.project__custom__dro and project_config.project__custom__breconfig
-      16:
+      17:
         flow: assign_feature_permission_sets
 
   assign_feature_psls:

--- a/tasks/rlm_fix_scratch_identity.py
+++ b/tasks/rlm_fix_scratch_identity.py
@@ -99,15 +99,25 @@ class FixScratchOrgIdentity(BaseTask):
                 # warns so an unreadable auth file is never swallowed silently.
                 self._fail_or_warn(f"Could not process auth file {path}: {exc}")
 
-        if patched:
+        if errors:
+            # Errors were already warned per-file above; make the summary reflect
+            # them too, even when some files were patched, so a partial repair is
+            # never mistaken for a full one.
+            if patched:
+                self.logger.warning(
+                    f"Scratch-org identity PARTIALLY repaired for {username}: "
+                    f"set isScratch=true in {patched} file(s), but {errors} "
+                    f"file(s) could not be processed (see warnings above)."
+                )
+            else:
+                self.logger.warning(
+                    f"Scratch-org identity NOT verified for {username}: "
+                    f"{errors} auth file(s) could not be processed (see warnings above)."
+                )
+        elif patched:
             self.logger.info(
                 f"Scratch-org identity repaired: set isScratch=true in "
                 f"{patched} auth file(s) for {username}."
-            )
-        elif errors:
-            self.logger.warning(
-                f"Scratch-org identity NOT verified for {username}: "
-                f"{errors} auth file(s) could not be processed (see warnings above)."
             )
         else:
             self.logger.info(
@@ -196,18 +206,14 @@ class FixScratchOrgIdentity(BaseTask):
 
     @staticmethod
     def _atomic_write(path, data):
-        """Write JSON to ``path`` atomically with owner-only permissions.
+        """Write JSON to ``path`` atomically with 0600 (owner-only) permissions.
 
-        Auth files hold credentials, so we never widen access beyond the owner:
-        all group/other bits are dropped and owner read/write is guaranteed,
-        regardless of the file's prior (possibly lax, e.g. 0644) mode.
+        Auth files hold credentials, so the result is forced to exactly 0600
+        (owner read/write — no group/other access and no execute bit)
+        regardless of the file's prior (possibly lax, e.g. 0644 or 0700) mode.
         """
-        try:
-            mode = os.stat(path).st_mode & 0o777
-        except OSError:
-            mode = 0o600
-        # Restrict to the owner: clear group/other bits, ensure owner can rw.
-        mode = (mode & 0o700) | 0o600
+        # Force exactly 0600; never carry over the prior mode for a creds file.
+        mode = 0o600
         directory = os.path.dirname(str(path)) or "."
         fd, tmp = tempfile.mkstemp(prefix=".rlm_auth_", dir=directory)
         try:

--- a/tasks/rlm_fix_scratch_identity.py
+++ b/tasks/rlm_fix_scratch_identity.py
@@ -217,10 +217,15 @@ class FixScratchOrgIdentity(BaseTask):
         directory = os.path.dirname(str(path)) or "."
         fd, tmp = tempfile.mkstemp(prefix=".rlm_auth_", dir=directory)
         try:
-            os.fchmod(fd, mode)
+            # Restrict perms before writing secrets. os.fchmod is POSIX-only;
+            # fall back to os.chmod(path) on platforms without it (e.g. Windows).
+            if hasattr(os, "fchmod"):
+                os.fchmod(fd, mode)
             with os.fdopen(fd, "w", encoding="utf-8") as fh:
                 json.dump(data, fh, indent=2)
                 fh.write("\n")
+            if not hasattr(os, "fchmod"):
+                os.chmod(tmp, mode)
             os.replace(tmp, str(path))
         except BaseException:
             # Clean up the temp file on any failure; never leave a stray.

--- a/tasks/rlm_fix_scratch_identity.py
+++ b/tasks/rlm_fix_scratch_identity.py
@@ -226,16 +226,19 @@ class FixScratchOrgIdentity(BaseTask):
         fd, tmp = tempfile.mkstemp(prefix=".rlm_auth_", dir=directory)
         fd_open = True  # we still own fd until os.fdopen takes it over
         try:
-            # Restrict perms before writing secrets. os.fchmod is POSIX-only;
-            # fall back to os.chmod(path) on platforms without it (e.g. Windows).
+            # Restrict perms BEFORE writing any secrets — never leave a window
+            # where the file is readable while credentials are on disk. os.fchmod
+            # is POSIX-only; fall back to os.chmod(path) on platforms without it
+            # (e.g. Windows). mkstemp already creates the file 0600 on POSIX; this
+            # enforces it explicitly on both paths.
             if hasattr(os, "fchmod"):
                 os.fchmod(fd, mode)
+            else:
+                os.chmod(tmp, mode)
             with os.fdopen(fd, "w", encoding="utf-8") as fh:
                 fd_open = False  # fdopen now owns fd and closes it on exit
                 json.dump(data, fh, indent=2)
                 fh.write("\n")
-            if not hasattr(os, "fchmod"):
-                os.chmod(tmp, mode)
             os.replace(tmp, str(path))
         except BaseException:
             # On any failure: close fd if fdopen never took ownership (e.g.

--- a/tasks/rlm_fix_scratch_identity.py
+++ b/tasks/rlm_fix_scratch_identity.py
@@ -88,18 +88,26 @@ class FixScratchOrgIdentity(BaseTask):
             )
             return
 
-        patched = 0
+        patched, errors = 0, 0
         for path in auth_files:
             try:
                 if self._repair_file(path):
                     patched += 1
             except Exception as exc:  # noqa: BLE001 - report per-file, keep going
+                errors += 1
+                # _fail_or_warn raises when raise_on_failure is set; otherwise
+                # warns so an unreadable auth file is never swallowed silently.
                 self._fail_or_warn(f"Could not process auth file {path}: {exc}")
 
         if patched:
             self.logger.info(
                 f"Scratch-org identity repaired: set isScratch=true in "
                 f"{patched} auth file(s) for {username}."
+            )
+        elif errors:
+            self.logger.warning(
+                f"Scratch-org identity NOT verified for {username}: "
+                f"{errors} auth file(s) could not be processed (see warnings above)."
             )
         else:
             self.logger.info(
@@ -141,16 +149,22 @@ class FixScratchOrgIdentity(BaseTask):
     # ------------------------------------------------------------------
 
     def _repair_file(self, path):
-        """Patch a single auth file. Returns True if it was changed."""
+        """Patch a single auth file. Returns True if it was changed.
+
+        Raises on an unreadable / non-JSON / non-object auth file so the caller
+        can surface it (warn, or raise when raise_on_failure is set) instead of
+        silently reporting "already correct" when the repair never actually ran.
+        """
         try:
-            data = json.loads(path.read_text(encoding="utf-8"))
-        except (json.JSONDecodeError, UnicodeDecodeError) as exc:
-            # Encrypted/unreadable auth file — not something we can safely edit.
-            self.logger.debug(f"Skipping unreadable auth file {path}: {exc}")
-            return False
+            raw = path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError) as exc:
+            raise RuntimeError(f"cannot read auth file: {exc}") from exc
+        try:
+            data = json.loads(raw)
+        except json.JSONDecodeError as exc:
+            raise RuntimeError(f"auth file is not valid JSON: {exc}") from exc
         if not isinstance(data, dict):
-            self.logger.debug(f"Skipping auth file {path}: not a JSON object.")
-            return False
+            raise RuntimeError("auth file is not a JSON object")
 
         if data.get("isScratch") is True:
             self.logger.debug(f"{path}: isScratch already true.")
@@ -182,19 +196,22 @@ class FixScratchOrgIdentity(BaseTask):
 
     @staticmethod
     def _atomic_write(path, data):
-        """Write JSON to ``path`` atomically, preserving restrictive perms.
+        """Write JSON to ``path`` atomically with owner-only permissions.
 
-        Auth files hold credentials, so the temp file is created 0600 and we
-        carry over the original mode when available before the atomic replace.
+        Auth files hold credentials, so we never widen access beyond the owner:
+        all group/other bits are dropped and owner read/write is guaranteed,
+        regardless of the file's prior (possibly lax, e.g. 0644) mode.
         """
         try:
             mode = os.stat(path).st_mode & 0o777
         except OSError:
             mode = 0o600
+        # Restrict to the owner: clear group/other bits, ensure owner can rw.
+        mode = (mode & 0o700) | 0o600
         directory = os.path.dirname(str(path)) or "."
         fd, tmp = tempfile.mkstemp(prefix=".rlm_auth_", dir=directory)
         try:
-            os.fchmod(fd, mode or 0o600)
+            os.fchmod(fd, mode)
             with os.fdopen(fd, "w", encoding="utf-8") as fh:
                 json.dump(data, fh, indent=2)
                 fh.write("\n")

--- a/tasks/rlm_fix_scratch_identity.py
+++ b/tasks/rlm_fix_scratch_identity.py
@@ -37,7 +37,11 @@ try:
     from cumulusci.core.exceptions import TaskOptionsError
 except ImportError:
     BaseTask = object
-    TaskOptionsError = Exception
+
+    class TaskOptionsError(Exception):
+        """Dedicated fallback when CumulusCI is unavailable (e.g. stdlib-only
+        test runs). A distinct type — not bare ``Exception`` — so callers and
+        tests that ``except TaskOptionsError`` catch only intended failures."""
 
 
 class FixScratchOrgIdentity(BaseTask):
@@ -216,19 +220,27 @@ class FixScratchOrgIdentity(BaseTask):
         mode = 0o600
         directory = os.path.dirname(str(path)) or "."
         fd, tmp = tempfile.mkstemp(prefix=".rlm_auth_", dir=directory)
+        fd_open = True  # we still own fd until os.fdopen takes it over
         try:
             # Restrict perms before writing secrets. os.fchmod is POSIX-only;
             # fall back to os.chmod(path) on platforms without it (e.g. Windows).
             if hasattr(os, "fchmod"):
                 os.fchmod(fd, mode)
             with os.fdopen(fd, "w", encoding="utf-8") as fh:
+                fd_open = False  # fdopen now owns fd and closes it on exit
                 json.dump(data, fh, indent=2)
                 fh.write("\n")
             if not hasattr(os, "fchmod"):
                 os.chmod(tmp, mode)
             os.replace(tmp, str(path))
         except BaseException:
-            # Clean up the temp file on any failure; never leave a stray.
+            # On any failure: close fd if fdopen never took ownership (e.g.
+            # os.fchmod raised) so we don't leak it, then remove the temp file.
+            if fd_open:
+                try:
+                    os.close(fd)
+                except OSError:
+                    pass
             try:
                 os.unlink(tmp)
             except OSError:

--- a/tasks/rlm_fix_scratch_identity.py
+++ b/tasks/rlm_fix_scratch_identity.py
@@ -101,7 +101,11 @@ class FixScratchOrgIdentity(BaseTask):
                 errors += 1
                 # _fail_or_warn raises when raise_on_failure is set; otherwise
                 # warns so an unreadable auth file is never swallowed silently.
-                self._fail_or_warn(f"Could not process auth file {path}: {exc}")
+                # Pass cause=exc so the raised error chains the original
+                # traceback (JSONDecodeError, etc.) for easier debugging.
+                self._fail_or_warn(
+                    f"Could not process auth file {path}: {exc}", cause=exc
+                )
 
         if errors:
             # Errors were already warned per-file above; make the summary reflect
@@ -251,7 +255,10 @@ class FixScratchOrgIdentity(BaseTask):
     # Error handling
     # ------------------------------------------------------------------
 
-    def _fail_or_warn(self, message):
+    def _fail_or_warn(self, message, cause=None):
         if self.options.get("raise_on_failure"):
-            raise TaskOptionsError(message)
+            # Chain the originating exception (when there is one) so the
+            # traceback/cause is preserved, per the repo's `raise ... from exc`
+            # convention. cause=None at non-exception call sites is harmless.
+            raise TaskOptionsError(message) from cause
         self.logger.warning(message)

--- a/tasks/rlm_fix_scratch_identity.py
+++ b/tasks/rlm_fix_scratch_identity.py
@@ -147,9 +147,14 @@ class FixScratchOrgIdentity(BaseTask):
         candidates = [home / ".sfdx" / f"{username}.json"]
         sf_dir = home / ".sf"
         if sf_dir.is_dir():
+            # Escape the directory prefix and the filename so any glob
+            # metacharacters in the path or username (e.g. "[") are matched
+            # literally; only the "**" segment stays a recursive wildcard.
+            pattern = os.path.join(
+                glob.escape(str(sf_dir)), "**", glob.escape(f"{username}.json")
+            )
             candidates += [
-                Path(p)
-                for p in glob.glob(str(sf_dir / "**" / f"{username}.json"), recursive=True)
+                Path(p) for p in glob.glob(pattern, recursive=True)
             ]
         # De-dupe while preserving order; keep only files that exist.
         seen, found = set(), []

--- a/tasks/rlm_fix_scratch_identity.py
+++ b/tasks/rlm_fix_scratch_identity.py
@@ -8,7 +8,7 @@ scratch orgs (valid ``devHubUsername``, present in ``sf org list`` scratchOrgs).
 The SF CLI then rejects scratch-only commands against them with
 NonScratchOrgError, e.g.:
 
-* ``sf org create user``        (this repo: the create_persona_user task)
+* ``sf org create user``        (this repo: the create_personas_sales_rep_user task)
 * ``sf org generate password``  (a developer running it manually)
 
 This task reads the org's auth file(s), and when ``isScratch`` is false/missing
@@ -47,9 +47,10 @@ except ImportError:
 class FixScratchOrgIdentity(BaseTask):
     """Ensure a CCI-created scratch org is marked ``isScratch: true`` locally.
 
-    Safe and idempotent: only flips ``false -> true`` when the auth file has a
-    ``devHubUsername`` and is not itself a DevHub or sandbox. Never flips
-    ``true -> false``. Non-fatal by default.
+    Safe and idempotent: sets ``isScratch`` to true when it is false *or
+    missing*, only when the auth file has a ``devHubUsername`` and is not itself
+    a DevHub or sandbox. Never sets a true flag back to false. Non-fatal by
+    default.
     """
 
     task_options = {

--- a/tasks/rlm_fix_scratch_identity.py
+++ b/tasks/rlm_fix_scratch_identity.py
@@ -1,0 +1,217 @@
+"""
+CumulusCI task to repair scratch-org identity in the local Salesforce CLI auth file.
+
+Works around an SF CLI v2.x bug where Enterprise-Edition ("ent"/workspace)
+scratch orgs created via the DevHub API are written to the local auth file
+(``~/.sfdx/<username>.json``) with ``isScratch: false`` even though they are real
+scratch orgs (valid ``devHubUsername``, present in ``sf org list`` scratchOrgs).
+The SF CLI then rejects scratch-only commands against them with
+NonScratchOrgError, e.g.:
+
+* ``sf org create user``        (this repo: the create_persona_user task)
+* ``sf org generate password``  (a developer running it manually)
+
+This task reads the org's auth file(s), and when ``isScratch`` is false/missing
+*but* a ``devHubUsername`` is present (i.e. it really is a scratch org), flips
+``isScratch`` to true and writes the file back atomically (preserving 0600
+permissions). It is idempotent (a no-op when the flag is already correct) and
+non-fatal by default (warns and continues), so it is safe to run as the first
+step of a build flow or standalone.
+
+Usage:
+    In cumulusci.yml (as the first step of prepare_core, gated on scratch):
+        fix_scratch_org_identity:
+            class_path: tasks.rlm_fix_scratch_identity.FixScratchOrgIdentity
+
+    Command line (one-off repair before `sf org create user` etc.):
+        cci task run fix_scratch_org_identity --org ent-r1
+"""
+import glob
+import json
+import os
+import tempfile
+from pathlib import Path
+
+try:
+    from cumulusci.core.tasks import BaseTask
+    from cumulusci.core.exceptions import TaskOptionsError
+except ImportError:
+    BaseTask = object
+    TaskOptionsError = Exception
+
+
+class FixScratchOrgIdentity(BaseTask):
+    """Ensure a CCI-created scratch org is marked ``isScratch: true`` locally.
+
+    Safe and idempotent: only flips ``false -> true`` when the auth file has a
+    ``devHubUsername`` and is not itself a DevHub or sandbox. Never flips
+    ``true -> false``. Non-fatal by default.
+    """
+
+    task_options = {
+        "raise_on_failure": {
+            "description": (
+                "Raise if no auth file is found or a file cannot be read/written. "
+                "Defaults to False (warn and continue) so a healthy build is never "
+                "broken by this best-effort repair."
+            ),
+            "required": False,
+            "type": bool,
+        },
+    }
+
+    def _run_task(self):
+        if not getattr(self, "org_config", None):
+            self._fail_or_warn("No org config available; nothing to repair.")
+            return
+
+        # CCI's own scratch flag is independent of the CLI's isScratch flag.
+        # If CCI doesn't consider this a scratch org, do nothing (the flow gate
+        # should already prevent this, but guard defensively).
+        if not getattr(self.org_config, "scratch", False):
+            self.logger.info(
+                "Org is not a CCI scratch org (org_config.scratch is false); "
+                "skipping scratch-identity repair."
+            )
+            return
+
+        username = getattr(self.org_config, "username", None)
+        if not username:
+            self._fail_or_warn("Org config has no username; cannot locate auth file.")
+            return
+
+        auth_files = self._find_auth_files(username)
+        if not auth_files:
+            self._fail_or_warn(
+                f"No local SF CLI auth file found for {username} "
+                f"(looked in ~/.sfdx and ~/.sf)."
+            )
+            return
+
+        patched = 0
+        for path in auth_files:
+            try:
+                if self._repair_file(path):
+                    patched += 1
+            except Exception as exc:  # noqa: BLE001 - report per-file, keep going
+                self._fail_or_warn(f"Could not process auth file {path}: {exc}")
+
+        if patched:
+            self.logger.info(
+                f"Scratch-org identity repaired: set isScratch=true in "
+                f"{patched} auth file(s) for {username}."
+            )
+        else:
+            self.logger.info(
+                f"Scratch-org identity already correct for {username}; no changes made."
+            )
+
+    # ------------------------------------------------------------------
+    # Auth-file discovery
+    # ------------------------------------------------------------------
+
+    def _find_auth_files(self, username):
+        """Return existing auth files for ``username`` in ~/.sfdx and ~/.sf.
+
+        The legacy ``~/.sfdx/<username>.json`` is the primary location the SF
+        CLI's StateAggregator reads. ``~/.sf`` is scanned defensively in case a
+        newer CLI version stores a per-org auth file there too.
+        """
+        home = Path.home()
+        candidates = [home / ".sfdx" / f"{username}.json"]
+        sf_dir = home / ".sf"
+        if sf_dir.is_dir():
+            candidates += [
+                Path(p)
+                for p in glob.glob(str(sf_dir / "**" / f"{username}.json"), recursive=True)
+            ]
+        # De-dupe while preserving order; keep only files that exist.
+        seen, found = set(), []
+        for path in candidates:
+            rp = str(path)
+            if rp in seen:
+                continue
+            seen.add(rp)
+            if path.is_file():
+                found.append(path)
+        return found
+
+    # ------------------------------------------------------------------
+    # Per-file repair
+    # ------------------------------------------------------------------
+
+    def _repair_file(self, path):
+        """Patch a single auth file. Returns True if it was changed."""
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+            # Encrypted/unreadable auth file — not something we can safely edit.
+            self.logger.debug(f"Skipping unreadable auth file {path}: {exc}")
+            return False
+        if not isinstance(data, dict):
+            self.logger.debug(f"Skipping auth file {path}: not a JSON object.")
+            return False
+
+        if data.get("isScratch") is True:
+            self.logger.debug(f"{path}: isScratch already true.")
+            return False
+
+        # Only flip when this really looks like a scratch org. A scratch org has
+        # a DevHub and is neither a DevHub nor a sandbox itself.
+        if not data.get("devHubUsername"):
+            self.logger.warning(
+                f"{path}: isScratch is not true but no devHubUsername is present; "
+                "leaving it unchanged (does not look like a scratch org)."
+            )
+            return False
+        if data.get("isDevHub") or data.get("isSandbox"):
+            self.logger.warning(
+                f"{path}: looks like a DevHub/sandbox, not a scratch org; "
+                "leaving isScratch unchanged."
+            )
+            return False
+
+        previous = data.get("isScratch")
+        data["isScratch"] = True
+        self._atomic_write(path, data)
+        self.logger.info(
+            f"{path}: isScratch {previous!r} -> True "
+            f"(devHubUsername={data.get('devHubUsername')})."
+        )
+        return True
+
+    @staticmethod
+    def _atomic_write(path, data):
+        """Write JSON to ``path`` atomically, preserving restrictive perms.
+
+        Auth files hold credentials, so the temp file is created 0600 and we
+        carry over the original mode when available before the atomic replace.
+        """
+        try:
+            mode = os.stat(path).st_mode & 0o777
+        except OSError:
+            mode = 0o600
+        directory = os.path.dirname(str(path)) or "."
+        fd, tmp = tempfile.mkstemp(prefix=".rlm_auth_", dir=directory)
+        try:
+            os.fchmod(fd, mode or 0o600)
+            with os.fdopen(fd, "w", encoding="utf-8") as fh:
+                json.dump(data, fh, indent=2)
+                fh.write("\n")
+            os.replace(tmp, str(path))
+        except BaseException:
+            # Clean up the temp file on any failure; never leave a stray.
+            try:
+                os.unlink(tmp)
+            except OSError:
+                pass
+            raise
+
+    # ------------------------------------------------------------------
+    # Error handling
+    # ------------------------------------------------------------------
+
+    def _fail_or_warn(self, message):
+        if self.options.get("raise_on_failure"):
+            raise TaskOptionsError(message)
+        self.logger.warning(message)

--- a/tests/test_fix_scratch_identity.py
+++ b/tests/test_fix_scratch_identity.py
@@ -224,8 +224,11 @@ def test_run_gating_and_failure_modes():
         try:
             task._run_task()
             check("raise_on_failure raises", False)
-        except TaskOptionsError:
+            check("raise_on_failure chains cause", False)
+        except TaskOptionsError as exc:
             check("raise_on_failure raises", True)
+            # The originating error must be chained (raise ... from exc).
+            check("raise_on_failure chains cause", exc.__cause__ is not None)
 
 
 def test_dedicated_exception_type():

--- a/tests/test_fix_scratch_identity.py
+++ b/tests/test_fix_scratch_identity.py
@@ -265,6 +265,27 @@ def test_atomic_write_cleanup_on_chmod_failure():
             os.fchmod = original_fchmod
 
 
+def test_atomic_write_without_fchmod():
+    # Simulate a platform without os.fchmod (e.g. Windows): the os.chmod path
+    # must still restrict perms to 0600 (before writing) and write correctly.
+    task = make_task()
+    had_fchmod = hasattr(os, "fchmod")
+    saved = os.fchmod if had_fchmod else None
+    if had_fchmod:
+        delattr(os, "fchmod")
+    try:
+        with tempfile.TemporaryDirectory() as d:
+            path = write_auth(d, {"isScratch": False, "devHubUsername": "dh"}, mode=0o644)
+            task._repair_file(path)
+            final = oct(os.stat(path).st_mode & 0o777)
+            data = json.loads(path.read_text())
+            check("no-fchmod path -> 0o600", final == "0o600")
+            check("no-fchmod path writes isScratch=true", data.get("isScratch") is True)
+    finally:
+        if had_fchmod:
+            os.fchmod = saved
+
+
 def main():
     test_repair_decisions()
     test_repair_raises_on_bad_files()
@@ -274,6 +295,7 @@ def main():
     test_run_gating_and_failure_modes()
     test_dedicated_exception_type()
     test_atomic_write_cleanup_on_chmod_failure()
+    test_atomic_write_without_fchmod()
 
     passed = sum(1 for _, ok in RESULTS if ok)
     total = len(RESULTS)

--- a/tests/test_fix_scratch_identity.py
+++ b/tests/test_fix_scratch_identity.py
@@ -149,9 +149,13 @@ def test_permissions_forced_0600():
 
 def test_find_auth_files():
     task = make_task()
-    original_home = os.environ.get("HOME")
+    # Path.home() reads HOME on POSIX and USERPROFILE on Windows — set/restore
+    # both so the test redirects the home dir portably.
+    home_vars = ("HOME", "USERPROFILE")
+    saved = {k: os.environ.get(k) for k in home_vars}
     with tempfile.TemporaryDirectory() as home:
-        os.environ["HOME"] = home
+        for k in home_vars:
+            os.environ[k] = home
         try:
             sfdx = os.path.join(home, ".sfdx")
             os.makedirs(sfdx)
@@ -160,10 +164,11 @@ def test_find_auth_files():
             check("finds ~/.sfdx/<user>.json", [str(p) for p in found] == [str(target)])
             check("missing user -> empty", task._find_auth_files("nobody@example.com") == [])
         finally:
-            if original_home is not None:
-                os.environ["HOME"] = original_home
-            else:
-                os.environ.pop("HOME", None)
+            for k, v in saved.items():
+                if v is None:
+                    os.environ.pop(k, None)
+                else:
+                    os.environ[k] = v
 
 
 # ----------------------------------------------------------------------
@@ -265,6 +270,30 @@ def test_atomic_write_cleanup_on_chmod_failure():
             os.fchmod = original_fchmod
 
 
+def test_find_auth_files_glob_safe():
+    # A username with glob metacharacters ("[") must be matched literally in the
+    # recursive ~/.sf scan, not interpreted as a glob char-class.
+    task = make_task()
+    home_vars = ("HOME", "USERPROFILE")
+    saved = {k: os.environ.get(k) for k in home_vars}
+    user = "weird[name]@example.com"
+    with tempfile.TemporaryDirectory() as home:
+        for k in home_vars:
+            os.environ[k] = home
+        try:
+            sf_sub = os.path.join(home, ".sf", "orgs")
+            os.makedirs(sf_sub)
+            target = write_auth(sf_sub, {"isScratch": True}, name=f"{user}.json")
+            found = [str(p) for p in task._find_auth_files(user)]
+            check("glob-safe: finds user with '[' in name", str(target) in found)
+        finally:
+            for k, v in saved.items():
+                if v is None:
+                    os.environ.pop(k, None)
+                else:
+                    os.environ[k] = v
+
+
 def test_atomic_write_without_fchmod():
     # Simulate a platform without os.fchmod (e.g. Windows): the os.chmod path
     # must still restrict perms to 0600 (before writing) and write correctly.
@@ -291,6 +320,7 @@ def main():
     test_repair_raises_on_bad_files()
     test_permissions_forced_0600()
     test_find_auth_files()
+    test_find_auth_files_glob_safe()
     test_run_summary_branches()
     test_run_gating_and_failure_modes()
     test_dedicated_exception_type()

--- a/tests/test_fix_scratch_identity.py
+++ b/tests/test_fix_scratch_identity.py
@@ -1,0 +1,246 @@
+#!/usr/bin/env python3
+"""Unit tests for tasks.rlm_fix_scratch_identity.FixScratchOrgIdentity.
+
+Self-contained — no pytest required (matches this repo's lightweight test
+convention). Run from the repo root with base Python (CumulusCI is not needed;
+the task module degrades to stdlib-only when CumulusCI is absent):
+
+    python tests/test_fix_scratch_identity.py
+
+Exits 0 when all checks pass, 1 otherwise. Covers every branch of the repair
+logic: the isScratch flip/no-op decisions, secret + permission handling, the
+raise-on-unreadable behavior, and the _run_task summary (clean / repaired /
+errors / partial).
+"""
+import json
+import logging
+import os
+import pathlib
+import sys
+import tempfile
+from types import SimpleNamespace
+
+# Make `tasks` importable regardless of cwd.
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, REPO_ROOT)
+
+from tasks.rlm_fix_scratch_identity import (  # noqa: E402
+    FixScratchOrgIdentity,
+    TaskOptionsError,
+)
+
+RESULTS = []
+
+
+def check(name, condition):
+    RESULTS.append((name, bool(condition)))
+    print(f"  [{'PASS' if condition else 'FAIL'}] {name}")
+
+
+class CapturingHandler(logging.Handler):
+    """Collects emitted log messages for summary assertions."""
+
+    def __init__(self):
+        super().__init__()
+        self.messages = []
+
+    def emit(self, record):
+        self.messages.append(record.getMessage())
+
+
+def make_task(options=None, org_config=None):
+    """Build a task instance without running CumulusCI's BaseTask.__init__."""
+    task = FixScratchOrgIdentity.__new__(FixScratchOrgIdentity)
+    handler = CapturingHandler()
+    logger = logging.getLogger(f"test.{id(task)}")
+    logger.handlers = [handler]
+    logger.setLevel(logging.DEBUG)
+    logger.propagate = False
+    task.logger = logger
+    task.options = options or {}
+    task.org_config = org_config
+    task._captured = handler.messages
+    return task
+
+
+def write_auth(directory, data, mode=0o600, name="u.json"):
+    path = os.path.join(directory, name)
+    with open(path, "w", encoding="utf-8") as fh:
+        json.dump(data, fh, indent=2)
+    os.chmod(path, mode)
+    return pathlib.Path(path)
+
+
+# ----------------------------------------------------------------------
+# _repair_file: flip / no-op decisions
+# ----------------------------------------------------------------------
+
+def test_repair_decisions():
+    task = make_task()
+    cases = {
+        "broken EE scratch flips": (
+            {"isScratch": False, "devHubUsername": "dh", "accessToken": "SECRET"}, True),
+        "missing isScratch flips": (
+            {"devHubUsername": "dh"}, True),
+        "already true is no-op": (
+            {"isScratch": True, "devHubUsername": "dh"}, False),
+        "no devHubUsername left alone": (
+            {"isScratch": False}, False),
+        "devhub left alone": (
+            {"isScratch": False, "devHubUsername": "dh", "isDevHub": True}, False),
+        "sandbox left alone": (
+            {"isScratch": False, "devHubUsername": "dh", "isSandbox": True}, False),
+    }
+    for name, (data, expect_change) in cases.items():
+        with tempfile.TemporaryDirectory() as d:
+            path = write_auth(d, dict(data))
+            changed = task._repair_file(path)
+            after = json.loads(path.read_text())
+            ok = changed == expect_change
+            if expect_change:
+                ok = ok and after.get("isScratch") is True
+            else:
+                ok = ok and after.get("isScratch") == data.get("isScratch")
+            # secrets must never be dropped
+            ok = ok and after.get("accessToken") == data.get("accessToken")
+            check(name, ok)
+
+
+# ----------------------------------------------------------------------
+# _repair_file: raises on unreadable / non-JSON / non-object
+# ----------------------------------------------------------------------
+
+def test_repair_raises_on_bad_files():
+    task = make_task()
+    bad = {
+        "non-JSON raises": "not json at all",
+        "non-object raises": "[1, 2, 3]",
+        "undecodable raises": "\udcff",  # not valid UTF-8 when written below
+    }
+    for name, content in bad.items():
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, "u.json")
+            with open(path, "wb") as fh:
+                fh.write(content.encode("utf-8", errors="surrogateescape"))
+            try:
+                task._repair_file(pathlib.Path(path))
+                check(name, False)
+            except RuntimeError:
+                check(name, True)
+
+
+# ----------------------------------------------------------------------
+# _atomic_write: permissions forced to 0600
+# ----------------------------------------------------------------------
+
+def test_permissions_forced_0600():
+    task = make_task()
+    for in_mode in (0o700, 0o644, 0o600, 0o666):
+        with tempfile.TemporaryDirectory() as d:
+            path = write_auth(d, {"isScratch": False, "devHubUsername": "dh"}, mode=in_mode)
+            task._repair_file(path)
+            final = oct(os.stat(path).st_mode & 0o777)
+            check(f"{oct(in_mode)} -> {final} (expect 0o600)", final == "0o600")
+
+
+# ----------------------------------------------------------------------
+# _find_auth_files: locates ~/.sfdx/<username>.json
+# ----------------------------------------------------------------------
+
+def test_find_auth_files():
+    task = make_task()
+    original_home = os.environ.get("HOME")
+    with tempfile.TemporaryDirectory() as home:
+        os.environ["HOME"] = home
+        try:
+            sfdx = os.path.join(home, ".sfdx")
+            os.makedirs(sfdx)
+            target = write_auth(sfdx, {"isScratch": True}, name="alice@example.com.json")
+            found = task._find_auth_files("alice@example.com")
+            check("finds ~/.sfdx/<user>.json", [str(p) for p in found] == [str(target)])
+            check("missing user -> empty", task._find_auth_files("nobody@example.com") == [])
+        finally:
+            if original_home is not None:
+                os.environ["HOME"] = original_home
+            else:
+                os.environ.pop("HOME", None)
+
+
+# ----------------------------------------------------------------------
+# _run_task: summary branches
+# ----------------------------------------------------------------------
+
+def _run_with_files(files, options=None):
+    task = make_task(options=options, org_config=SimpleNamespace(scratch=True, username="u"))
+    task._find_auth_files = lambda username: files
+    task._run_task()
+    return task._captured
+
+
+def test_run_summary_branches():
+    # all clean -> "already correct"
+    with tempfile.TemporaryDirectory() as d:
+        good = write_auth(d, {"isScratch": True, "devHubUsername": "dh"})
+        msgs = _run_with_files([good])
+        check("summary: already correct", any("already correct" in m for m in msgs))
+
+    # patched only -> "repaired"
+    with tempfile.TemporaryDirectory() as d:
+        broken = write_auth(d, {"isScratch": False, "devHubUsername": "dh"})
+        msgs = _run_with_files([broken])
+        check("summary: repaired", any("identity repaired" in m for m in msgs))
+
+    # errors only -> "NOT verified"
+    with tempfile.TemporaryDirectory() as d:
+        bad = pathlib.Path(os.path.join(d, "bad.json"))
+        bad.write_text("not json")
+        msgs = _run_with_files([bad])
+        check("summary: NOT verified", any("NOT verified" in m for m in msgs))
+
+    # patched + errors -> "PARTIALLY repaired"
+    with tempfile.TemporaryDirectory() as d:
+        good = write_auth(d, {"isScratch": False, "devHubUsername": "dh"}, name="g.json")
+        bad = pathlib.Path(os.path.join(d, "b.json"))
+        bad.write_text("not json")
+        msgs = _run_with_files([good, bad])
+        check("summary: partial", any("PARTIALLY repaired" in m for m in msgs))
+
+
+def test_run_gating_and_failure_modes():
+    # non-scratch org -> skip
+    task = make_task(org_config=SimpleNamespace(scratch=False, username="u"))
+    task._run_task()
+    check("non-scratch org skipped", any("skipping" in m for m in task._captured))
+
+    # raise_on_failure raises when a file can't be parsed
+    with tempfile.TemporaryDirectory() as d:
+        bad = pathlib.Path(os.path.join(d, "bad.json"))
+        bad.write_text("not json")
+        task = make_task(
+            options={"raise_on_failure": True},
+            org_config=SimpleNamespace(scratch=True, username="u"),
+        )
+        task._find_auth_files = lambda username: [bad]
+        try:
+            task._run_task()
+            check("raise_on_failure raises", False)
+        except TaskOptionsError:
+            check("raise_on_failure raises", True)
+
+
+def main():
+    test_repair_decisions()
+    test_repair_raises_on_bad_files()
+    test_permissions_forced_0600()
+    test_find_auth_files()
+    test_run_summary_branches()
+    test_run_gating_and_failure_modes()
+
+    passed = sum(1 for _, ok in RESULTS if ok)
+    total = len(RESULTS)
+    print(f"\n{passed}/{total} checks passed")
+    return 0 if passed == total else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_fix_scratch_identity.py
+++ b/tests/test_fix_scratch_identity.py
@@ -228,6 +228,40 @@ def test_run_gating_and_failure_modes():
             check("raise_on_failure raises", True)
 
 
+def test_dedicated_exception_type():
+    # The CumulusCI-absent fallback must be a distinct type, not bare Exception,
+    # so `except TaskOptionsError` catches only intended failures.
+    check("TaskOptionsError is not bare Exception", TaskOptionsError is not Exception)
+    check("TaskOptionsError subclasses Exception", issubclass(TaskOptionsError, Exception))
+
+
+def test_atomic_write_cleanup_on_chmod_failure():
+    # If os.fchmod raises before os.fdopen takes ownership of the descriptor,
+    # _atomic_write must still re-raise and leave no stray temp file behind.
+    if not hasattr(os, "fchmod"):
+        check("atomic_write cleanup on fchmod failure (skipped: no fchmod)", True)
+        return
+    original_fchmod = os.fchmod
+
+    def boom(*args, **kwargs):
+        raise OSError("simulated fchmod failure")
+
+    with tempfile.TemporaryDirectory() as d:
+        path = write_auth(d, {"isScratch": False, "devHubUsername": "dh"})
+        os.fchmod = boom
+        try:
+            raised = False
+            try:
+                FixScratchOrgIdentity._atomic_write(path, {"isScratch": True})
+            except OSError:
+                raised = True
+            leftover = [f for f in os.listdir(d) if f.startswith(".rlm_auth_")]
+            check("atomic_write re-raises on fchmod failure", raised)
+            check("atomic_write leaves no temp file", leftover == [])
+        finally:
+            os.fchmod = original_fchmod
+
+
 def main():
     test_repair_decisions()
     test_repair_raises_on_bad_files()
@@ -235,6 +269,8 @@ def main():
     test_find_auth_files()
     test_run_summary_branches()
     test_run_gating_and_failure_modes()
+    test_dedicated_exception_type()
+    test_atomic_write_cleanup_on_chmod_failure()
 
     passed = sum(1 for _, ok in RESULTS if ok)
     total = len(RESULTS)


### PR DESCRIPTION
## Problem

SF CLI v2.x writes `"isScratch": false` to the local auth file (`~/.sfdx/<username>.json`) for **Enterprise-Edition ("ent") scratch orgs created via the DevHub API** — which is how CCI creates them — even though they are real scratch orgs (valid `devHubUsername`, listed under `scratchOrgs` in `sf org list`). The CLI then rejects scratch-only commands with **`NonScratchOrgError: "This command works with only scratch orgs."`**

In this repo the casualty is the `create_personas_sales_rep_user` task's `sf org create user` (in `prepare_personas`); developers also hit it running `sf org generate password` manually. It has recurred across workstations and has been worked around by hand-patching the auth file.

## Fix

New task **`tasks.rlm_fix_scratch_identity.FixScratchOrgIdentity`**:
- Reads the org's auth file(s) under `~/.sfdx` (and defensively `~/.sf`).
- Sets `isScratch` to true **when it is false or missing**, and **only** when a `devHubUsername` is present and the org is not itself a DevHub/sandbox — so it never mis-tags a genuine non-scratch org.
- Idempotent (no-op when already correct), atomic write forcing `0600` (owner-only) perms set before any write, portable chmod (`os.fchmod` with an `os.chmod` fallback for Windows), glob-escaped file lookup, non-fatal by default (warn-and-continue; raises on unreadable files / under `--raise-on-failure`, chaining the cause; reports PARTIAL repairs).

Wired as **`prepare_core` step 1**, gated `when: org_config.scratch` (CCI's own keychain flag — reliable and independent of the broken CLI flag), so `prepare_rlm_org` **self-heals** before any scratch-only CLI command runs. Also runnable standalone:

```bash
cci org default ent-r1            # this build selects the default org (no --org)
cci task run fix_scratch_org_identity
```

## Verification

- **Committed unit test** — `tests/test_fix_scratch_identity.py` (self-contained, no pytest; `python tests/test_fix_scratch_identity.py` → **29/29**). Covers: flip/no-op decisions (incl. missing `isScratch`), secret + `0600` permission handling (`0700/0644/0666 → 0600`, no-`fchmod` path), raise-on-unreadable + cause chaining, fd-leak cleanup, glob-safe + portable `_find_auth_files`, and every `_run_task` summary path (clean / repaired / errors / partial) plus scratch gating and `raise_on_failure`.
- **CCI E2E (live `ent-r1`)** — simulated `isScratch=false`, ran the task via real CCI → repaired to `true`; re-run is a clean no-op; semantic diff vs. the original auth file = only `isScratch` ever touched.
- **Gold E2E (live `ent-r1`)** — broken: `sf org create user` → `NonScratchOrgError`; after repair: `sf org generate password` → success (same `isScratch` gate that blocks create-user).
- Regenerated CCI references; added a `NonScratchOrgError` troubleshooting entry. `prepare_rlm_org` resolves; generation is idempotent.

## Files
- `tasks/rlm_fix_scratch_identity.py` (new)
- `tests/test_fix_scratch_identity.py` (new)
- `cumulusci.yml` — task def + `prepare_core` step 1 (renumber)
- `.cursor/skills/cci-orchestration/{tasks,flows,feature-flags}-reference.md` (regenerated)
- `.cursor/skills/troubleshooting/SKILL.md` — `NonScratchOrgError` entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)
