### PR TITLE
fix(dev-guide): match absolute atlas URLs in link rewriting

### DIFF
--- a/tasks/rlm_snapshot_dev_guide.py
+++ b/tasks/rlm_snapshot_dev_guide.py
@@ -147,9 +147,14 @@ def _atlas_link_re(deliverable: str) -> "re.Pattern":
     """Regex matching an atlas intra-guide page reference for ``deliverable``.
 
     Captures group 1 = page id (``<page>.htm``), group 2 = optional ``#anchor``.
+    Optionally consumes a leading ``https://developer.salesforce.com/docs/`` so
+    that *absolute* atlas URLs are matched and replaced whole — otherwise only
+    the suffix would be rewritten, leaving a dangling ``…/docs/`` prefix (e.g.
+    ``https://developer.salesforce.com/docs/./page.htm.md``).
     """
     d = re.escape(deliverable)
     return re.compile(
+        r"(?:https?://developer\.salesforce\.com/docs/)?"
         r"(?:atlas\.en-us\.)?(?:[0-9.]+\.)?" + d + r"\.meta/" + d
         + r"/([A-Za-z0-9_.\-]+\.htm)(#[A-Za-z0-9_.\-]+)?"
     )


### PR DESCRIPTION
Follow-up to #216. Codex review of the corpus (#219) found 248 malformed local links + 1 doubled external link: when a source page used an **absolute** atlas URL, `_atlas_link_re` matched only the `atlas…<page>.htm` suffix, leaving the `https://developer.salesforce.com/docs/` prefix → `https://developer.salesforce.com/docs/./page.htm.md`.

Fix: the regex now optionally consumes the `https://developer.salesforce.com/docs/` prefix, so an absolute atlas URL is matched and replaced whole — captured → `./page.htm.md`, uncaptured → a single absolute URL. Relative links unchanged; `extract_link_targets` also benefits (now sees absolute atlas links).

Verified: absolute/relative × captured/uncaptured × anchor all rewrite cleanly. The corpus (#219) is corrected to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)