### PR TITLE
fix: exclude test/ and .bak dirs from SFDMU validator (#190)

### DIFF
--- a/.cursor/skills/sfdmu-data-plans/SKILL.md
+++ b/.cursor/skills/sfdmu-data-plans/SKILL.md
@@ -156,10 +156,22 @@ Example: `qb-billing` uses 3 passes: draft insert → activate treatment items �
 - [ ] No `$$` composite notation used for lookup reference columns (Bug 4 — use simple field references instead)
 - [ ] Self-referential lookups use simple field references (e.g., `ParentGroup.Code` not `ParentGroup.$$Code$...`)
 
+## Developer-Local Scratch Directory
+
+`datasets/sfdmu/test/` is a developer-local scratch area for experimental and throwaway plans. It is:
+
+- **Gitignored** — `datasets/sfdmu/test/**` in `.gitignore`; never committed or pushed
+- **Excluded from validation** — `validate_sfdmu_v5_datasets.py` skips `test/` and `*.bak` directories
+- **Not referenced** by any shipped task, flow, CI job, or test
+
+To clean up local scratch plans: `rm -rf datasets/sfdmu/test/`
+
+**Convention:** Never commit anything under `datasets/sfdmu/test/`. Never add a shipped plan there. For real plans, use `datasets/sfdmu/qb/`, `mfg/`, `q3/`, `procedure-plans/`, or `scratch_data/`.
+
 ## Validation Tool
 
 ```bash
-python scripts/validate_sfdmu_v5_datasets.py                           # validate all
+python scripts/validate_sfdmu_v5_datasets.py                           # validate all shipped plans (skips test/ and *.bak)
 python scripts/validate_sfdmu_v5_datasets.py --dataset datasets/sfdmu/qb/en-US/qb-pricing  # one plan
 python scripts/validate_sfdmu_v5_datasets.py --fix-all --dry-run       # preview fixes
 python scripts/validate_sfdmu_v5_datasets.py --fix-all                 # apply fixes

--- a/scripts/validate_sfdmu_v5_datasets.py
+++ b/scripts/validate_sfdmu_v5_datasets.py
@@ -32,6 +32,28 @@ from pathlib import Path
 from typing import Dict, List, Optional, Set, Tuple
 
 
+# Path segments (relative to the scan root) that mark a directory we never validate:
+# internal SFDMU subdirs, developer-local scratch (test/), and backup dirs (*.bak).
+_SKIP_SEGMENTS = ("objectset_source", "processed", "source", "logs", "test")
+
+
+def _is_skippable_export(export_json: Path, root: Path) -> bool:
+    """Return True if an export.json found under ``root`` should be skipped.
+
+    The skip filters are applied to the path RELATIVE TO ``root`` (the SFDMU base
+    or the ``--dataset`` parent), not the absolute filesystem path. Otherwise a
+    checkout directory literally named, e.g., ``test`` or ``source`` (such as
+    ``/tmp/test/rlm-base-dev``) would wrongly filter out every shipped dataset.
+    """
+    try:
+        rel_parts = export_json.relative_to(root).parts
+    except ValueError:
+        rel_parts = export_json.parts
+    if any(seg in _SKIP_SEGMENTS for seg in rel_parts):
+        return True
+    return any(seg.endswith(".bak") for seg in rel_parts)
+
+
 class Severity(Enum):
     """Issue severity levels."""
     CRITICAL = "Critical"
@@ -180,10 +202,9 @@ class SFDMUValidator:
         # Find all export.json files in SFDMU directory tree
         for export_json in self.sfdmu_base.rglob("export.json"):
             dataset_dir = export_json.parent
-            # Skip internal subdirs, developer-local scratch (test/), and backup dirs (*.bak)
-            if any(p in export_json.parts for p in ["objectset_source", "processed", "source", "logs", "test"]):
-                continue
-            if any(p.endswith(".bak") for p in export_json.parts):
+            # Skip internal subdirs, developer-local scratch (test/), and backup dirs (*.bak).
+            # Filter on the path relative to sfdmu_base so the checkout path can't matter.
+            if _is_skippable_export(export_json, self.sfdmu_base):
                 continue
             datasets.append(dataset_dir)
 
@@ -1132,10 +1153,9 @@ Examples:
             datasets = []
             for export_json in dataset_path.rglob("export.json"):
                 dataset_dir = export_json.parent
-                # Skip internal subdirs, developer-local scratch (test/), and backup dirs (*.bak)
-                if any(p in export_json.parts for p in ["objectset_source", "processed", "source", "logs", "test"]):
-                    continue
-                if any(p.endswith(".bak") for p in export_json.parts):
+                # Skip internal subdirs, developer-local scratch (test/), and backup dirs (*.bak).
+                # Filter on the path relative to the --dataset parent, not the checkout path.
+                if _is_skippable_export(export_json, dataset_path):
                     continue
                 datasets.append(dataset_dir)
             datasets = sorted(datasets)

--- a/scripts/validate_sfdmu_v5_datasets.py
+++ b/scripts/validate_sfdmu_v5_datasets.py
@@ -180,8 +180,10 @@ class SFDMUValidator:
         # Find all export.json files in SFDMU directory tree
         for export_json in self.sfdmu_base.rglob("export.json"):
             dataset_dir = export_json.parent
-            # Skip if it's in a subdirectory like objectset_source or processed
-            if any(p in export_json.parts for p in ["objectset_source", "processed", "source", "logs"]):
+            # Skip internal subdirs, developer-local scratch (test/), and backup dirs (*.bak)
+            if any(p in export_json.parts for p in ["objectset_source", "processed", "source", "logs", "test"]):
+                continue
+            if any(p.endswith(".bak") for p in export_json.parts):
                 continue
             datasets.append(dataset_dir)
 
@@ -1130,8 +1132,10 @@ Examples:
             datasets = []
             for export_json in dataset_path.rglob("export.json"):
                 dataset_dir = export_json.parent
-                # Skip if it's in a subdirectory like objectset_source or processed
-                if any(p in export_json.parts for p in ["objectset_source", "processed", "source", "logs"]):
+                # Skip internal subdirs, developer-local scratch (test/), and backup dirs (*.bak)
+                if any(p in export_json.parts for p in ["objectset_source", "processed", "source", "logs", "test"]):
+                    continue
+                if any(p.endswith(".bak") for p in export_json.parts):
                     continue
                 datasets.append(dataset_dir)
             datasets = sorted(datasets)


### PR DESCRIPTION
Fix `scripts/validate_sfdmu_v5_datasets.py` to exclude `datasets/sfdmu/test/` and `*.bak` snapshot directories from both dataset discovery paths, preventing developer-local scratch plans from causing false validation failures.

Also documents the `datasets/sfdmu/test/` convention in the SFDMU data-plans skill.

Closes #190

Generated with [Claude Code](https://claude.ai/code)