### PR TITLE
chore(orgs): enable Slack + forecasting in scratch org shapes

### DIFF
--- a/orgs/beta.json
+++ b/orgs/beta.json
@@ -30,6 +30,7 @@
     "SalesforceHostedMCP",
     "Scrt2Conversation",
     "ServiceCloud",
+    "SlackSalesEnabled",
     "UnifiedCatalog",
     "UsageManagement"
   ],
@@ -57,6 +58,9 @@
     },
     "experienceBundleSettings": {
       "enableExperienceBundleMetadata": true
+    },
+    "forecastingSettings": {
+      "enableForecasts": true
     },
     "industriesContextSettings": {
       "enableContextDefinitions": true

--- a/orgs/dev.json
+++ b/orgs/dev.json
@@ -29,6 +29,7 @@
     "SalesforceHostedMCP",
     "Scrt2Conversation",
     "ServiceCloud",
+    "SlackSalesEnabled",
     "UnifiedCatalog",
     "UsageManagement"
   ],
@@ -56,6 +57,9 @@
     },
     "experienceBundleSettings": {
       "enableExperienceBundleMetadata": true
+    },
+    "forecastingSettings": {
+      "enableForecasts": true
     },
     "industriesContextSettings": {
       "enableContextDefinitions": true

--- a/orgs/ent.json
+++ b/orgs/ent.json
@@ -30,6 +30,7 @@
     "SalesforceHostedMCP",
     "Scrt2Conversation",
     "ServiceCloud",
+    "SlackSalesEnabled",
     "UnifiedCatalog",
     "UsageManagement"
   ],
@@ -57,6 +58,9 @@
     },
     "experienceBundleSettings": {
       "enableExperienceBundleMetadata": true
+    },
+    "forecastingSettings": {
+      "enableForecasts": true
     },
     "industriesContextSettings": {
       "enableContextDefinitions": true

--- a/orgs/feature.json
+++ b/orgs/feature.json
@@ -30,6 +30,7 @@
     "SalesforceHostedMCP",
     "Scrt2Conversation",
     "ServiceCloud",
+    "SlackSalesEnabled",
     "UnifiedCatalog",
     "UsageManagement"
   ],
@@ -57,6 +58,9 @@
     },
     "experienceBundleSettings": {
       "enableExperienceBundleMetadata": true
+    },
+    "forecastingSettings": {
+      "enableForecasts": true
     },
     "industriesContextSettings": {
       "enableContextDefinitions": true

--- a/orgs/internal/dev-r1.json
+++ b/orgs/internal/dev-r1.json
@@ -30,6 +30,7 @@
     "SalesforceHostedMCP",
     "Scrt2Conversation",
     "ServiceCloud",
+    "SlackSalesEnabled",
     "UnifiedCatalog",
     "UsageManagement"
   ],
@@ -57,6 +58,9 @@
     },
     "experienceBundleSettings": {
       "enableExperienceBundleMetadata": true
+    },
+    "forecastingSettings": {
+      "enableForecasts": true
     },
     "industriesContextSettings": {
       "enableContextDefinitions": true

--- a/orgs/internal/dev-sb0.json
+++ b/orgs/internal/dev-sb0.json
@@ -30,6 +30,7 @@
     "SalesforceHostedMCP",
     "Scrt2Conversation",
     "ServiceCloud",
+    "SlackSalesEnabled",
     "UnifiedCatalog",
     "UsageManagement"
   ],
@@ -57,6 +58,9 @@
     },
     "experienceBundleSettings": {
       "enableExperienceBundleMetadata": true
+    },
+    "forecastingSettings": {
+      "enableForecasts": true
     },
     "industriesContextSettings": {
       "enableContextDefinitions": true

--- a/orgs/internal/ent-datacloud.json
+++ b/orgs/internal/ent-datacloud.json
@@ -32,6 +32,7 @@
     "SalesforceHostedMCP",
     "Scrt2Conversation",
     "ServiceCloud",
+    "SlackSalesEnabled",
     "UnifiedCatalog",
     "UsageManagement"
   ],
@@ -59,6 +60,9 @@
     },
     "experienceBundleSettings": {
       "enableExperienceBundleMetadata": true
+    },
+    "forecastingSettings": {
+      "enableForecasts": true
     },
     "industriesContextSettings": {
       "enableContextDefinitions": true

--- a/orgs/internal/ent-r1.json
+++ b/orgs/internal/ent-r1.json
@@ -31,6 +31,7 @@
     "SalesforceHostedMCP",
     "Scrt2Conversation",
     "ServiceCloud",
+    "SlackSalesEnabled",
     "UnifiedCatalog",
     "UsageManagement"
   ],
@@ -58,6 +59,9 @@
     },
     "experienceBundleSettings": {
       "enableExperienceBundleMetadata": true
+    },
+    "forecastingSettings": {
+      "enableForecasts": true
     },
     "industriesContextSettings": {
       "enableContextDefinitions": true

--- a/orgs/internal/ent-sb0.json
+++ b/orgs/internal/ent-sb0.json
@@ -31,6 +31,7 @@
     "SalesforceHostedMCP",
     "Scrt2Conversation",
     "ServiceCloud",
+    "SlackSalesEnabled",
     "UnifiedCatalog",
     "UsageManagement"
   ],
@@ -58,6 +59,9 @@
     },
     "experienceBundleSettings": {
       "enableExperienceBundleMetadata": true
+    },
+    "forecastingSettings": {
+      "enableForecasts": true
     },
     "industriesContextSettings": {
       "enableContextDefinitions": true

--- a/orgs/internal/ent-sdb27.json
+++ b/orgs/internal/ent-sdb27.json
@@ -31,6 +31,7 @@
     "SalesforceHostedMCP",
     "Scrt2Conversation",
     "ServiceCloud",
+    "SlackSalesEnabled",
     "UnifiedCatalog",
     "UsageManagement"
   ],
@@ -58,6 +59,9 @@
     },
     "experienceBundleSettings": {
       "enableExperienceBundleMetadata": true
+    },
+    "forecastingSettings": {
+      "enableForecasts": true
     },
     "industriesContextSettings": {
       "enableContextDefinitions": true

--- a/orgs/internal/ent-sdb39.json
+++ b/orgs/internal/ent-sdb39.json
@@ -31,6 +31,7 @@
     "SalesforceHostedMCP",
     "Scrt2Conversation",
     "ServiceCloud",
+    "SlackSalesEnabled",
     "UnifiedCatalog",
     "UsageManagement"
   ],
@@ -58,6 +59,9 @@
     },
     "experienceBundleSettings": {
       "enableExperienceBundleMetadata": true
+    },
+    "forecastingSettings": {
+      "enableForecasts": true
     },
     "industriesContextSettings": {
       "enableContextDefinitions": true

--- a/orgs/internal/ent-sdb6.json
+++ b/orgs/internal/ent-sdb6.json
@@ -31,6 +31,7 @@
     "SalesforceHostedMCP",
     "Scrt2Conversation",
     "ServiceCloud",
+    "SlackSalesEnabled",
     "UnifiedCatalog",
     "UsageManagement"
   ],
@@ -58,6 +59,9 @@
     },
     "experienceBundleSettings": {
       "enableExperienceBundleMetadata": true
+    },
+    "forecastingSettings": {
+      "enableForecasts": true
     },
     "industriesContextSettings": {
       "enableContextDefinitions": true

--- a/orgs/internal/ent-sdb9.json
+++ b/orgs/internal/ent-sdb9.json
@@ -31,6 +31,7 @@
     "SalesforceHostedMCP",
     "Scrt2Conversation",
     "ServiceCloud",
+    "SlackSalesEnabled",
     "UnifiedCatalog",
     "UsageManagement"
   ],
@@ -58,6 +59,9 @@
     },
     "experienceBundleSettings": {
       "enableExperienceBundleMetadata": true
+    },
+    "forecastingSettings": {
+      "enableForecasts": true
     },
     "industriesContextSettings": {
       "enableContextDefinitions": true

--- a/orgs/release.json
+++ b/orgs/release.json
@@ -30,6 +30,7 @@
     "SalesforceHostedMCP",
     "Scrt2Conversation",
     "ServiceCloud",
+    "SlackSalesEnabled",
     "UnifiedCatalog",
     "UsageManagement"
   ],
@@ -57,6 +58,9 @@
     },
     "experienceBundleSettings": {
       "enableExperienceBundleMetadata": true
+    },
+    "forecastingSettings": {
+      "enableForecasts": true
     },
     "industriesContextSettings": {
       "enableContextDefinitions": true


### PR DESCRIPTION
## Summary
- Add the `SlackSalesEnabled` feature to all scratch org definitions that define `features` and `settings`.
- Add `forecastingSettings.enableForecasts: true` to the same set.
- 14 scratch org shapes updated (`orgs/*.json` and `orgs/internal/*.json`), +4 lines each, keeping the shapes consistent.

## Motivation
Keeps the scratch org shapes aligned after enabling Slack sales features and forecasting.

## Note
This change does **not** include the `platformSlackSettings` (`slackCapabilitiesEnabled` / `slackBetaTOS`) block. That setting is the one most directly tied to the `UserSlackCapabilities` profile permission deploy error seen in `assemble_and_deploy_ux`. If the intent was to fully resolve that error across all shapes, a follow-up adding `platformSlackSettings` may be needed.

## Test plan
- [ ] Spin up a scratch org from an updated shape (e.g. `cci org scratch dev` / `beta`) and confirm it creates successfully.
- [ ] Confirm `assemble_and_deploy_ux` deploys the `RLM Custom Partner Community User` profile without the `Unknown user permission: UserSlackCapabilities` failure.

Made with [Cursor](https://cursor.com)