### PR TITLE
fix(profiles): remove UserSlackCapabilities from RLM Custom Partner Community User

### DIFF
--- a/templates/profiles/base/RLM Custom Partner Community User.profile-meta.xml
+++ b/templates/profiles/base/RLM Custom Partner Community User.profile-meta.xml
@@ -128,10 +128,6 @@
     </userPermissions>
     <userPermissions>
         <enabled>true</enabled>
-        <name>UserSlackCapabilities</name>
-    </userPermissions>
-    <userPermissions>
-        <enabled>true</enabled>
         <name>WalletManagementUser</name>
     </userPermissions>
 </Profile>

--- a/unpackaged/post_prm/force-app/main/default/profiles/RLM Custom Partner Community User.profile-meta.xml
+++ b/unpackaged/post_prm/force-app/main/default/profiles/RLM Custom Partner Community User.profile-meta.xml
@@ -127,10 +127,6 @@
     </userPermissions>
     <userPermissions>
         <enabled>true</enabled>
-        <name>UserSlackCapabilities</name>
-    </userPermissions>
-    <userPermissions>
-        <enabled>true</enabled>
         <name>WalletManagementUser</name>
     </userPermissions>
 </Profile>

--- a/unpackaged/post_ux/profiles/RLM Custom Partner Community User.profile-meta.xml
+++ b/unpackaged/post_ux/profiles/RLM Custom Partner Community User.profile-meta.xml
@@ -128,10 +128,6 @@
     </userPermissions>
     <userPermissions>
         <enabled>true</enabled>
-        <name>UserSlackCapabilities</name>
-    </userPermissions>
-    <userPermissions>
-        <enabled>true</enabled>
         <name>WalletManagementUser</name>
     </userPermissions>
     <layoutAssignments>


### PR DESCRIPTION
## Summary
- Remove the `UserSlackCapabilities` user permission from the `RLM Custom Partner Community User` profile.
- Applied to both the `templates/` source of truth and the assembled `unpackaged/post_ux/` copy so they stay in sync.

## Motivation
`assemble_and_deploy_ux` failed to deploy with:

```
Profile/RLM Custom Partner Community User: Unknown user permission: UserSlackCapabilities
```

`UserSlackCapabilities` is not a valid user permission for this profile/license, so removing it unblocks the UX assembly deploy.

## Test plan
- [ ] Run `cci task run assemble_and_deploy_ux` and confirm the `RLM Custom Partner Community User` profile deploys without the `Unknown user permission` error.

Made with [Cursor](https://cursor.com)