### PR TITLE
fix(pricing): correct spread params and deactivate quote procedure plan version

### DIFF
--- a/datasets/sfdmu/procedure-plans/ProcedurePlanDefinitionVersion.csv
+++ b/datasets/sfdmu/procedure-plans/ProcedurePlanDefinitionVersion.csv
@@ -1,2 +1,2 @@
 DefaultReadContextMapping,DefaultSaveContextMapping,DeveloperName,EffectiveFrom,EffectiveTo,InheritedFrom,IsActive,ProcedurePlanDefinition.DeveloperName,Rank
-QuoteEntitiesMapping,QuoteEntitiesMapping,RLM_Quote_Pricing_Procedure_Plan,2026-01-17T00:00:00.000+0000,,,true,RLM_Quote_Pricing_Procedure_Plan,1
+QuoteEntitiesMapping,QuoteEntitiesMapping,RLM_Quote_Pricing_Procedure_Plan,2026-01-17T00:00:00.000+0000,,,false,RLM_Quote_Pricing_Procedure_Plan,1

--- a/force-app/main/default/expressionSetDefinition/RLM_DefaultPricingProcedure.expressionSetDefinition-meta.xml
+++ b/force-app/main/default/expressionSetDefinition/RLM_DefaultPricingProcedure.expressionSetDefinition-meta.xml
@@ -3583,21 +3583,21 @@
                     <name>SpreadValue</name>
                     <output>true</output>
                     <type>Parameter</type>
-                    <value>AdjustmentValue</value>
+                    <value>LineItemDiscountValue</value>
                 </parameters>
                 <parameters>
                     <input>false</input>
                     <name>SpreadType</name>
                     <output>true</output>
                     <type>Parameter</type>
-                    <value>HeaderDiscountType</value>
+                    <value>HeaderDistributionType</value>
                 </parameters>
                 <parameters>
                     <input>false</input>
                     <name>LineItemDiscountType</name>
                     <output>true</output>
                     <type>Parameter</type>
-                    <value>AdjustmentType</value>
+                    <value>LineItemDiscountType</value>
                 </parameters>
                 <parameters>
                     <input>false</input>


### PR DESCRIPTION
## Summary
- **RLM_DefaultPricingProcedure** (`expressionSetDefinition`): corrected the spread/distribution parameter mappings:
  - `SpreadValue`: `AdjustmentValue` → `LineItemDiscountValue`
  - `SpreadType`: `HeaderDiscountType` → `HeaderDistributionType`
  - `LineItemDiscountType`: `AdjustmentType` → `LineItemDiscountType`
- **ProcedurePlanDefinitionVersion** (SFDMU CSV): set `RLM_Quote_Pricing_Procedure_Plan` `IsActive` to `false`.

## Test plan
- [x] Deploy `RLM_DefaultPricingProcedure` and confirm the spread/distribution step resolves correctly during quote pricing.
- [x] Load the procedure-plans SFDMU plan and verify the quote pricing procedure plan version is inactive as expected.

Made with [Cursor](https://cursor.com)