### PR TITLE
docs(policy): require live scratch-org verification for behavioral robot changes

### DIFF
--- a/.cursor/rules/cci-python-tasks.mdc
+++ b/.cursor/rules/cci-python-tasks.mdc
@@ -12,11 +12,11 @@ alwaysApply: false
 - Log access tokens or session IDs
 - Use `org_config.name` (CCI alias) as `--target-org` — use `.username`
 - Write SOQL in loops (batch-query before processing)
-- **If this task wraps a Robot Framework suite** (runs `robot` via subprocess / imports
-  `tasks.robot_utils`): commit a behavioral change to the suite or this wrapper validated only
-  by `robot --dryrun`. Dryrun never launches a browser — verify in a **live scratch org** first
-  (`cci task run <robot_task> --org <alias>`), or keep the PR blocked
-  (`blocked: needs-live-verification`). See AGENTS.md DO NOT #9 and
+- **Commit a behavioral change to a wrapped Robot Framework suite — or to this wrapper
+  itself — validated only by `robot --dryrun`** (applies when this task runs `robot` via
+  subprocess / imports `tasks.robot_utils`). Dryrun never launches a browser — verify in a
+  **live scratch org** first (`cci task run <robot_task> --org <alias>`), or keep the PR
+  blocked (`blocked: needs-live-verification`). See AGENTS.md DO NOT #9 and
   `robot-testing/SKILL.md` → Verification.
 
 ## Base Class Selection

--- a/.cursor/rules/cci-python-tasks.mdc
+++ b/.cursor/rules/cci-python-tasks.mdc
@@ -12,6 +12,12 @@ alwaysApply: false
 - Log access tokens or session IDs
 - Use `org_config.name` (CCI alias) as `--target-org` — use `.username`
 - Write SOQL in loops (batch-query before processing)
+- **If this task wraps a Robot Framework suite** (runs `robot` via subprocess / imports
+  `tasks.robot_utils`): commit a behavioral change to the suite or this wrapper validated only
+  by `robot --dryrun`. Dryrun never launches a browser — verify in a **live scratch org** first
+  (`cci task run <robot_task> --org <alias>`), or keep the PR blocked
+  (`blocked: needs-live-verification`). See AGENTS.md DO NOT #9 and
+  `robot-testing/SKILL.md` → Verification.
 
 ## Base Class Selection
 

--- a/.cursor/rules/robot-tests.mdc
+++ b/.cursor/rules/robot-tests.mdc
@@ -9,6 +9,12 @@ globs:
 
 ## DO NOT
 
+- **Commit a behavioral robot change — or its Python task wrapper — validated only
+  by `robot --dryrun`.** Dryrun is syntax/keyword-resolution only; it never runs the
+  browser or `Execute JavaScript`. Verify in a **live scratch org** first
+  (`cci task run <robot_task> --org <alias>`), or mark the change unverified and keep
+  the PR blocked (`blocked: needs-live-verification`). Comment/`[Documentation]`-only
+  edits are exempt. (See `robot-testing/SKILL.md` → Verification, and AGENTS.md DO NOT #9.)
 - Use `//` comments in Robot JavaScript blocks — use `/* */`
 - Use standard `input_text` for LWC inputs — use native setter pattern
 - Log session tokens in Robot output (`Set Log Level NONE`)

--- a/.cursor/rules/robot-tests.mdc
+++ b/.cursor/rules/robot-tests.mdc
@@ -13,9 +13,10 @@ globs:
   by `robot --dryrun`.** Dryrun is syntax/keyword-resolution only; it never runs the
   browser or `Execute JavaScript`. Verify in a **live scratch org** first
   (`cci task run <robot_task> --org <alias>`), or mark the change unverified and keep
-  the PR blocked (`blocked: needs-live-verification`). Comment/`[Documentation]`-only
-  edits are exempt. (This rule's `globs` cover the `.robot` suites; the same requirement for
-  task wrappers under `tasks/**/*.py` is carried by `cci-python-tasks.mdc`. See
+  the PR blocked (`blocked: needs-live-verification`). Exempt: comment/`[Documentation]`-only
+  edits, and resource files with no behavioral change. (This rule's `globs` cover the
+  `robot/**` tree — both `*.robot` suites and in-tree Python `robot/**/*.py`; the same
+  requirement for task wrappers under `tasks/**/*.py` is carried by `cci-python-tasks.mdc`. See
   `robot-testing/SKILL.md` → Verification, and AGENTS.md DO NOT #9.)
 - Use `//` comments in Robot JavaScript blocks — use `/* */`
 - Use standard `input_text` for LWC inputs — use native setter pattern

--- a/.cursor/rules/robot-tests.mdc
+++ b/.cursor/rules/robot-tests.mdc
@@ -14,7 +14,9 @@ globs:
   browser or `Execute JavaScript`. Verify in a **live scratch org** first
   (`cci task run <robot_task> --org <alias>`), or mark the change unverified and keep
   the PR blocked (`blocked: needs-live-verification`). Comment/`[Documentation]`-only
-  edits are exempt. (See `robot-testing/SKILL.md` → Verification, and AGENTS.md DO NOT #9.)
+  edits are exempt. (This rule's `globs` cover the `.robot` suites; the same requirement for
+  task wrappers under `tasks/**/*.py` is carried by `cci-python-tasks.mdc`. See
+  `robot-testing/SKILL.md` → Verification, and AGENTS.md DO NOT #9.)
 - Use `//` comments in Robot JavaScript blocks — use `/* */`
 - Use standard `input_text` for LWC inputs — use native setter pattern
 - Log session tokens in Robot output (`Set Log Level NONE`)

--- a/.cursor/skills/robot-testing/SKILL.md
+++ b/.cursor/skills/robot-testing/SKILL.md
@@ -34,10 +34,16 @@ suite, run it against a live scratch org:
 
 ```bash
 # via the CCI task wrapper (preferred — mirrors how prepare_rlm_org runs it)
-cci task run <robot_task> --org <alias>
-# or directly against a suite
-robot -v ORG_ALIAS:<alias> robot/rlm-base/tests/setup/<suite>.robot
+cci task run <robot_task> --org <cci_alias>           # CCI alias, e.g. beta
+# or directly against a suite — ORG_ALIAS is passed to `sf org open -o`, so it
+# takes the SF CLI alias (or username), NOT the CCI alias
+robot -v ORG_ALIAS:<sf_alias> robot/rlm-base/tests/setup/<suite>.robot   # e.g. rlm-base__beta
 ```
+
+The two commands take **different** alias forms (see AGENTS.md → *Org Identity:
+CCI vs SF CLI*): `cci task run --org` uses the CCI alias (`beta`); the direct
+`robot` run's `ORG_ALIAS` feeds `sf org open`, so it needs the SF CLI alias
+(`rlm-base__beta`) or the org username.
 
 Confirm the suite actually passes (toggle flips, pill/value reads back, element
 is found) — not just that it parses. **Exempt:** comment/`[Documentation]`-only

--- a/.cursor/skills/robot-testing/SKILL.md
+++ b/.cursor/skills/robot-testing/SKILL.md
@@ -11,12 +11,39 @@ Use this skill when writing, modifying, or debugging Robot Framework tests.
 5. Use `self.org_config.username` in Python wrappers for `sf org open -o`.
 6. Gate E2E tests with `Skip If "${QB}" == "false"` on the relevant feature flag.
 7. For Setup UI + shadow DOM vs iframe: read `setup-ui-shadow-dom.md` before adding new keywords (LWS, `composed`, VF frames).
+8. **Live-org verification is mandatory** for any behavioral change to a `.robot` suite or its Python wrapper — `robot --dryrun` is syntax-only and does **not** prove UI/shadow-DOM logic works. See **DO NOT** and **Verification — dryrun is not enough** below.
 
 ## DO NOT
 
 - **DO NOT** use `//` comments in Robot JavaScript — use `/* */` instead
 - **DO NOT** use standard `input_text` for LWC inputs — use native setter pattern
 - **DO NOT** log session tokens — wrap URL retrieval with `Set Log Level NONE`
+- **DO NOT** commit a behavioral robot change (keywords, locators, `Execute JavaScript`/DOM logic, click targets, wait/assert flow) **or** its Python task wrapper as verified — or merge it — on `robot --dryrun` alone. Run the affected suite against a live scratch org first. Dryrun never launches a browser. Comment/`[Documentation]`-only edits are exempt.
+
+## Verification — dryrun is not enough
+
+`robot --dryrun` resolves keyword names, argument counts, and syntax. It does
+**not** launch a browser, load a Salesforce page, or execute `Execute JavaScript`
+blocks. A wrong DOM/shadow-root assumption passes dryrun and then fails mid-build
+during `prepare_rlm_org` — after a full scratch-org spin-up, the most expensive
+place to discover it.
+
+**Before committing a behavioral robot change** (new/changed keyword, locator,
+JS, click target, wait/assert flow) or a change to the Python task that runs a
+suite, run it against a live scratch org:
+
+```bash
+# via the CCI task wrapper (preferred — mirrors how prepare_rlm_org runs it)
+cci task run <robot_task> --org <alias>
+# or directly against a suite
+robot -v ORG_ALIAS:<alias> robot/rlm-base/tests/setup/<suite>.robot
+```
+
+Confirm the suite actually passes (toggle flips, pill/value reads back, element
+is found) — not just that it parses. **Exempt:** comment/`[Documentation]`-only
+edits and resource files with no behavioral change. When you cannot run a live
+org, state that explicitly and mark the change **unverified** (PR label
+`blocked: needs-live-verification`) — never present a dryrun as verification.
 
 ---
 

--- a/.cursor/skills/robot-testing/SKILL.md
+++ b/.cursor/skills/robot-testing/SKILL.md
@@ -18,7 +18,7 @@ Use this skill when writing, modifying, or debugging Robot Framework tests.
 - **DO NOT** use `//` comments in Robot JavaScript — use `/* */` instead
 - **DO NOT** use standard `input_text` for LWC inputs — use native setter pattern
 - **DO NOT** log session tokens — wrap URL retrieval with `Set Log Level NONE`
-- **DO NOT** commit a behavioral robot change (keywords, locators, `Execute JavaScript`/DOM logic, click targets, wait/assert flow) **or** its Python task wrapper as verified — or merge it — on `robot --dryrun` alone. Run the affected suite against a live scratch org first. Dryrun never launches a browser. Comment/`[Documentation]`-only edits are exempt.
+- **DO NOT** commit a behavioral robot change (keywords, locators, `Execute JavaScript`/DOM logic, click targets, wait/assert flow) **or** its Python task wrapper as verified — or merge it — on `robot --dryrun` alone. Run the affected suite against a live scratch org first. Dryrun never launches a browser. Exempt: comment/`[Documentation]`-only edits, and resource files with no behavioral change.
 
 ## Verification — dryrun is not enough
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,6 +67,17 @@ docs/                  # Documentation (lower-kebab-case filenames)
 8. **DO NOT** commit or push directly to `main` — all changes must go
    through a feature branch and pull request. Never use `git push origin main`
    or force-push main without explicit user approval.
+9. **DO NOT** present a behavioral Robot Framework change as verified —
+   or merge one — on the strength of `robot --dryrun`. Dryrun validates only
+   syntax and keyword resolution; it never launches a browser or runs the
+   `Execute JavaScript`/shadow-DOM logic, so it is **not** verification. Any
+   behavioral change to a `robot/**/*.robot` suite (keywords, locators, JS,
+   click targets, wait/assert flow) **or** the Python task wrapper that invokes
+   a suite (`tasks/rlm_*.py`) must be run against a **live scratch org** before
+   the PR merges. If you must commit such a change unverified, say so explicitly
+   and keep the PR blocked (label `blocked: needs-live-verification`) until a
+   live run passes. Comment/`[Documentation]`-only edits are exempt. See
+   `.cursor/skills/robot-testing/SKILL.md` → **Verification**.
 
 ## Org Identity: CCI vs SF CLI
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,7 +76,8 @@ docs/                  # Documentation (lower-kebab-case filenames)
    a suite (`tasks/rlm_*.py`) must be run against a **live scratch org** before
    the PR merges. If you must commit such a change unverified, say so explicitly
    and keep the PR blocked (label `blocked: needs-live-verification`) until a
-   live run passes. Comment/`[Documentation]`-only edits are exempt. See
+   live run passes. Exempt: comment/`[Documentation]`-only edits, and resource
+   files with no behavioral change. See
    `.cursor/skills/robot-testing/SKILL.md` → **Verification**.
 
 ## Org Identity: CCI vs SF CLI


### PR DESCRIPTION
## Summary
Codifies a new repo rule: **behavioral Robot Framework changes — and the Python task wrappers that invoke robot suites — must be verified in a live scratch org before a PR merges.** `robot --dryrun` validates only syntax and keyword resolution; it never launches a browser or executes `Execute JavaScript`/shadow-DOM logic, so it is **not** verification.

### Why
A wrong DOM/shadow-root assumption passes dryrun, merges, and then fails mid-build during `prepare_rlm_org` — after a full scratch-org spin-up, the most expensive place to discover it. This came out of PR #182, where round 6–7 robot changes (label-target clicks, `_Verify`→`_Get` keyword refactors, `findEl` replacing an unbounded shadow walk) were validated only by dryrun.

### Scope (as decided)
- **In scope:** behavioral changes to `robot/**/*.robot` (keywords, locators, `Execute JavaScript`/DOM logic, click targets, wait/assert flow) **and** the `tasks/rlm_*.py` wrappers that run robot suites.
- **Exempt:** comment / `[Documentation]`-only edits, and resource changes with no behavioral effect.
- If a behavioral change must be committed unverified, it is marked and the PR stays blocked (`blocked: needs-live-verification`) until a live run passes.

### Changes
- `AGENTS.md` — **DO NOT #9** (canonical statement; `CLAUDE.md` symlinks to it)
- `.cursor/skills/robot-testing/SKILL.md` — Quick Rule 8, a DO NOT bullet, and a new **Verification — dryrun is not enough** section with the live-org run commands
- `.cursor/rules/robot-tests.mdc` — DO NOT bullet (auto-injects in Cursor whenever a robot file is edited)

### Related
- PR #182 is now labeled `blocked: needs-live-verification` pending a live run of its setup suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)