### PR TITLE
docs(troubleshooting): CCI/sf-CLI token-redaction workaround guide

### DIFF
--- a/.cursor/skills/troubleshooting/SKILL.md
+++ b/.cursor/skills/troubleshooting/SKILL.md
@@ -98,7 +98,7 @@ cci org info beta         # shows username, instance URL
 sf CLI >= 2.13.0 now **redacts** it. CCI sends a bogus header.
 
 **Fix:** set `SF_TEMP_SHOW_SECRETS=true` (prefix a command for a one-off; for a
-durable, IDE-covering setup use a LaunchAgent + `~/.zshrc`). **Do not** delete or
+durable, IDE-covering setup use a LaunchAgent + `~/.zshenv`). **Do not** delete or
 recreate the org — and never `cci org remove` a scratch org (it deletes it).
 Full guide, including the durable setup, the security tradeoff, and **how to
 check for / remove the workaround once an official fix ships**:

--- a/.cursor/skills/troubleshooting/SKILL.md
+++ b/.cursor/skills/troubleshooting/SKILL.md
@@ -92,10 +92,10 @@ cci org info beta         # shows username, instance URL
 
 **Symptom:** every `cci` command that touches an org fails with
 `INVALID_AUTH_HEADER` (or "Expired session"), even on a brand-new org — but
-`sf data query --target-org <username>` reaches the same org fine.
+`sf data query --target-org USERNAME` reaches the same org fine.
 
 **Cause:** CumulusCI 4.10 parses `sf org display` for the access token, and
-sf CLI ≥ 2.13x now **redacts** it. CCI sends a bogus header.
+sf CLI >= 2.13.0 now **redacts** it. CCI sends a bogus header.
 
 **Fix:** set `SF_TEMP_SHOW_SECRETS=true` (prefix a command for a one-off; for a
 durable, IDE-covering setup use a LaunchAgent + `~/.zshrc`). **Do not** delete or

--- a/.cursor/skills/troubleshooting/SKILL.md
+++ b/.cursor/skills/troubleshooting/SKILL.md
@@ -97,9 +97,11 @@ cci org info beta         # shows username, instance URL
 **Cause:** CumulusCI 4.10 parses `sf org display` for the access token, and
 sf CLI >= 2.13.0 now **redacts** it. CCI sends a bogus header.
 
-**Fix:** set `SF_TEMP_SHOW_SECRETS=true` (prefix a command for a one-off; for a
-durable, IDE-covering setup use a LaunchAgent + `~/.zshenv`). **Do not** delete or
-recreate the org — and never `cci org remove` a scratch org (it deletes it).
+**Fix:** set `SF_TEMP_SHOW_SECRETS=true`. The repo's tracked `.envrc` already exports
+it, so **direnv users are covered automatically** inside the repo; otherwise prefix a
+command for a one-off, or for a durable / Dock-launched-IDE setup use `~/.zshenv` + a
+LaunchAgent. **Do not** delete or recreate the org — and never `cci org remove` a
+scratch org (it deletes it).
 Full guide, including the durable setup, the security tradeoff, and **how to
 check for / remove the workaround once an official fix ships**:
 [cci-sf-cli-token-workaround.md](../../../docs/guides/cci-sf-cli-token-workaround.md).

--- a/.cursor/skills/troubleshooting/SKILL.md
+++ b/.cursor/skills/troubleshooting/SKILL.md
@@ -88,6 +88,22 @@ sf org list               # shows sf aliases (rlm-base__* prefix)
 cci org info beta         # shows username, instance URL
 ```
 
+### `INVALID_AUTH_HEADER` / "Expired session" on a healthy scratch org
+
+**Symptom:** every `cci` command that touches an org fails with
+`INVALID_AUTH_HEADER` (or "Expired session"), even on a brand-new org — but
+`sf data query --target-org <username>` reaches the same org fine.
+
+**Cause:** CumulusCI 4.10 parses `sf org display` for the access token, and
+sf CLI ≥ 2.13x now **redacts** it. CCI sends a bogus header.
+
+**Fix:** set `SF_TEMP_SHOW_SECRETS=true` (prefix a command for a one-off; for a
+durable, IDE-covering setup use a LaunchAgent + `~/.zshrc`). **Do not** delete or
+recreate the org — and never `cci org remove` a scratch org (it deletes it).
+Full guide, including the durable setup, the security tradeoff, and **how to
+check for / remove the workaround once an official fix ships**:
+[cci-sf-cli-token-workaround.md](../../../docs/guides/cci-sf-cli-token-workaround.md).
+
 ### `NonScratchOrgError` ("This command works with only scratch orgs")
 
 **Symptom:** a scratch-only SF CLI command — most often `sf org create user`

--- a/.github/workflows/check-cci-token-fix.yml
+++ b/.github/workflows/check-cci-token-fix.yml
@@ -51,11 +51,14 @@ jobs:
         run: |
           set -euo pipefail
           TITLE="Re-evaluate SF_TEMP_SHOW_SECRETS workaround — CumulusCI $LATEST available"
-          # Don't open a duplicate: reuse any open issue with the same title.
-          EXISTING=$(gh issue list --repo "$REPO" --state open --search "in:title \"$TITLE\"" \
-            --json number --jq '.[0].number // empty')
+          # Don't open a duplicate: reuse any issue with the same title, open OR
+          # closed. The title is version-specific, so closing this issue suppresses
+          # re-creation for the same release (the team chose not to act on it) while
+          # a genuinely newer release gets a new title — and thus a fresh issue.
+          EXISTING=$(gh issue list --repo "$REPO" --state all --search "in:title \"$TITLE\"" \
+            --json number,state --jq '.[0] | select(.) | "\(.number) (\(.state))"')
           if [ -n "$EXISTING" ]; then
-            echo "Tracking issue already open: #$EXISTING"
+            echo "Tracking issue already exists: #$EXISTING — not re-creating."
             exit 0
           fi
           {

--- a/.github/workflows/check-cci-token-fix.yml
+++ b/.github/workflows/check-cci-token-fix.yml
@@ -1,0 +1,73 @@
+name: Check CumulusCI token-fix availability
+
+# Watches for a CumulusCI release newer than the one affected by the sf-CLI
+# token-redaction bug (see docs/guides/cci-sf-cli-token-workaround.md). When a
+# newer release appears on PyPI, it opens a tracking issue so the team can check
+# whether the release fixes the bug and, if so, drop the SF_TEMP_SHOW_SECRETS
+# workaround. Remove this workflow once the workaround is gone.
+
+on:
+  workflow_dispatch: {}
+  schedule:
+    # Weekly, Monday 09:23 UTC (off-minute to avoid the top-of-hour fleet pile-up).
+    - cron: "23 9 * * 1"
+
+# Read-only floor; the job elevates only issues:write.
+permissions:
+  contents: read
+
+jobs:
+  check-pypi:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    env:
+      # The CumulusCI version affected by the bug. Bump this when the workaround
+      # is removed / CCI is upgraded, or this workflow keeps firing.
+      BASELINE: "4.10.0"
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - name: Query PyPI for the latest CumulusCI release
+        id: pypi
+        run: |
+          set -euo pipefail
+          LATEST=$(curl -fsSL https://pypi.org/pypi/cumulusci/json \
+            | python3 -c 'import sys,json; print(json.load(sys.stdin)["info"]["version"])')
+          echo "latest=$LATEST" >> "$GITHUB_OUTPUT"
+          # "newer" = larger of {baseline, latest} under version sort, and != baseline.
+          NEWER=$(printf '%s\n%s\n' "$BASELINE" "$LATEST" | sort -V | tail -1)
+          if [ "$LATEST" != "$BASELINE" ] && [ "$NEWER" = "$LATEST" ]; then
+            echo "is_newer=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "is_newer=false" >> "$GITHUB_OUTPUT"
+          fi
+          echo "Latest CumulusCI on PyPI: $LATEST (baseline $BASELINE)"
+
+      - name: Open tracking issue when a newer release exists
+        if: steps.pypi.outputs.is_newer == 'true'
+        env:
+          LATEST: ${{ steps.pypi.outputs.latest }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          TITLE="Re-evaluate SF_TEMP_SHOW_SECRETS workaround — CumulusCI $LATEST available"
+          # Don't open a duplicate: reuse any open issue with the same title.
+          EXISTING=$(gh issue list --repo "$REPO" --state open --search "in:title \"$TITLE\"" \
+            --json number --jq '.[0].number // empty')
+          if [ -n "$EXISTING" ]; then
+            echo "Tracking issue already open: #$EXISTING"
+            exit 0
+          fi
+          {
+            printf 'CumulusCI **%s** is now on PyPI (baseline affected by the bug: **%s**).\n\n' "$LATEST" "$BASELINE"
+            printf '**Action:** check the [CumulusCI release notes](https://github.com/SFDO-Tooling/CumulusCI/releases) '
+            printf 'for whether this release reads the org access token via `sf org auth show-access-token` instead of '
+            printf 'parsing `sf org display`.\n\n'
+            printf 'If it does, the `SF_TEMP_SHOW_SECRETS=true` workaround can be removed:\n'
+            printf -- '- Upgrade CumulusCI, then follow `docs/guides/cci-sf-cli-token-workaround.md` -> "Removal steps".\n'
+            printf -- '- Bump `BASELINE` in `.github/workflows/check-cci-token-fix.yml` (or delete the workflow once the '
+            printf 'workaround is gone) so it stops firing.\n\n'
+            printf 'If the release does **not** fix it, close this issue; it reopens on the next newer release.\n\n'
+            printf '_Opened automatically by the `Check CumulusCI token-fix availability` workflow._\n'
+          } > "$RUNNER_TEMP/issue_body.md"
+          gh issue create --repo "$REPO" --title "$TITLE" --body-file "$RUNNER_TEMP/issue_body.md"

--- a/.github/workflows/check-cci-token-fix.yml
+++ b/.github/workflows/check-cci-token-fix.yml
@@ -39,17 +39,16 @@ jobs:
         id: pypi
         run: |
           set -euo pipefail
-          LATEST=$(curl -fsSL https://pypi.org/pypi/cumulusci/json \
-            | python3 -c 'import sys,json; print(json.load(sys.stdin)["info"]["version"])')
+          # Compare with PEP 440 semantics (packaging.Version) — `sort -V` can mis-order
+          # pre/post/dev releases (e.g. 4.11.0rc1 vs 4.11.0). PyPI versions are PEP 440.
+          python3 -m pip install --quiet --disable-pip-version-check packaging
+          curl -fsSL https://pypi.org/pypi/cumulusci/json -o "$RUNNER_TEMP/cci.json"
+          OUT=$(python3 -c 'import sys,json; from packaging.version import Version as V; d=json.load(open(sys.argv[2])); l=d["info"]["version"]; print(l, "true" if V(l)>V(sys.argv[1]) else "false")' "$BASELINE" "$RUNNER_TEMP/cci.json")
+          LATEST=${OUT%% *}
+          IS_NEWER=${OUT##* }
           echo "latest=$LATEST" >> "$GITHUB_OUTPUT"
-          # "newer" = larger of {baseline, latest} under version sort, and != baseline.
-          NEWER=$(printf '%s\n%s\n' "$BASELINE" "$LATEST" | sort -V | tail -1)
-          if [ "$LATEST" != "$BASELINE" ] && [ "$NEWER" = "$LATEST" ]; then
-            echo "is_newer=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "is_newer=false" >> "$GITHUB_OUTPUT"
-          fi
-          echo "Latest CumulusCI on PyPI: $LATEST (baseline $BASELINE)"
+          echo "is_newer=$IS_NEWER" >> "$GITHUB_OUTPUT"
+          echo "Latest CumulusCI on PyPI: $LATEST (baseline $BASELINE, PEP 440 compare)"
 
       - name: Open tracking issue when a newer release exists
         if: steps.pypi.outputs.is_newer == 'true'

--- a/.github/workflows/check-cci-token-fix.yml
+++ b/.github/workflows/check-cci-token-fix.yml
@@ -12,6 +12,14 @@ on:
     # Weekly, Monday 09:23 UTC (off-minute to avoid the top-of-hour fleet pile-up).
     - cron: "23 9 * * 1"
 
+# Serialize runs so a manual workflow_dispatch overlapping the scheduled run can't
+# both pass the "no existing issue" check and create duplicates. cancel-in-progress
+# is false so the first run finishes (and creates the issue) before the queued one
+# runs and sees it.
+concurrency:
+  group: check-cci-token-fix
+  cancel-in-progress: false
+
 # Read-only floor; the job elevates only issues:write.
 permissions:
   contents: read

--- a/.github/workflows/check-cci-token-fix.yml
+++ b/.github/workflows/check-cci-token-fix.yml
@@ -20,13 +20,18 @@ concurrency:
   group: check-cci-token-fix
   cancel-in-progress: false
 
-# Read-only floor; the job elevates only issues:write.
+# Default permissions floor for any job that does NOT declare its own `permissions`.
+# NOTE: a job-level `permissions:` block REPLACES this floor (it does not merge) —
+# every scope the job omits becomes `none`. So each job must list every scope it needs.
 permissions:
   contents: read
 
 jobs:
   check-pypi:
     runs-on: ubuntu-latest
+    # Replaces the floor above. This job only calls PyPI (curl) and the GitHub issues
+    # API (gh) — it never checks out the repo — so `issues: write` is the complete
+    # least-privilege set; `contents` is intentionally `none` here.
     permissions:
       issues: write
     env:

--- a/docs/guides/cci-sf-cli-token-workaround.md
+++ b/docs/guides/cci-sf-cli-token-workaround.md
@@ -37,8 +37,8 @@ org — never use it to "refresh" a token.)
 
 ## Root cause
 
-CumulusCI **4.10.0** (the latest release as of 2026-06) reads an org's access token by parsing
-the output of `sf org display`. Salesforce CLI **>= 2.13.0** now **redacts secrets** from that
+CumulusCI **4.10.0** (the version affected by this bug — the workflow's `BASELINE`) reads an
+org's access token by parsing the output of `sf org display`. Salesforce CLI **>= 2.13.0** now **redacts secrets** from that
 output by default:
 
 ```
@@ -166,7 +166,7 @@ If a newer release exists, confirm from its changelog that it addresses the
 ```bash
 pipx upgrade cumulusci                       # or to a specific fixed version
 # then remove the workaround:
-launchctl unload ~/Library/LaunchAgents/com.example.sf-temp-show-secrets.plist
+launchctl unload -w ~/Library/LaunchAgents/com.example.sf-temp-show-secrets.plist   # -w mirrors the -w used on load
 rm ~/Library/LaunchAgents/com.example.sf-temp-show-secrets.plist
 launchctl unsetenv SF_TEMP_SHOW_SECRETS
 # remove the `export SF_TEMP_SHOW_SECRETS=true` line from ~/.zshrc

--- a/docs/guides/cci-sf-cli-token-workaround.md
+++ b/docs/guides/cci-sf-cli-token-workaround.md
@@ -68,10 +68,14 @@ whole flow.
 
 ### Durable — terminals (POSIX shells: macOS / Linux)
 
-Add to your shell profile (covers terminals, including IDE integrated terminals):
+Add it to `~/.zshenv`. Per this repo's shell setup
+(`docs/guides/dev-environment-setup.md`), `~/.zshenv` runs for **every** zsh shell —
+interactive, login, and **non-interactive** (CCI subprocesses, IDE integrated terminals,
+CI) — whereas `~/.zshrc` is interactive-only and is skipped in exactly the non-interactive
+contexts CCI runs in:
 
 ```bash
-echo 'export SF_TEMP_SHOW_SECRETS=true' >> ~/.zshrc   # or ~/.bashrc
+echo 'export SF_TEMP_SHOW_SECRETS=true' >> ~/.zshenv   # bash: ~/.bashrc (interactive) or the BASH_ENV file (non-interactive)
 ```
 
 On Linux / CI runners this is all you need — export the variable in the job environment.
@@ -174,7 +178,7 @@ pipx upgrade cumulusci                       # or to a specific fixed version
 launchctl unload -w ~/Library/LaunchAgents/com.example.sf-temp-show-secrets.plist   # -w mirrors the -w used on load
 rm ~/Library/LaunchAgents/com.example.sf-temp-show-secrets.plist
 launchctl unsetenv SF_TEMP_SHOW_SECRETS
-# remove the `export SF_TEMP_SHOW_SECRETS=true` line from ~/.zshrc
+# remove the `export SF_TEMP_SHOW_SECRETS=true` line from ~/.zshenv
 ```
 
 Verify `cci org info CCI_ALIAS` still works **without** the flag, then delete this note's entry

--- a/docs/guides/cci-sf-cli-token-workaround.md
+++ b/docs/guides/cci-sf-cli-token-workaround.md
@@ -139,6 +139,10 @@ This workaround relies on a flag Salesforce documents as **temporary** (`SF_TEMP
 2. **The Salesforce CLI removes `SF_TEMP_SHOW_SECRETS`** — this *breaks* the workaround and
    forces option 1. Watch the `sf` release notes.
 
+> **Automated:** the `.github/workflows/check-cci-token-fix.yml` workflow runs this check
+> weekly (and on demand via *Run workflow*) and opens a tracking issue when a newer CumulusCI
+> release appears — so nobody has to remember. The manual command below is the same check.
+
 ### How to check (run periodically)
 
 ```bash

--- a/docs/guides/cci-sf-cli-token-workaround.md
+++ b/docs/guides/cci-sf-cli-token-workaround.md
@@ -84,7 +84,7 @@ CI) — whereas `~/.zshrc` is interactive-only and is skipped in exactly the non
 contexts CCI runs in:
 
 ```bash
-echo 'export SF_TEMP_SHOW_SECRETS=true' >> ~/.zshenv   # bash: ~/.bashrc (interactive) or the BASH_ENV file (non-interactive)
+echo 'export SF_TEMP_SHOW_SECRETS=true' >> ~/.zshenv   # bash: use ~/.bashrc for interactive shells; non-interactive bash reads only the file named by the $BASH_ENV variable
 ```
 
 On Linux / CI runners this is all you need — export the variable in the job environment.
@@ -160,21 +160,18 @@ This workaround relies on a flag Salesforce documents as **temporary** (`SF_TEMP
 
 > **Automated:** the `.github/workflows/check-cci-token-fix.yml` workflow runs this check
 > weekly (and on demand via *Run workflow*) and opens a tracking issue when a newer CumulusCI
-> release appears — so nobody has to remember. The manual command below is the same check.
+> release appears — so nobody has to remember. It compares versions with PEP 440 semantics
+> (`packaging.Version`). The manual command below just prints the latest for you to eyeball.
 
 ### How to check (run periodically)
 
 ```bash
-# Is there a CumulusCI release newer than the one with the bug? (same logic as the workflow)
+# Print the latest CumulusCI on PyPI; compare it against the baseline yourself.
 BASELINE=4.10.0
 LATEST=$(curl -fsSL https://pypi.org/pypi/cumulusci/json | python3 -c 'import sys,json; print(json.load(sys.stdin)["info"]["version"])')
-echo "Latest CumulusCI on PyPI: $LATEST (workaround baseline: $BASELINE)"
-# "newer" = larger of {baseline, latest} under version sort, and != baseline.
-NEWER=$(printf '%s\n%s\n' "$BASELINE" "$LATEST" | sort -V | tail -1)
-if [ "$LATEST" != "$BASELINE" ] && [ "$NEWER" = "$LATEST" ]; then
-  echo "NEW RELEASE — check its changelog for the sf-token / 'show-access-token' fix:
-  https://github.com/SFDO-Tooling/CumulusCI/releases"
-fi
+echo "Latest CumulusCI on PyPI: $LATEST   (workaround baseline: $BASELINE)"
+echo "If $LATEST is newer than $BASELINE, check its changelog for the sf-token / 'show-access-token' fix:"
+echo "  https://github.com/SFDO-Tooling/CumulusCI/releases"
 ```
 
 If a newer release exists, confirm from its changelog that it addresses the

--- a/docs/guides/cci-sf-cli-token-workaround.md
+++ b/docs/guides/cci-sf-cli-token-workaround.md
@@ -78,10 +78,13 @@ whole flow.
 ### Durable — terminals (POSIX shells: macOS / Linux)
 
 Add it to `~/.zshenv`. Per this repo's shell setup
-(`docs/guides/dev-environment-setup.md`), `~/.zshenv` runs for **every** zsh shell —
-interactive, login, and **non-interactive** (CCI subprocesses, IDE integrated terminals,
-CI) — whereas `~/.zshrc` is interactive-only and is skipped in exactly the non-interactive
-contexts CCI runs in:
+(`docs/guides/dev-environment-setup.md`), `~/.zshenv` is sourced by **every** zsh shell you
+start — interactive, login, and **non-interactive** (e.g. an IDE's integrated terminal) —
+whereas `~/.zshrc` is sourced only by interactive shells. Any CCI command you run from such a
+shell then has the variable, and CCI's own child subprocesses inherit it from that shell's
+environment (they don't re-source `~/.zshenv` themselves). Note this is a personal-shell
+mechanism: a **CI** runner uses its own (often non-zsh) shell and won't read your `~/.zshenv`
+— there, export the variable in the job environment instead (see below).
 
 ```bash
 echo 'export SF_TEMP_SHOW_SECRETS=true' >> ~/.zshenv   # bash: use ~/.bashrc for interactive shells; non-interactive bash reads only the file named by the $BASH_ENV variable

--- a/docs/guides/cci-sf-cli-token-workaround.md
+++ b/docs/guides/cci-sf-cli-token-workaround.md
@@ -66,7 +66,7 @@ SF_TEMP_SHOW_SECRETS=true cci flow run prepare_rlm_org --org pr182
 Env vars propagate to CCI's child processes, so prefixing the top-level command covers the
 whole flow.
 
-### Durable — terminals (all platforms)
+### Durable — terminals (POSIX shells: macOS / Linux)
 
 Add to your shell profile (covers terminals, including IDE integrated terminals):
 
@@ -75,6 +75,9 @@ echo 'export SF_TEMP_SHOW_SECRETS=true' >> ~/.zshrc   # or ~/.bashrc
 ```
 
 On Linux / CI runners this is all you need — export the variable in the job environment.
+
+On **Windows**, set it as a user environment variable instead — `setx SF_TEMP_SHOW_SECRETS true`
+(PowerShell or cmd), then reopen the terminal/IDE so it picks up the new value.
 
 ### Durable — IDE launched from the macOS Dock
 

--- a/docs/guides/cci-sf-cli-token-workaround.md
+++ b/docs/guides/cci-sf-cli-token-workaround.md
@@ -54,6 +54,15 @@ CCI receives the redacted placeholder instead of the real token and sends a malf
 Set `SF_TEMP_SHOW_SECRETS=true` in the environment so `sf` exposes the token to CCI. Pick the
 scope that matches how you run CCI.
 
+### Already handled in-repo via direnv
+
+This repo's tracked **`.envrc`** already exports `SF_TEMP_SHOW_SECRETS=true` (see the
+*Salesforce CLI token redaction opt-out* block, `.envrc:34-47`). If you use **direnv**
+(the repo's standard setup — see `docs/guides/dev-environment-setup.md`), the flag is
+applied automatically whenever your shell is inside the repo, and any CCI command you run
+there inherits it. The scopes below are for processes direnv doesn't reach — a shell where
+direnv isn't hooked, or a GUI-launched IDE that never triggers `.envrc`.
+
 ### Quick / one-off
 
 Prefix any CCI command:
@@ -85,9 +94,10 @@ On **Windows**, set it as a user environment variable instead — `setx SF_TEMP_
 
 ### Durable — IDE launched from the macOS Dock
 
-The shell profile does **not** cover an app launched from the Dock (Cursor / VS Code), because
-macOS GUI apps don't source `~/.zshrc`. To cover the IDE process itself and anything it spawns,
-set the variable in the GUI login session with a LaunchAgent.
+Neither a shell profile nor direnv covers an app launched from the Dock (Cursor / VS Code):
+macOS GUI apps don't source `~/.zshenv`/`~/.zshrc`, and direnv only fires inside a hooked
+shell. To cover the IDE process itself and anything it spawns, set the variable in the GUI
+login session with a LaunchAgent.
 
 Create `~/Library/LaunchAgents/com.example.sf-temp-show-secrets.plist` (replace `example`
 with your own identifier — e.g. your username — keeping the filename and the `Label` below
@@ -178,8 +188,12 @@ pipx upgrade cumulusci                       # or to a specific fixed version
 launchctl unload -w ~/Library/LaunchAgents/com.example.sf-temp-show-secrets.plist   # -w mirrors the -w used on load
 rm ~/Library/LaunchAgents/com.example.sf-temp-show-secrets.plist
 launchctl unsetenv SF_TEMP_SHOW_SECRETS
-# remove the `export SF_TEMP_SHOW_SECRETS=true` line from ~/.zshenv
+# remove the `export SF_TEMP_SHOW_SECRETS=true` line from ~/.zshenv (personal scope)
 ```
+
+**Repo scope:** the in-repo `.envrc` export (`.envrc:34-47`) is the shared, committed
+copy — remove that block in the same PR that upgrades CumulusCI (and delete the
+`.github/workflows/check-cci-token-fix.yml` watcher), so it stops applying for everyone.
 
 Verify `cci org info CCI_ALIAS` still works **without** the flag, then delete this note's entry
 from the troubleshooting skill.

--- a/docs/guides/cci-sf-cli-token-workaround.md
+++ b/docs/guides/cci-sf-cli-token-workaround.md
@@ -1,0 +1,172 @@
+# Workaround: CCI `INVALID_AUTH_HEADER` on healthy scratch orgs (sf CLI token redaction)
+
+> **Status:** temporary workaround. Track the removal conditions in
+> [When can we remove this?](#when-can-we-remove-this) and drop it as soon as an
+> official fix ships.
+
+## Symptom
+
+Any CumulusCI command that touches an org fails with an expired-session / invalid-auth error,
+**even on a brand-new scratch org**:
+
+```
+$ cci org info pr182
+Error: Expired session for https://...scratch.my.salesforce.com/services/data/v67.0/...
+Response content: [{'message': 'INVALID_AUTH_HEADER', 'errorCode': 'INVALID_AUTH_HEADER'}]
+```
+
+It is not org-specific — it hits every scratch org, and a full `cci flow run prepare_rlm_org`
+dies on the first org-touching step. In an IDE (Cursor / VS Code) it can look like the auth
+"randomly breaks," and relaunching the IDE only helps until the next time.
+
+## How to confirm it's this bug
+
+The org is healthy; only CumulusCI can't authenticate. The `sf` CLI reaches it fine:
+
+```bash
+# Works (sf refreshes its own token):
+sf data query -q "SELECT Id FROM Organization LIMIT 1" --target-org <username-or-sf-alias>
+
+# Fails with INVALID_AUTH_HEADER (CCI):
+cci org info <cci-alias>
+```
+
+If `sf` succeeds and `cci` fails, it's this bug — **do not delete or recreate the org.**
+(Note: `cci org remove <scratch-alias>` runs `sf org delete scratch -p` and **deletes** the
+org — never use it to "refresh" a token.)
+
+## Root cause
+
+CumulusCI **4.10.0** (the latest release as of 2026-06) reads an org's access token by parsing
+the output of `sf org display`. Salesforce CLI **≥ 2.13x** now **redacts secrets** from that
+output by default:
+
+```
+Warning: Secrets are now hidden from 'sf org display' command output.
+... set SF_TEMP_SHOW_SECRETS=true to render these secrets.
+```
+
+CCI receives the redacted placeholder instead of the real token and sends a malformed
+`Authorization` header → `INVALID_AUTH_HEADER`.
+
+## The fix
+
+Set `SF_TEMP_SHOW_SECRETS=true` in the environment so `sf` exposes the token to CCI. Pick the
+scope that matches how you run CCI.
+
+### Quick / one-off
+
+Prefix any CCI command:
+
+```bash
+SF_TEMP_SHOW_SECRETS=true cci org info pr182
+SF_TEMP_SHOW_SECRETS=true cci flow run prepare_rlm_org --org pr182
+```
+
+Env vars propagate to CCI's child processes, so prefixing the top-level command covers the
+whole flow.
+
+### Durable — terminals (all platforms)
+
+Add to your shell profile (covers terminals, including IDE integrated terminals):
+
+```bash
+echo 'export SF_TEMP_SHOW_SECRETS=true' >> ~/.zshrc   # or ~/.bashrc
+```
+
+On Linux / CI runners this is all you need — export the variable in the job environment.
+
+### Durable — IDE launched from the macOS Dock
+
+The shell profile does **not** cover an app launched from the Dock (Cursor / VS Code), because
+macOS GUI apps don't source `~/.zshrc`. To cover the IDE process itself and anything it spawns,
+set the variable in the GUI login session with a LaunchAgent.
+
+Create `~/Library/LaunchAgents/com.<you>.sf-temp-show-secrets.plist`:
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.<you>.sf-temp-show-secrets</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/launchctl</string>
+        <string>setenv</string>
+        <string>SF_TEMP_SHOW_SECRETS</string>
+        <string>true</string>
+    </array>
+    <key>RunAtLoad</key>
+    <true/>
+</dict>
+</plist>
+```
+
+Load it and set it immediately for the current session:
+
+```bash
+launchctl setenv SF_TEMP_SHOW_SECRETS true                                   # current session
+launchctl load -w ~/Library/LaunchAgents/com.<you>.sf-temp-show-secrets.plist # every login
+```
+
+**Relaunch the IDE once** afterward — an already-running app does not inherit a freshly-set
+`launchctl` variable. It is permanent after that (the LaunchAgent re-applies it at every login).
+
+Verify:
+
+```bash
+launchctl getenv SF_TEMP_SHOW_SECRETS    # -> true
+cci org info <cci-alias>                  # -> instance_url, no INVALID_AUTH_HEADER
+```
+
+### Security note
+
+`SF_TEMP_SHOW_SECRETS=true` makes `sf org display` print access tokens in **plaintext**. That's
+acceptable for local scratch-org development, but it means tokens can appear in `sf` output,
+logs, screen shares, and CI artifacts. Don't commit logs produced with it set, and prefer the
+narrowest scope that solves your case.
+
+## When can we remove this?
+
+This workaround relies on a flag Salesforce documents as **temporary** (`SF_TEMP_SHOW_SECRETS`
+"will be removed in an upcoming release"). There are two clocks — remove the workaround when the
+**first** of these happens:
+
+1. **CumulusCI ships a release that reads the token via `sf org auth show-access-token`** (the
+   non-redacted API) instead of parsing `sf org display`. Then upgrade CCI and drop the flag.
+2. **The Salesforce CLI removes `SF_TEMP_SHOW_SECRETS`** — this *breaks* the workaround and
+   forces option 1. Watch the `sf` release notes.
+
+### How to check (run periodically)
+
+```bash
+# Is there a CumulusCI release newer than the one with the bug (4.10.0)?
+LATEST=$(curl -fsSL https://pypi.org/pypi/cumulusci/json | python3 -c 'import sys,json; print(json.load(sys.stdin)["info"]["version"])')
+echo "Latest CumulusCI on PyPI: $LATEST (workaround baseline: 4.10.0)"
+[ "$LATEST" != "4.10.0" ] && echo "NEW RELEASE — check its changelog for the sf-token / 'show-access-token' fix:
+  https://github.com/SFDO-Tooling/CumulusCI/releases"
+```
+
+If a newer release exists, confirm from its changelog that it addresses the
+`sf org display` token-redaction issue, then:
+
+### Removal steps (once the official fix lands)
+
+```bash
+pipx upgrade cumulusci                       # or to a specific fixed version
+# then remove the workaround:
+launchctl unload ~/Library/LaunchAgents/com.<you>.sf-temp-show-secrets.plist
+rm ~/Library/LaunchAgents/com.<you>.sf-temp-show-secrets.plist
+launchctl unsetenv SF_TEMP_SHOW_SECRETS
+# remove the `export SF_TEMP_SHOW_SECRETS=true` line from ~/.zshrc
+```
+
+Verify `cci org info <alias>` still works **without** the flag, then delete this note's entry
+from the troubleshooting skill.
+
+## Related
+
+- `.cursor/skills/troubleshooting/SKILL.md` → Environment & Setup Errors
+- `docs/guides/dev-environment-setup.md` (toolchain setup)

--- a/docs/guides/cci-sf-cli-token-workaround.md
+++ b/docs/guides/cci-sf-cli-token-workaround.md
@@ -25,20 +25,20 @@ The org is healthy; only CumulusCI can't authenticate. The `sf` CLI reaches it f
 
 ```bash
 # Works (sf refreshes its own token):
-sf data query -q "SELECT Id FROM Organization LIMIT 1" --target-org <username-or-sf-alias>
+sf data query -q "SELECT Id FROM Organization LIMIT 1" --target-org USERNAME_OR_SF_ALIAS
 
 # Fails with INVALID_AUTH_HEADER (CCI):
-cci org info <cci-alias>
+cci org info CCI_ALIAS
 ```
 
 If `sf` succeeds and `cci` fails, it's this bug — **do not delete or recreate the org.**
-(Note: `cci org remove <scratch-alias>` runs `sf org delete scratch -p` and **deletes** the
+(Note: `cci org remove SCRATCH_ALIAS` runs `sf org delete scratch -p` and **deletes** the
 org — never use it to "refresh" a token.)
 
 ## Root cause
 
 CumulusCI **4.10.0** (the latest release as of 2026-06) reads an org's access token by parsing
-the output of `sf org display`. Salesforce CLI **≥ 2.13x** now **redacts secrets** from that
+the output of `sf org display`. Salesforce CLI **>= 2.13.0** now **redacts secrets** from that
 output by default:
 
 ```
@@ -82,7 +82,9 @@ The shell profile does **not** cover an app launched from the Dock (Cursor / VS 
 macOS GUI apps don't source `~/.zshrc`. To cover the IDE process itself and anything it spawns,
 set the variable in the GUI login session with a LaunchAgent.
 
-Create `~/Library/LaunchAgents/com.<you>.sf-temp-show-secrets.plist`:
+Create `~/Library/LaunchAgents/com.example.sf-temp-show-secrets.plist` (replace `example`
+with your own identifier — e.g. your username — keeping the filename and the `Label` below
+identical):
 
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
@@ -90,7 +92,7 @@ Create `~/Library/LaunchAgents/com.<you>.sf-temp-show-secrets.plist`:
 <plist version="1.0">
 <dict>
     <key>Label</key>
-    <string>com.<you>.sf-temp-show-secrets</string>
+    <string>com.example.sf-temp-show-secrets</string>
     <key>ProgramArguments</key>
     <array>
         <string>/bin/launchctl</string>
@@ -108,7 +110,7 @@ Load it and set it immediately for the current session:
 
 ```bash
 launchctl setenv SF_TEMP_SHOW_SECRETS true                                   # current session
-launchctl load -w ~/Library/LaunchAgents/com.<you>.sf-temp-show-secrets.plist # every login
+launchctl load -w ~/Library/LaunchAgents/com.example.sf-temp-show-secrets.plist # every login
 ```
 
 **Relaunch the IDE once** afterward — an already-running app does not inherit a freshly-set
@@ -118,7 +120,7 @@ Verify:
 
 ```bash
 launchctl getenv SF_TEMP_SHOW_SECRETS    # -> true
-cci org info <cci-alias>                  # -> instance_url, no INVALID_AUTH_HEADER
+cci org info CCI_ALIAS                     # -> instance_url, no INVALID_AUTH_HEADER
 ```
 
 ### Security note
@@ -161,13 +163,13 @@ If a newer release exists, confirm from its changelog that it addresses the
 ```bash
 pipx upgrade cumulusci                       # or to a specific fixed version
 # then remove the workaround:
-launchctl unload ~/Library/LaunchAgents/com.<you>.sf-temp-show-secrets.plist
-rm ~/Library/LaunchAgents/com.<you>.sf-temp-show-secrets.plist
+launchctl unload ~/Library/LaunchAgents/com.example.sf-temp-show-secrets.plist
+rm ~/Library/LaunchAgents/com.example.sf-temp-show-secrets.plist
 launchctl unsetenv SF_TEMP_SHOW_SECRETS
 # remove the `export SF_TEMP_SHOW_SECRETS=true` line from ~/.zshrc
 ```
 
-Verify `cci org info <alias>` still works **without** the flag, then delete this note's entry
+Verify `cci org info CCI_ALIAS` still works **without** the flag, then delete this note's entry
 from the troubleshooting skill.
 
 ## Related

--- a/docs/guides/cci-sf-cli-token-workaround.md
+++ b/docs/guides/cci-sf-cli-token-workaround.md
@@ -151,11 +151,16 @@ This workaround relies on a flag Salesforce documents as **temporary** (`SF_TEMP
 ### How to check (run periodically)
 
 ```bash
-# Is there a CumulusCI release newer than the one with the bug (4.10.0)?
+# Is there a CumulusCI release newer than the one with the bug? (same logic as the workflow)
+BASELINE=4.10.0
 LATEST=$(curl -fsSL https://pypi.org/pypi/cumulusci/json | python3 -c 'import sys,json; print(json.load(sys.stdin)["info"]["version"])')
-echo "Latest CumulusCI on PyPI: $LATEST (workaround baseline: 4.10.0)"
-[ "$LATEST" != "4.10.0" ] && echo "NEW RELEASE — check its changelog for the sf-token / 'show-access-token' fix:
+echo "Latest CumulusCI on PyPI: $LATEST (workaround baseline: $BASELINE)"
+# "newer" = larger of {baseline, latest} under version sort, and != baseline.
+NEWER=$(printf '%s\n%s\n' "$BASELINE" "$LATEST" | sort -V | tail -1)
+if [ "$LATEST" != "$BASELINE" ] && [ "$NEWER" = "$LATEST" ]; then
+  echo "NEW RELEASE — check its changelog for the sf-token / 'show-access-token' fix:
   https://github.com/SFDO-Tooling/CumulusCI/releases"
+fi
 ```
 
 If a newer release exists, confirm from its changelog that it addresses the


### PR DESCRIPTION
## Summary
Shareable guide for the `INVALID_AUTH_HEADER` failure that hits **every** CumulusCI command on a healthy scratch org, **plus** an automated weekly check so the workaround isn't kept longer than needed. Root cause: CCI 4.10 reads the access token from `sf org display`, but Salesforce CLI ≥ 2.13x now redacts secrets there, so CCI sends a bogus auth header. Fix is `SF_TEMP_SHOW_SECRETS=true`.

### What's in the guide
- **How to confirm it's this bug** — `sf` reaches the org, `cci` doesn't (and the warning: never `cci org remove` a scratch org — it deletes it).
- **The fix at three scopes** — one-off prefix, durable `~/.zshrc` (terminals / all platforms), and a **LaunchAgent** for the Dock-launched IDE (Cursor/VS Code) that `~/.zshrc` can't reach.
- **Security tradeoff** — it prints access tokens in plaintext in `sf` output.
- **When can we remove this?** — two clocks (CCI ships a `sf org auth show-access-token` fix, or sf CLI removes the flag), a copy-paste PyPI check command, and removal steps.

### Automated removal-watch
`.github/workflows/check-cci-token-fix.yml` runs **weekly (Mon 09:23 UTC)** + on-demand, queries PyPI for a CumulusCI release newer than the bug baseline (`4.10.0`), and **opens a tracking issue** when one appears — prompting the team to verify the fix and drop the workaround. Least-privilege (`contents:read` floor, `issues:write` only on the job); idempotent (reuses an existing open issue). A local cron was rejected for this: it would be session-bound and expire in 7 days, whereas the fix could be weeks/months out.

### Files
- `docs/guides/cci-sf-cli-token-workaround.md` — the guide
- `.cursor/skills/troubleshooting/SKILL.md` — concise entry + link under *Environment & Setup Errors*
- `.github/workflows/check-cci-token-fix.yml` — the weekly removal-watch

Note: the `workflow_dispatch`/`schedule` triggers activate once this merges to `main` (GitHub runs scheduled workflows from the default branch). The PyPI query + version-compare logic were validated locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)