### PR TITLE
chore(orgs): update trialforce template IDs

### DIFF
--- a/orgs/tfid/tfid-cdo-rlm.json
+++ b/orgs/tfid/tfid-cdo-rlm.json
@@ -1,6 +1,6 @@
 {
   "orgName": "Salesforce Agentforce Revenue Management",
   "country": "US",
-  "template": "0TTWt000000oJCL",
+  "template": "0TTWt000000rQ2n",
   "instance": "USA796"
 }

--- a/orgs/tfid/tfid-cdo.json
+++ b/orgs/tfid/tfid-cdo.json
@@ -1,6 +1,6 @@
 {
   "orgName": "Salesforce Agentforce Revenue Management",
   "country": "US",
-  "template": "0TTKX000001N3pi",
+  "template": "0TTKX000001N46s",
   "instance": "USA796"
 }

--- a/orgs/tfid/tfid-sdo-lite.json
+++ b/orgs/tfid/tfid-sdo-lite.json
@@ -1,6 +1,6 @@
 {
   "orgName": "Salesforce Agentforce Revenue Management",
   "country": "US",
-  "template": "0TTKX000001Cy9N",
-  "instance": "USA794"
+  "template": "0TTKX000001D0iI",
+  "instance": "USA796"
 }

--- a/orgs/tfid/tfid-sdo.json
+++ b/orgs/tfid/tfid-sdo.json
@@ -1,6 +1,6 @@
 {
   "orgName": "Salesforce Agentforce Revenue Management",
   "country": "US",
-  "template": "0TTKX000001hyCa",
-  "instance": "USA794"
+  "template": "0TTKX000001hzYr",
+  "instance": "USA796"
 }


### PR DESCRIPTION
## Summary
Refresh trialforce (TFID) template IDs for the snapshot org definitions:

- `tfid-cdo-rlm.json`: `0TTWt000000oJCL` → `0TTWt000000rQ2n`
- `tfid-cdo.json`: `0TTKX000001N3pi` → `0TTKX000001N46s`
- `tfid-sdo-lite.json`: `0TTKX000001Cy9N` → `0TTKX000001D0iI` (instance `USA794` → `USA796`)
- `tfid-sdo.json`: `0TTKX000001hyCa` → `0TTKX000001hzYr` (instance `USA794` → `USA796`)

## Test plan
- [ ] Confirm each updated template ID resolves to the intended trialforce snapshot on instance `USA796`.

Made with [Cursor](https://cursor.com)