### PR TITLE
ci: bump GitHub Actions off Node 20 (Node 24 forced 2026-06-16)

### DIFF
--- a/.github/workflows/agent-tooling-optimization.yml
+++ b/.github/workflows/agent-tooling-optimization.yml
@@ -50,7 +50,7 @@ jobs:
           persist-credentials: false
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.13"
 
@@ -81,7 +81,7 @@ jobs:
           persist-credentials: false
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.13"
 
@@ -95,7 +95,7 @@ jobs:
         run: python scripts/ai/analyze_agent_tooling.py all
 
       - name: Upload tooling artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: agent-tooling-artifacts
           path: |
@@ -106,8 +106,8 @@ jobs:
 
       - name: Open or update optimization pull request
         # Third-party, write-scoped action — pinned to a full commit SHA (not the
-        # mutable v7 tag) to limit supply-chain blast radius. Bump via Dependabot.
-        uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676  # v7.0.11
+        # mutable v8 tag) to limit supply-chain blast radius. Bump via Dependabot.
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1  # v8.1.1
         with:
           token: ${{ github.token }}
           branch: automation/agent-tooling-optimization

--- a/.github/workflows/prepare-rlm-org.yml
+++ b/.github/workflows/prepare-rlm-org.yml
@@ -65,17 +65,17 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Set up Python 3.13
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.13"
 
       - name: Set up Node.js 24
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: "24"
 
       - name: Cache npm download cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.npm
           key: npm-cache-${{ runner.os }}-node24


### PR DESCRIPTION
## Summary
GitHub forces Node 24 on **2026-06-16**; several actions still ran on the deprecated Node 20 runtime (surfaced as annotations on the first `Agent Tooling Optimization` deep-checks run). This bumps each to a Node 24-supporting major.

| Action | Before (node20) | After (node24) | Where |
|---|---|---|---|
| actions/setup-python | v5 | **v6** | agent-tooling-optimization, prepare-rlm-org |
| actions/upload-artifact | v4 | **v7** | agent-tooling-optimization |
| actions/setup-node | v4 | **v5** | prepare-rlm-org |
| actions/cache | v4 | **v5** | prepare-rlm-org |
| peter-evans/create-pull-request | v7.0.11 | **v8.1.1** (SHA-pinned) | agent-tooling-optimization |

`actions/checkout@v6` already runs on Node 24 — left as-is.

## Notes
- Target versions verified by reading each `action.yml` `runs.using` (all `node24`). Note `upload-artifact@v5`/`v6` are **still node20**; `v7` is the first node24 major.
- Usages are minimal (`python-version` / `node-version` / cache `path`+`key` / `name`+`path`+`if-no-files-found`) — unchanged across these majors, so drop-in.
- `create-pull-request` kept SHA-pinned per the existing supply-chain policy; pin `5f6978fa…` matches tag `v8.1.1`.

## Validation
- Both workflows parse (`yaml.safe_load`).
- `setup-python@v6` + `checkout@v6` are exercised by this PR's own baseline job.
- `upload-artifact@v7` + `create-pull-request@v8.1.1` (deep-checks-only) validated via a `workflow_dispatch` run on this branch — see below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)