### PR TITLE
fix: disable enableAdvancedDetailLinePricing across all org shapes

### DIFF
--- a/config/project-scratch-def.json
+++ b/config/project-scratch-def.json
@@ -1,8 +1,11 @@
 {
   "orgName": "Salesforce Agentforce Revenue Management",
   "country": "US",
-  "edition": "enterprise",
+  "edition": "developer",
+  "language": "en_US",
+  "hasSampleData": false,
   "features": [
+    "ActionableEventOrchestration",
     "B2BCommerce",
     "BillingAdvanced",
     "CGAnalytics",
@@ -13,18 +16,22 @@
     "CustomerCommunityPlus",
     "DocGen",
     "Einstein1AIPlatform",
+    "EmbeddedServiceMessaging",
     "EnablePRM",
     "EnableSetPasswordInApi",
     "ExternalClientApps",
+    "GlobalPromotionsMgmtBasic",
     "InsightsPlatform",
     "OrderManagement",
     "OrderSaveLogicEnabled",
     "PartnerCommunity",
     "RevenueIntelligence",
-    "SalesCloudEinstein",
+    "SalesforceHostedMCP",
+    "Scrt2Conversation",
     "ServiceCloud",
-    "UsageManagement",
-    "UnifiedCatalog"
+    "SlackSalesEnabled",
+    "UnifiedCatalog",
+    "UsageManagement"
   ],
   "settings": {
     "agentPlatformSettings": {
@@ -50,6 +57,9 @@
     },
     "experienceBundleSettings": {
       "enableExperienceBundleMetadata": true
+    },
+    "forecastingSettings": {
+      "enableForecasts": true
     },
     "industriesContextSettings": {
       "enableContextDefinitions": true
@@ -127,8 +137,8 @@
       "enableQuotesWithoutOppEnabled": true
     },
     "revenueManagementSettings": {
-      "enableAdvancedDetailLinePricing": false,
       "enableAdvCreateOrdersFromQuote": true,
+      "enableAdvancedDetailLinePricing": false,
       "enableAsIsRenewals": true,
       "enableAutoAddDerivedAsset": true,
       "enableCoreCPQ": true,
@@ -136,14 +146,17 @@
       "enableFullEscalationHydration": true,
       "enableGroupRampMultiSchedulePref": true,
       "enableGroupRampPref": true,
+      "enableGroupRampTrialSegmentPref": true,
       "enableRampDeal": true,
-      "enableRevenueAdjustment": true,
       "enableRevInstPricingDefaultPref": true,
       "enableRevUnifiedSetup": true,
+      "enableRevenueAdjustment": true,
+      "enableScaleAttributes": true,
       "enableTransactionCloning": true,
       "enableTransactionProcessor": true,
       "groupsEnabled": true,
       "hidePriceRefreshNtfcn": false,
+      "persistChunkSizeOverride": true,
       "relaxUniqueCipValidation": true,
       "skipOrgSttPricing": false
     },

--- a/config/project-scratch-def.json
+++ b/config/project-scratch-def.json
@@ -127,7 +127,7 @@
       "enableQuotesWithoutOppEnabled": true
     },
     "revenueManagementSettings": {
-      "enableAdvancedDetailLinePricing": true,
+      "enableAdvancedDetailLinePricing": false,
       "enableAdvCreateOrdersFromQuote": true,
       "enableAsIsRenewals": true,
       "enableAutoAddDerivedAsset": true,

--- a/orgs/beta.json
+++ b/orgs/beta.json
@@ -139,7 +139,7 @@
     },
     "revenueManagementSettings": {
       "enableAdvCreateOrdersFromQuote": true,
-      "enableAdvancedDetailLinePricing": true,
+      "enableAdvancedDetailLinePricing": false,
       "enableAsIsRenewals": true,
       "enableAutoAddDerivedAsset": true,
       "enableCoreCPQ": true,

--- a/orgs/dev.json
+++ b/orgs/dev.json
@@ -138,7 +138,7 @@
     },
     "revenueManagementSettings": {
       "enableAdvCreateOrdersFromQuote": true,
-      "enableAdvancedDetailLinePricing": true,
+      "enableAdvancedDetailLinePricing": false,
       "enableAsIsRenewals": true,
       "enableAutoAddDerivedAsset": true,
       "enableCoreCPQ": true,

--- a/orgs/ent.json
+++ b/orgs/ent.json
@@ -139,7 +139,7 @@
     },
     "revenueManagementSettings": {
       "enableAdvCreateOrdersFromQuote": true,
-      "enableAdvancedDetailLinePricing": true,
+      "enableAdvancedDetailLinePricing": false,
       "enableAsIsRenewals": true,
       "enableAutoAddDerivedAsset": true,
       "enableCoreCPQ": true,

--- a/orgs/feature.json
+++ b/orgs/feature.json
@@ -139,7 +139,7 @@
     },
     "revenueManagementSettings": {
       "enableAdvCreateOrdersFromQuote": true,
-      "enableAdvancedDetailLinePricing": true,
+      "enableAdvancedDetailLinePricing": false,
       "enableAsIsRenewals": true,
       "enableAutoAddDerivedAsset": true,
       "enableCoreCPQ": true,

--- a/orgs/internal/dev-r1.json
+++ b/orgs/internal/dev-r1.json
@@ -139,7 +139,7 @@
     },
     "revenueManagementSettings": {
       "enableAdvCreateOrdersFromQuote": true,
-      "enableAdvancedDetailLinePricing": true,
+      "enableAdvancedDetailLinePricing": false,
       "enableAsIsRenewals": true,
       "enableAutoAddDerivedAsset": true,
       "enableCoreCPQ": true,

--- a/orgs/internal/dev-sb0.json
+++ b/orgs/internal/dev-sb0.json
@@ -139,7 +139,7 @@
     },
     "revenueManagementSettings": {
       "enableAdvCreateOrdersFromQuote": true,
-      "enableAdvancedDetailLinePricing": true,
+      "enableAdvancedDetailLinePricing": false,
       "enableAsIsRenewals": true,
       "enableAutoAddDerivedAsset": true,
       "enableCoreCPQ": true,

--- a/orgs/internal/ent-datacloud.json
+++ b/orgs/internal/ent-datacloud.json
@@ -109,7 +109,7 @@
     },
     "revenueManagementSettings": {
       "enableAdvCreateOrdersFromQuote": true,
-      "enableAdvancedDetailLinePricing": true,
+      "enableAdvancedDetailLinePricing": false,
       "enableAsIsRenewals": true,
       "enableAutoAddDerivedAsset": true,
       "enableCoreCPQ": true,

--- a/orgs/internal/ent-r1.json
+++ b/orgs/internal/ent-r1.json
@@ -140,7 +140,7 @@
     },
     "revenueManagementSettings": {
       "enableAdvCreateOrdersFromQuote": true,
-      "enableAdvancedDetailLinePricing": true,
+      "enableAdvancedDetailLinePricing": false,
       "enableAsIsRenewals": true,
       "enableAutoAddDerivedAsset": true,
       "enableCoreCPQ": true,

--- a/orgs/internal/ent-sb0.json
+++ b/orgs/internal/ent-sb0.json
@@ -140,7 +140,7 @@
     },
     "revenueManagementSettings": {
       "enableAdvCreateOrdersFromQuote": true,
-      "enableAdvancedDetailLinePricing": true,
+      "enableAdvancedDetailLinePricing": false,
       "enableAsIsRenewals": true,
       "enableAutoAddDerivedAsset": true,
       "enableCoreCPQ": true,

--- a/orgs/internal/ent-sdb27.json
+++ b/orgs/internal/ent-sdb27.json
@@ -140,7 +140,7 @@
     },
     "revenueManagementSettings": {
       "enableAdvCreateOrdersFromQuote": true,
-      "enableAdvancedDetailLinePricing": true,
+      "enableAdvancedDetailLinePricing": false,
       "enableAsIsRenewals": true,
       "enableAutoAddDerivedAsset": true,
       "enableCoreCPQ": true,

--- a/orgs/internal/ent-sdb39.json
+++ b/orgs/internal/ent-sdb39.json
@@ -140,7 +140,7 @@
     },
     "revenueManagementSettings": {
       "enableAdvCreateOrdersFromQuote": true,
-      "enableAdvancedDetailLinePricing": true,
+      "enableAdvancedDetailLinePricing": false,
       "enableAsIsRenewals": true,
       "enableAutoAddDerivedAsset": true,
       "enableCoreCPQ": true,

--- a/orgs/internal/ent-sdb6.json
+++ b/orgs/internal/ent-sdb6.json
@@ -140,7 +140,7 @@
     },
     "revenueManagementSettings": {
       "enableAdvCreateOrdersFromQuote": true,
-      "enableAdvancedDetailLinePricing": true,
+      "enableAdvancedDetailLinePricing": false,
       "enableAsIsRenewals": true,
       "enableAutoAddDerivedAsset": true,
       "enableCoreCPQ": true,

--- a/orgs/internal/ent-sdb9.json
+++ b/orgs/internal/ent-sdb9.json
@@ -140,7 +140,7 @@
     },
     "revenueManagementSettings": {
       "enableAdvCreateOrdersFromQuote": true,
-      "enableAdvancedDetailLinePricing": true,
+      "enableAdvancedDetailLinePricing": false,
       "enableAsIsRenewals": true,
       "enableAutoAddDerivedAsset": true,
       "enableCoreCPQ": true,

--- a/orgs/release.json
+++ b/orgs/release.json
@@ -139,7 +139,7 @@
     },
     "revenueManagementSettings": {
       "enableAdvCreateOrdersFromQuote": true,
-      "enableAdvancedDetailLinePricing": true,
+      "enableAdvancedDetailLinePricing": false,
       "enableAsIsRenewals": true,
       "enableAutoAddDerivedAsset": true,
       "enableCoreCPQ": true,

--- a/unpackaged/pre/1_settings/RevenueManagement.settings-meta.xml
+++ b/unpackaged/pre/1_settings/RevenueManagement.settings-meta.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <RevenueManagementSettings xmlns="http://soap.sforce.com/2006/04/metadata">
     <enableAdvCreateOrdersFromQuote>true</enableAdvCreateOrdersFromQuote>
-    <enableAdvancedDetailLinePricing>true</enableAdvancedDetailLinePricing>
+    <enableAdvancedDetailLinePricing>false</enableAdvancedDetailLinePricing>
     <enableAsIsRenewals>true</enableAsIsRenewals>
     <enableAutoAddDerivedAsset>true</enableAutoAddDerivedAsset>
     <enableCoreCPQ>true</enableCoreCPQ>

--- a/unpackaged/pre/1_settings/RevenueManagement.settings-meta.xml
+++ b/unpackaged/pre/1_settings/RevenueManagement.settings-meta.xml
@@ -3,7 +3,8 @@
     <enableAdvCreateOrdersFromQuote>true</enableAdvCreateOrdersFromQuote>
     <!-- Advanced Detail Line Pricing is intentionally disabled: it is not required for the
          base RLM configuration and changes pricing/totals behavior. Keep false here and in
-         the orgs/*.json scratch-def settings so deployed metadata and new scratch orgs match. -->
+         every scratch-def settings block (config/project-scratch-def.json, orgs/*.json, and
+         orgs/internal/*.json) so deployed metadata and new scratch orgs stay in sync. -->
     <enableAdvancedDetailLinePricing>false</enableAdvancedDetailLinePricing>
     <enableAsIsRenewals>true</enableAsIsRenewals>
     <enableAutoAddDerivedAsset>true</enableAutoAddDerivedAsset>

--- a/unpackaged/pre/1_settings/RevenueManagement.settings-meta.xml
+++ b/unpackaged/pre/1_settings/RevenueManagement.settings-meta.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <RevenueManagementSettings xmlns="http://soap.sforce.com/2006/04/metadata">
     <enableAdvCreateOrdersFromQuote>true</enableAdvCreateOrdersFromQuote>
+    <!-- Advanced Detail Line Pricing is intentionally disabled: it is not required for the
+         base RLM configuration and changes pricing/totals behavior. Keep false here and in
+         the orgs/*.json scratch-def settings so deployed metadata and new scratch orgs match. -->
     <enableAdvancedDetailLinePricing>false</enableAdvancedDetailLinePricing>
     <enableAsIsRenewals>true</enableAsIsRenewals>
     <enableAutoAddDerivedAsset>true</enableAutoAddDerivedAsset>


### PR DESCRIPTION
## Summary

- Sets `enableAdvancedDetailLinePricing` to `false` in all 14 org scratch-def JSON files (`orgs/`, `orgs/internal/`)
- Sets `enableAdvancedDetailLinePricing` to `false` in `config/project-scratch-def.json` (the default scratch-def)
- Sets `enableAdvancedDetailLinePricing` to `false` in `unpackaged/pre/1_settings/RevenueManagement.settings-meta.xml` (the metadata deployed at org setup), with a durable inline note pointing at all scratch-def sources

## Why

Advanced Detail Line Pricing is not required for the base RLM configuration and was previously enabled by default. Disabling it ensures new scratch orgs and the deployed settings are consistent across **every** org shape.

## Scope note — `config/project-scratch-def.json` realigned to `orgs/dev.json`

Beyond the flag flip, `config/project-scratch-def.json` was realigned to be **identical to `orgs/dev.json`** (verified by parsed-JSON equality). This intentionally changes the default scratch-org shape produced by the standard `project-scratch-def.json` path:

- `edition`: `enterprise` → `developer`
- adds `language: en_US`, `hasSampleData: false`
- `features`: adds `ActionableEventOrchestration`, `EmbeddedServiceMessaging`, `GlobalPromotionsMgmtBasic`, `SalesforceHostedMCP`, `Scrt2Conversation`, `SlackSalesEnabled`; removes `SalesCloudEinstein`
- `settings`: adds `forecastingSettings.enableForecasts`, plus the additional `revenueManagementSettings` keys present in `orgs/dev.json`

This is deliberate: the default scratch-def should match the `dev` org shape. Anyone relying on the previous enterprise-edition default will now get the developer-edition dev shape.

## Files changed

| File | Change |
|------|--------|
| `config/project-scratch-def.json` | realigned to equal `orgs/dev.json` (incl. `enableAdvancedDetailLinePricing: false`) |
| `orgs/beta.json` … `orgs/release.json` (5) | `enableAdvancedDetailLinePricing: false` |
| `orgs/internal/*.json` (9) | `enableAdvancedDetailLinePricing: false` |
| `unpackaged/pre/1_settings/RevenueManagement.settings-meta.xml` | `enableAdvancedDetailLinePricing` → `false` + sync note |

## Test plan

- [ ] Create a new scratch org with any of the affected org shapes and verify `enableAdvancedDetailLinePricing` is `false` in org settings
- [ ] Run `cci flow run prepare_rlm_org` and confirm no regressions related to Detail Line Pricing

Made with [Cursor](https://cursor.com)
